### PR TITLE
Properly integrated sentry-release github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
       BUILD_ARTIFACT_STAGING_DIR: build/
       BUILD_ARTIFACT_DESTINATION_DIR: /domains/proto.utwente.nl/deployment/uploads/
       HOST_SERVER: s176.webhostingserver.nl
+      SENTRY_ORG: sa-proto
+      SENTRY_PROJECT: sa-proto-website
     steps:
       - name: 🛎️ Checkout project
         uses: actions/checkout@v2
@@ -57,8 +59,14 @@ jobs:
       - name: 🗑️ Remove storage directory
         run: rm -rf storage
         
-      - name: 📝 Set Sentry release
-        run: sed -i "s/GIT_SHA/$(git rev-parse --short "$GITHUB_SHA")/" config/sentry.php
+      - name: 📝 Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ env.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
+        with:
+          environment: production
         
       - name: 📁 Create build directory
         run: mkdir ${{ env.BUILD_ARTIFACT_STAGING_DIR }}

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -3,9 +3,6 @@
 return [
     'dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
 
-    // Release as git sha is captured in deploy action
-    'release' => 'GIT_SHA',
-
     // When left empty or `null` the Laravel environment will be used
     'environment' => null,
 


### PR DESCRIPTION
Already set up GitHub actions secret and sentry integration. This update will allow for tracking commits related to sentry releases.