### PR TITLE
Fixed the placeholder link being in the way

### DIFF
--- a/resources/views/dinnerform/admin_includes/dinnerform-details.blade.php
+++ b/resources/views/dinnerform/admin_includes/dinnerform-details.blade.php
@@ -44,8 +44,8 @@
 
                             <label for="url">Url:</label>
                             <input type="text" class="form-control" id="url" name="url"
-                                   value="{{ $dinnerformCurrent->url ?? 'https://forms.gle/t2hDEnkNCLXNpvYTA' }}" required>
-
+                                   placeholder='https://forms.gle/t2hDEnkNCLXNpvYTA'
+                                   value="{{ $dinnerformCurrent->url ?? ''}}" required>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
When making a dinnerform the standard link was not a placeholder and therefore would sometimes be behind the real link when pasted. Is now a proper placeholder. Adds to and closes issue #1396