### PR TITLE
Replace the 9292 api with the rest ovapi

### DIFF
--- a/app/Http/Controllers/SmartXpScreenController.php
+++ b/app/Http/Controllers/SmartXpScreenController.php
@@ -33,22 +33,20 @@ class SmartXpScreenController extends Controller
      * @param $stop
      * @return object[]
      */
-    public function bus($tpc_id)
+    public function bus($tpc_id, $tpc_id_other_side)
     {
         try {
-            $departures = json_decode(file_get_contents(stripslashes("http://v0.ovapi.nl/tpc/$tpc_id")));
-            return json_encode($departures->$tpc_id->Passes);
+            $departures = json_decode(file_get_contents(stripslashes("http://v0.ovapi.nl/tpc/$tpc_id,$tpc_id_other_side")));
+            return json_encode( (object) array_merge((array) $departures->$tpc_id->Passes, (array) $departures->$tpc_id_other_side->Passes));
         } catch (Exception $e) {
-            return [(object) [
-                'time' => $tpc_id,
-                'service' => '',
-                'mode' => (object) [
-                    'name' => 'Error in API!',
-                ],
-                'realtimeText' => '',
-                'realtimeState' => '9292',
-                'destinationName' => 'who knows?',
-            ]];
+            return json_encode((object)[
+                'dragon'=>(object)[
+                'ExpectedArrivalTime' => '1',
+                'TransportType' => 'ERROR',
+                'LinePublicNumber' =>' ',
+                'TripStopStatus' => 'Dragon',
+                'DestinationName50' => 'who knows?',
+            ]]);
         }
     }
 

--- a/app/Http/Controllers/SmartXpScreenController.php
+++ b/app/Http/Controllers/SmartXpScreenController.php
@@ -33,11 +33,11 @@ class SmartXpScreenController extends Controller
      * @param $stop
      * @return object[]
      */
