### PR TITLE
Dbport to env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ COOKIE_DOMAIN=example.saproto.nl
 SSL=true
 
 DB_HOST=localhost
+DB_PORT=3306
 DB_DATABASE=database_name
 DB_USERNAME=database_username
 DB_PASSWORD=database_password

--- a/config/database.php
+++ b/config/database.php
@@ -49,6 +49,7 @@ return [
         'mysql' => [
             'driver'    => 'mysql',
             'host'      => env('DB_HOST', 'localhost'),
+            'port'	=> env('DB_PORT', 3306),
             'database'  => env('DB_DATABASE', 'forge'),
             'username'  => env('DB_USERNAME', 'forge'),
             'password'  => env('DB_PASSWORD', ''),


### PR DESCRIPTION
For local development using MAMP, using the default MySQL port doesn't work for some reason. This means that there has to be a way to change this port to a different port :)