### PR TITLE
Deleted duplications in allergy information lists

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -254,7 +254,9 @@ class Event extends Model
             $users = $users->merge($ticket->getUsers());
         }
         if ($this->activity) {
-            $users = $users->merge($this->activity->allUsers);
+            $users = $users->merge($this->activity->allUsers->sort(function ($a, $b) {
+                return isset($a->pivot->committees_activities_id); // prefer helper participation registration
+            })->unique());
         }
         return $users->sort(function ($a, $b) {
             return strcmp($a->name, $b->name);

--- a/resources/views/event/checklist.blade.php
+++ b/resources/views/event/checklist.blade.php
@@ -38,7 +38,7 @@
 
                         <tbody>
 
-                        @foreach($event->activity->allUsersSorted() as $user)
+                        @foreach($event->returnAllUsers() as $user)
                             <tr>
 
                                 <td>


### PR DESCRIPTION
Collection of users is now filtered to only contain unique users based on user id. Duplicated users are not removed in participant checklist etc, let me know if anyone wants to see that added too. 