### PR TITLE
Fixed mariadb docker not starting because of mapped volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - MYSQL_DATABASE=${DB_DATABASE}
       - MYSQL_USER=${DB_USERNAME}
       - MYSQL_PASSWORD=${DB_PASSWORD}
-    volumes:
-      - ./docker/mariadb:/var/lib/mysql
     command:
       'mysqld --innodb-flush-method=fsync'
 


### PR DESCRIPTION
Mariadb handles persistent storage by itself, so a mapped volume is not needed.