### PR TITLE
Disabling 1337 soundboard sound cronjob

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -63,7 +63,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('proto:omnomcleanup')->daily()->at('06:00');
         $schedule->command('proto:helperremindercron')->daily()->at('08:00');
         $schedule->command('proto:helpernotificationcron')->daily()->at('10:00');
-        $schedule->command('proto:playsound '.config('proto.soundboardSounds')['1337'])->daily()->at('13:37');
+//        $schedule->command('proto:playsound '.config('proto.soundboardSounds')['1337'])->daily()->at('13:37');
         $schedule->command('proto:checkutaccounts')->monthly();
         $schedule->command('proto:verifydetailscron')->monthlyOn(1, '12:00');
     }


### PR DESCRIPTION
Because soundboard is still broken and this cronjob throws an error.