### PR TITLE
Add option to disable OmNomCom for yourself.

### DIFF
--- a/app/Http/Controllers/OmNomController.php
+++ b/app/Http/Controllers/OmNomController.php
@@ -117,6 +117,11 @@ class OmNomController extends Controller
             return json_encode($result);
         }
 
+        if ($user->disable_omnomcom) {
+            $result->message = "<span style='color: orange;'>You've disabled the OmNomCom for yourself. Contact the board to enable it again.</span>";
+            return json_encode($result);
+        }
+
         $withCash = $request->input('cash');
 
         if ($withCash == "true" && !$storedata->cash_allowed) {

--- a/app/Http/Controllers/UserAdminController.php
+++ b/app/Http/Controllers/UserAdminController.php
@@ -219,6 +219,16 @@ class UserAdminController extends Controller
         return redirect()->back();
     }
 
+    public function unblockOmnomcom($id)
+    {
+        $user = User::findOrFail($id);
+        $user->disable_omnomcom = false;
+        $user->save();
+
+        Session::flash("flash_message", "OmNomCom unblocked for " . $user->name . ".");
+        return redirect()->back();
+    }
+
     public function toggleStudiedCreate($id)
     {
         $user = User::findOrFail($id);

--- a/app/Http/Controllers/UserDashboardController.php
+++ b/app/Http/Controllers/UserDashboardController.php
@@ -68,6 +68,10 @@ class UserDashboardController extends Controller
             $userdata['show_achievements'] = $request->has('show_achievements');
         }
 
+        if ($request->has('disable_omnomcom')) {
+            $userdata['disable_omnomcom'] = true;
+        }
+
         $userdata['keep_omnomcom_history'] = $request->has('keep_omnomcom_history');
         $userdata['theme'] = $request->input('theme');
 
@@ -160,7 +164,7 @@ class UserDashboardController extends Controller
                 'text' => "To enter your in our member administration, you need to provide is with some extra information."
             ],
             [
-                'url' => Auth::check() ? sprintf('%s?wizard=1', route("user::bank::add", ["id"=>$user->id])) : null,
+                'url' => Auth::check() ? sprintf('%s?wizard=1', route("user::bank::add", ["id" => $user->id])) : null,
                 'unlocked' => Auth::check(),
                 'done' => Auth::check() && Auth::user()->bank,
                 'heading' => "Provide payment details",
@@ -196,8 +200,8 @@ class UserDashboardController extends Controller
         $todo = [];
         $done = [];
 
-        foreach($steps as $step) {
-            if($step['done']) array_push($done, $step);
+        foreach ($steps as $step) {
+            if ($step['done']) array_push($done, $step);
             else array_push($todo, $step);
         }
 

--- a/database/migrations/2019_04_11_164711_add_omnomcom_block_to_users_table.php
+++ b/database/migrations/2019_04_11_164711_add_omnomcom_block_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddOmnomcomBlockToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('disable_omnomcom')->after('keep_omnomcom_history')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('disable_omnomcom');
+        });
+    }
+}

--- a/resources/views/users/admin/admin_includes/actions.blade.php
+++ b/resources/views/users/admin/admin_includes/actions.blade.php
@@ -29,6 +29,12 @@
                     Make temporary admin
                 </a>
             @endif
+            @if($user->disable_omnomcom)
+                <a href="{{ route('user::admin::unblock_omnomcom', ['id' => $user->id]) }}"
+                   class="list-group-item">
+                    Unblock OmNomCom
+                </a>
+            @endif
             @if($user->member)
                 <a class="list-group-item"
                    href="{{ route('user::profile', ['id' => $user->getPublicId()]) }}">

--- a/resources/views/users/dashboard/includes/account.blade.php
+++ b/resources/views/users/dashboard/includes/account.blade.php
@@ -181,15 +181,35 @@
 
                                 <br>
 
-                                
+
                                 <input name="show_omnomcom_calories" type="checkbox" class="form-check-input"
                                        id="dashboard__check__omnomcal" {{ ($user->show_omnomcom_calories == 1 ? 'checked' : '') }}>
                                 <label class="form-check-label" for="dashboard__check__omnomcal">
                                     After checkout, show how much calories worth of food I've bought today.<br>
-                                    <small><i class="fas fa-flask"></i>&nbsp;&nbsp;Experimental feature, might not always be accurate</small>
+                                    <small><i class="fas fa-flask"></i>&nbsp;&nbsp;Experimental feature, might not
+                                        always be accurate
+                                    </small>
                                 </label>
                                 <small class="form-text text-muted">
-                                    This feature was requested by members who want to be aware of how much calories they eat.
+                                    This feature was requested by members who want to be aware of how much calories they
+                                    eat.
+                                </small>
+
+                                <br>
+
+
+                                <input name="disable_omnomcom" type="checkbox" class="form-check-input"
+                                       id="dashboard__check__omnomcal" {{ ($user->disable_omnomcom == 1 ? 'checked disabled' : '') }}>
+                                <label class="form-check-label" for="disable_omnomcom">
+                                    Don't let me use the OmNomCom. Only the board can allow you access to the OmNomCom
+                                    again.<br>
+                                    <small><i class="fas fa-info-circle"></i>&nbsp;&nbsp;You can still sign-up for
+                                        activities, and the board can manually buy something for you if you need that.
+                                    </small>
+                                </label>
+                                <small class="form-text text-muted">
+                                    This feature was requested by members who wanted some help controlling their
+                                    personal spendings.
                                 </small>
 
                                 <br>
@@ -220,7 +240,7 @@
                         </p>
                         <select class="form-control" name="theme">
                             @foreach(config('proto.themes') as $name => $file)
-                            <option value="{{ $file }}" {{ ($user->theme == $file) ? 'selected' : '' }}>{{ $name }}</option>
+                                <option value="{{ $file }}" {{ ($user->theme == $file) ? 'selected' : '' }}>{{ $name }}</option>
                             @endforeach
                         </select>
                         <small>

--- a/routes/web.php
+++ b/routes/web.php
@@ -109,6 +109,7 @@ Route::group(['middleware' => ['forcedomain']], function () {
             Route::get('studied_create/{id}', ['as' => 'toggle_studied_create', 'uses' => 'UserAdminController@toggleStudiedCreate']);
             Route::get('studied_itech/{id}', ['as' => 'toggle_studied_itech', 'uses' => 'UserAdminController@toggleStudiedITech']);
             Route::get('nda/{id}', ['as' => 'toggle_nda', 'middleware' => ['permission:sysadmin'], 'uses' => 'UserAdminController@toggleNda']);
+            Route::get('unblock_omnomcom/{id}', ['as' => 'unblock_omnomcom', 'uses' => 'UserAdminController@unblockOmnomcom']);
         });
 
         Route::get('quit_impersonating', ['as' => 'quitimpersonating', 'uses' => 'UserAdminController@quitImpersonating']);


### PR DESCRIPTION
Board can enable the OmNomCom for you via the user admin. Blocks access in ALL OmNomCom stores. Does not prevent direct withdrawal, manual adding of orderlines, buying tickets or joining activities. Meant to help people with impuls control.