-    public function bus($tpc_id, $tpc_id_other_side)
+    public function bus($tpc_id, $tpc_id_other)
     {
         try {
-            $departures = json_decode(file_get_contents(stripslashes("http://v0.ovapi.nl/tpc/$tpc_id,$tpc_id_other_side")));
-            return json_encode( (object) array_merge((array) $departures->$tpc_id->Passes, (array) $departures->$tpc_id_other_side->Passes));
+            $departures = json_decode(file_get_contents(stripslashes("http://v0.ovapi.nl/tpc/$tpc_id,$tpc_id_other")));
+            return json_encode( (object) array_merge((array) $departures->$tpc_id->Passes, (array) $departures->$tpc_id_other->Passes));
         } catch (Exception $e) {
             return json_encode((object)[
                 'dragon'=>(object)[

--- a/app/Http/Controllers/SmartXpScreenController.php
+++ b/app/Http/Controllers/SmartXpScreenController.php
@@ -33,15 +33,14 @@ class SmartXpScreenController extends Controller
      * @param $stop
      * @return object[]
      */
-    public function bus($stop)
+    public function bus($tpc_id)
     {
         try {
-            $departures = json_decode(stripslashes(file_get_contents("https://api.9292.nl/0.1/locations/enschede/$stop/departure-times?lang=en-GB")));
-
-            return $departures->tabs[0]->departures;
+            $departures = json_decode(file_get_contents(stripslashes("http://v0.ovapi.nl/tpc/$tpc_id")));
+            return json_encode($departures->$tpc_id->Passes);
         } catch (Exception $e) {
             return [(object) [
-                'time' => '00:00',
+                'time' => $tpc_id,
                 'service' => '',
                 'mode' => (object) [
                     'name' => 'Error in API!',
@@ -104,3 +103,6 @@ class SmartXpScreenController extends Controller
             'answer' => $this->smartxpTimetable()->answer, ]);
     }
 }
+
+
+

--- a/resources/views/smartxp/screen.blade.php
+++ b/resources/views/smartxp/screen.blade.php
@@ -440,8 +440,8 @@
     updateActivities();
 
     function updateBuses() {
-        updateBus('bushalte-ut-hallenweg', '#businfo-hallen');
-        updateBus('bushalte-westerbegraafplaats-ut', '#businfo-wester');
+        updateBus(43005640, '#businfo-hallen');
+        updateBus(43005640, '#businfo-wester');
     }
 
     function updateBus(stop, element) {
@@ -449,15 +449,19 @@
             url: "{{ urldecode(route('api::screen::bus',['stop' => '--replaceme--'])) }}".replace('--replaceme--', stop),
             dataType: 'json',
             success: function (data) {
-                if (data.length > 0) {
+                console.log()
+                if (Object.keys(data).length > 0) {
+                    console.log(data);
                     $(element).html('');
-                    for (i in data) {
-                        $(element).append('<div class="busentry">' + data[i].time + ' ' + data[i].mode.name + ' ' + data[i].service + ' <span style="color: #c1ff00;">' + (data[i].realtimeText !== null ? data[i].realtimeText + ' (' + data[i].realtimeState + ')' : '(' + data[i].realtimeState + ')') + '</span><br>Towards ' + data[i].destinationName + '</div>');
+                    for (const [key, value] of Object.entries(data)) {
+                        console.log(`${key}: ${value}`);
+                        $(element).append('<div class="busentry">' + value.ExpectedArrivalTime + ' ' + value.TransportType+' '+ value.LinePublicNumber + ' <span style="color: #c1ff00;">' + value.TripStopStatus + '</span><br>Towards ' + value.DestinationName50 + '</div>');
                     }
                 } else {
                     $(element).html('<div class="notice">No buses!</div>');
                 }
             },
+
             error: function () {
                 $(element).html('<div class="notice">Error...</div>');
             }

--- a/resources/views/smartxp/screen.blade.php
+++ b/resources/views/smartxp/screen.blade.php
@@ -458,9 +458,11 @@
                         return ((new Date(a[1].ExpectedArrivalTime).valueOf()) - (new Date(b[1].ExpectedArrivalTime).valueOf()));
                     });
                     for (const [key, value] of sortableBusses) {
-                         let colorLate= (Math.abs(new Date(value.ExpectedArrivalTime) - new Date(value.TargetArrivalTime))/1000*60 > 1) ? '#ff0000':'#c1ff00';
-                         let drivingColor= value.TripStopStatus==="DRIVING"?'#c1ff00':'#fff'
-                        $(element).append('<div class="busentry">'+`<span style=color:${colorLate}>` +new Date(value.ExpectedArrivalTime).toISOString().substr(11, 8).substr(0,5)+'</span>'+ ' ' + value.TransportType+' '+ value.LinePublicNumber +` `+ `<span style="color: ${drivingColor};">` + value.TripStopStatus + '</span><br>Towards ' + value.DestinationName50 + '</div>')
+                        let colorLate = (Math.abs(new Date(value.ExpectedArrivalTime) - new Date(value.TargetArrivalTime)) / 1000 * 60 > 1) ? '#ff0000' : '#c1ff00';
+                        let drivingColor = value.TripStopStatus === "DRIVING" ? '#c1ff00' : '#fff'
+                        if (value.TripStopStatus != "ARRIVED") {
+                            $(element).append('<div class="busentry">' + `<span style=color:${colorLate}>` + new Date(value.ExpectedArrivalTime).toISOString().substr(11, 8).substr(0, 5) + '</span>' + ' ' + value.TransportType + ' ' + value.LinePublicNumber + ` ` + `<span style="color: ${drivingColor};">` + value.TripStopStatus + '</span><br>Towards ' + value.DestinationName50 + '</div>')
+                        }
                     }
                 } else {
                     $(element).html('<div class="notice">No buses!</div>');

--- a/resources/views/smartxp/screen.blade.php
+++ b/resources/views/smartxp/screen.blade.php
@@ -440,22 +440,26 @@
     updateActivities();
 
     function updateBuses() {
-        updateBus(43005640, '#businfo-hallen');
-        updateBus(43005640, '#businfo-wester');
+        updateBus(43005640, 43005630, '#businfo-hallen');
+        updateBus(43005640, 43005630, '#businfo-wester');
     }
 
-    function updateBus(stop, element) {
+    function updateBus(stop, stop_other_side, element) {
         $.ajax({
-            url: "{{ urldecode(route('api::screen::bus',['stop' => '--replaceme--'])) }}".replace('--replaceme--', stop),
+            url: "{{ urldecode(route('api::screen::bus',['stop' => '43005630', 'other_stop'=>'43005630'])) }}",
             dataType: 'json',
             success: function (data) {
-                console.log()
+                console.log(Object.keys(data))
                 if (Object.keys(data).length > 0) {
-                    console.log(data);
                     $(element).html('');
-                    for (const [key, value] of Object.entries(data)) {
-                        console.log(`${key}: ${value}`);
-                        $(element).append('<div class="busentry">' + value.ExpectedArrivalTime + ' ' + value.TransportType+' '+ value.LinePublicNumber + ' <span style="color: #c1ff00;">' + value.TripStopStatus + '</span><br>Towards ' + value.DestinationName50 + '</div>');
+
+                    let sortableBusses =Object.entries(data).slice(0)
+                    sortableBusses.sort(function(a,b) {
+                        return ((new Date(a[1].ExpectedArrivalTime).valueOf()) - (new Date(b[1].ExpectedArrivalTime).valueOf()));
+                    });
+                    for (const [key, value] of sortableBusses) {
+                        // let colorLate= (Math.abs(value.ExpectedArrivalTime - value.TargetArrivalTime)/1000*60 < 1) ? '#ff0000':'#ff0000';
+                        $(element).append('<div class="busentry">'+ new Date(value.ExpectedArrivalTime).toISOString().substr(11, 8).substr(0,5)+ ' ' + value.TransportType+' '+ value.LinePublicNumber + ' <span style="color: #c1ff00;">' + value.TripStopStatus + '</span><br>Towards ' + value.DestinationName50 + '</div>');
                     }
                 } else {
                     $(element).html('<div class="notice">No buses!</div>');

--- a/resources/views/smartxp/screen.blade.php
+++ b/resources/views/smartxp/screen.blade.php
@@ -459,7 +459,8 @@
                     });
                     for (const [key, value] of sortableBusses) {
                          let colorLate= (Math.abs(new Date(value.ExpectedArrivalTime) - new Date(value.TargetArrivalTime))/1000*60 > 1) ? '#ff0000':'#c1ff00';
-                        $(element).append('<div class="busentry">'+`<span style=color:${colorLate}>` +new Date(value.ExpectedArrivalTime).toISOString().substr(11, 8).substr(0,5)+'</span>'+ ' ' + value.TransportType+' '+ value.LinePublicNumber + ' <span style="color: #c1ff00;">' + value.TripStopStatus + '</span><br>Towards ' + value.DestinationName50 + '</div>')
+                         let drivingColor= value.TripStopStatus==="DRIVING"?'#c1ff00':'#fff'
+                        $(element).append('<div class="busentry">'+`<span style=color:${colorLate}>` +new Date(value.ExpectedArrivalTime).toISOString().substr(11, 8).substr(0,5)+'</span>'+ ' ' + value.TransportType+' '+ value.LinePublicNumber +` `+ `<span style="color: ${drivingColor};">` + value.TripStopStatus + '</span><br>Towards ' + value.DestinationName50 + '</div>')
                     }
                 } else {
                     $(element).html('<div class="notice">No buses!</div>');

--- a/resources/views/smartxp/screen.blade.php
+++ b/resources/views/smartxp/screen.blade.php
@@ -319,10 +319,10 @@
 
                         <div class="box-header small">
                             <i class="fas fa-bus fa-fw mr-1"></i>
-                            Hallenweg
+                            Westerbegraafplaats
                         </div>
 
-                        <div id="businfo-hallen" class="businfo">
+                        <div id="businfo-wester" class="businfo">
 
                         </div>
 
@@ -332,10 +332,10 @@
 
                         <div class="box-header small">
                             <i class="fas fa-bus fa-fw mr-1"></i>
-                            Westerbegraafplaats
+                            Langenkampweg
                         </div>
 
-                        <div id="businfo-wester" class="businfo">
+                        <div id="businfo-langen" class="businfo">
 
                         </div>
 
@@ -440,26 +440,26 @@
     updateActivities();
 
     function updateBuses() {
-        updateBus(43005640, 43005630, '#businfo-hallen');
+        updateBus(43110270, 43110270, '#businfo-langen');
         updateBus(43005640, 43005630, '#businfo-wester');
     }
 
     function updateBus(stop, stop_other_side, element) {
         $.ajax({
-            url: "{{ urldecode(route('api::screen::bus',['stop' => '43005630', 'other_stop'=>'43005630'])) }}",
+            url: "{{urldecode(route('api::screen::bus',['stop' => '--replaceme--','stop_other_side' => '--replaceme_other--']))}}".replace('--replaceme--', stop).replace('--replaceme_other--', stop_other_side),
             dataType: 'json',
             success: function (data) {
                 console.log(Object.keys(data))
                 if (Object.keys(data).length > 0) {
                     $(element).html('');
 
-                    let sortableBusses =Object.entries(data).slice(0)
+                    let sortableBusses = Object.entries(data).slice(0)
                     sortableBusses.sort(function(a,b) {
                         return ((new Date(a[1].ExpectedArrivalTime).valueOf()) - (new Date(b[1].ExpectedArrivalTime).valueOf()));
                     });
                     for (const [key, value] of sortableBusses) {
-                        // let colorLate= (Math.abs(value.ExpectedArrivalTime - value.TargetArrivalTime)/1000*60 < 1) ? '#ff0000':'#ff0000';
-                        $(element).append('<div class="busentry">'+ new Date(value.ExpectedArrivalTime).toISOString().substr(11, 8).substr(0,5)+ ' ' + value.TransportType+' '+ value.LinePublicNumber + ' <span style="color: #c1ff00;">' + value.TripStopStatus + '</span><br>Towards ' + value.DestinationName50 + '</div>');
+                         let colorLate= (Math.abs(new Date(value.ExpectedArrivalTime) - new Date(value.TargetArrivalTime))/1000*60 > 1) ? '#ff0000':'#c1ff00';
+                        $(element).append('<div class="busentry">'+`<span style=color:${colorLate}>` +new Date(value.ExpectedArrivalTime).toISOString().substr(11, 8).substr(0,5)+'</span>'+ ' ' + value.TransportType+' '+ value.LinePublicNumber + ' <span style="color: #c1ff00;">' + value.TripStopStatus + '</span><br>Towards ' + value.DestinationName50 + '</div>')
                     }
                 } else {
                     $(element).html('<div class="notice">No buses!</div>');

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,7 +79,7 @@ Route::group(['middleware' => ['forcedomain'], 'as' => 'api::'], function () {
     });
 
     Route::group(['prefix' => 'screen', 'as' => 'screen::'], function () {
-        Route::get('bus/{stop}', ['as' => 'bus', 'uses' => 'SmartXpScreenController@bus']);
+        Route::get('bus/{stop}/{stop_other_side}', ['as' => 'bus', 'uses' => 'SmartXpScreenController@bus']);
         Route::get('timetable', ['as' => 'timetable', 'uses' => 'SmartXpScreenController@timetable']);
         Route::get('timetable/protopeners', ['as' => 'timetable::protopeners', 'uses' => 'SmartXpScreenController@protopenersTimetable']);
         Route::get('narrowcasting', ['as' => 'narrowcasting', 'uses' => 'NarrowcastingController@indexApi']);


### PR DESCRIPTION
The 9292 implementation for the busses on the smartxp screen does not get supported anymore, now replaced by the rest OVapi https://github.com/skywave/KV78Turbo-OVAPI/wiki. The timingpointcodes are for each stop, for each side of the road. Currently hallenweg is discontinued so I chose the closest stop I could get actual data from (langenkampweg)