### PR TITLE
Set dmx_values outside the web and inside the api middleware

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -5,7 +5,6 @@ Route::group(['middleware' => ['forcedomain'], 'as' => 'api::'], function () {
     /* Route for smartXp dmx_values (excluded from web and therefore https) */
     Route::get('dmx_values', ['as' => 'dmx_values', 'uses' => 'DmxController@valueApi']);
 
-
     /* Routes related to the General APIs */
     Route::group(['middleware' => ['web']], function () {
         Route::get('token', ['as' => 'token', 'uses' => 'ApiController@getToken']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,10 +1,10 @@
 <?php
 
 Route::group(['middleware' => ['forcedomain'], 'as' => 'api::'], function () {
-    /* Routes for smartXp dmx_values (excluded from web and therefore https) */
-    Route::group(['middleware' => ['api']], function () {
-        Route::get('dmx_values', ['as' => 'dmx_values', 'uses' => 'DmxController@valueApi']);
-    });
+
+    /* Route for smartXp dmx_values (excluded from web and therefore https) */
+    Route::get('dmx_values', ['as' => 'dmx_values', 'uses' => 'DmxController@valueApi']);
+
 
     /* Routes related to the General APIs */
     Route::group(['middleware' => ['web']], function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,13 @@
 <?php
 
 Route::group(['middleware' => ['forcedomain'], 'as' => 'api::'], function () {
+    /* Routes for smartXp dmx_values (excluded from web and therefore https) */
+    Route::group(['middleware' => ['api']], function () {
+        Route::get('dmx_values', ['as' => 'dmx_values', 'uses' => 'DmxController@valueApi']);
+    });
+
     /* Routes related to the General APIs */
     Route::group(['middleware' => ['web']], function () {
-        Route::get('dmx_values', ['as' => 'dmx_values', 'uses' => 'DmxController@valueApi']);
         Route::get('token', ['as' => 'token', 'uses' => 'ApiController@getToken']);
         Route::get('fishcam', ['as' => 'fishcam', 'uses' => 'ApiController@fishcamStream']);
         Route::get('scan/{event}', ['as' => 'scan', 'middleware' => ['auth'], 'uses' => 'TicketController@scanApi']);


### PR DESCRIPTION
It does not get forced over https anymore (not in a 'web' group) but does get throttled now as it is in an API middleware group