### PR TITLE
Disabled directadminsync logging

### DIFF
--- a/app/Console/Commands/DirectAdminSync.php
+++ b/app/Console/Commands/DirectAdminSync.php
@@ -290,7 +290,7 @@ class DirectAdminSync extends Command
     private function executeQueries($da, $queries)
     {
         foreach ($queries as $i => $query) {
-            $this->info('Query '.$i.'/'.count($queries).': '.$query['cmd'].implode($query['options']));
+            //$this->info('Query '.$i.'/'.count($queries).': '.$query['cmd'].implode($query['options'])); //Temporarily disabled to reduce Sentry spam
             $da->query($query['cmd'], $query['options']);
 
             $response = $da->fetch_parsed_body();


### PR DESCRIPTION
Disabled logging to stop 'array to string conversion' errors in sentry