### PR TITLE
Added concurrency to GitHub deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,14 @@
 name: 🚀 Deploy
+
 on:
   push:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy


### PR DESCRIPTION
This will cancel any already running deploy actions to stop them from accidentally overwriting each other. See [github actions docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow) on concurrency for more info.