### PR TITLE
Fix dmx_value route and date error for overrides

### DIFF
--- a/app/Models/DmxOverride.php
+++ b/app/Models/DmxOverride.php
@@ -30,8 +30,6 @@ class DmxOverride extends Model
 
     protected $guarded = ['id'];
 
-    protected $dates = ['start', 'end'];
-
     public $timestamps = false;
 
     /** @return Collection|DmxOverride[] */

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,7 +3,7 @@
 Route::group(['middleware' => ['forcedomain'], 'as' => 'api::'], function () {
     /* Routes related to the General APIs */
     Route::group(['middleware' => ['web']], function () {
-        Route::get('dmx_values', ['as', 'dmx_values', 'uses' => 'DmxController@valueApi']);
+        Route::get('dmx_values', ['as' => 'dmx_values', 'uses' => 'DmxController@valueApi']);
         Route::get('token', ['as' => 'token', 'uses' => 'ApiController@getToken']);
         Route::get('fishcam', ['as' => 'fishcam', 'uses' => 'ApiController@fishcamStream']);
         Route::get('scan/{event}', ['as' => 'scan', 'middleware' => ['auth'], 'uses' => 'TicketController@scanApi']);


### PR DESCRIPTION
Open up the route to access the JSON data for the smart-XP light system again and disable the laravel protected dates attribute as we do not expect it to be this in our code.