### PR TITLE
Revert "Fixed php-queue Docker container"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ When you have finished the setup and Docker the following port will be exposed o
 
 You can sign in with the same Proto username you use on the *live* website and the password given to you during the database seeding. This user will have full admin rights on the local website.
 
-> _Note:_ the php-queue container might not work yet on the first run. Restart the Docker containers after you have installed the backend dependencies and the container should be functional.
-
 ### Handy commands
 
 ##### Running

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,8 @@ services:
       - .:/var/www
 
   queue:
-    build: ./docker/build/php
+    build: ./docker/build/php-queue
     container_name: ${DOCKER_NAME}-queue
-    command: 'php artisan queue:work --verbose --tries=3 --timeout=90 --queue=low,medium,high'
     volumes:
       - .:/var/www
 

--- a/docker/build/php-queue/Dockerfile
+++ b/docker/build/php-queue/Dockerfile
@@ -1,0 +1,38 @@
+FROM php:7.3-cli
+
+# Set working directory
+WORKDIR /var/www
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    mariadb-client \
+    libpng-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
+    locales \
+    zip \
+    jpegoptim optipng pngquant gifsicle \
+    vim \
+    unzip \
+    git \
+    curl \
+    libgmp-dev \
+    libmcrypt-dev \
+    libzip-dev
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install extensions
+RUN docker-php-ext-install pdo_mysql mbstring zip exif pcntl gmp
+RUN docker-php-ext-configure gd --with-gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/
+RUN docker-php-ext-install gd
+RUN pecl install mcrypt-1.0.2 && docker-php-ext-enable mcrypt
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY ./php.ini /usr/local/etc/php/
+
+CMD ["php", "/var/www/artisan", "queue:work", "--verbose", "--tries=3", "--timeout=90", "--queue=low,medium,high"]

--- a/docker/build/php-queue/php.ini
+++ b/docker/build/php-queue/php.ini
@@ -1,0 +1,4 @@
+date.timezone="Europe/Amsterdam"
+memory_limit=1024M
+upload_max_filesize=10M
+post_max_size=1024M


### PR DESCRIPTION
Reverts saproto/saproto#1478

Missed the fact that php-queue docker file is based on php-cli instead of php-fpm. Problem is actually in the missing calendar package.