### PR TITLE
Really fixed retrieving helper reminder subscribers!

### DIFF
--- a/app/Console/Commands/HelperReminderCron.php
+++ b/app/Console/Commands/HelperReminderCron.php
@@ -52,7 +52,7 @@ class HelperReminderCron extends Command
                 continue;
             }
             $helping_committees = HelpingCommittee::where('activity_id', $event->activity->id)->get();
-            if ($helping_committees->count() == 0) {
+            if (count($helping_committees) == 0) {
                 $this->info('Event has no helping committees. Skipping');
                 continue;
             }
@@ -61,13 +61,13 @@ class HelperReminderCron extends Command
                 if ($helping_committee->getHelpingCount() >= $helping_committee->amount) {
                     $this->info(sprintf('%s has enough helpers, skipping.', $helping_committee->committee->name));
                     continue;
-                } elseif (count($helping_committee->committee->helper_reminder_subscribers) == 0) {
+                }
+                if (count($helping_committee->committee->helper_reminder_subscribers) == 0) {
                     $this->info(sprintf('%s has no people subscribed to helper reminders, skipping.', $helping_committee->committee->name));
                     continue;
-                } else {
-                    $this->error(sprintf('Sending reminder e-mail for %s (%s/%s helping).', $helping_committee->committee->name, $helping_committee->getHelpingCount(), $helping_committee->amount));
-                    Mail::queue((new HelperReminder($helping_committee))->onQueue('medium'));
                 }
+                $this->error(sprintf('Sending reminder e-mail for %s (%s/%s helping).', $helping_committee->committee->name, $helping_committee->getHelpingCount(), $helping_committee->amount));
+                Mail::queue((new HelperReminder($helping_committee))->onQueue('medium'));
             }
         }
     }

--- a/app/Models/Committee.php
+++ b/app/Models/Committee.php
@@ -28,7 +28,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int $is_society
  * @property-read string $email_address
  * @property-read Collection|User[] $helper_reminder_subscribers
- * @property-read Collection|HelperReminder[] $helperReminderSubscribers
+ * @property-read Collection|HelperReminder[] $helperReminderSubscriptions
  * @property-read StorageEntry|null $image
  * @property-read Collection|Event[] $organizedEvents
  * @property-read Collection|User[] $users
@@ -92,7 +92,7 @@ class Committee extends Model
     }
 
     /** @return HasMany|HelperReminder[] */
-    public function helperReminderSubscribers()
+    public function helperReminderSubscriptions()
     {
         return $this->hasMany('Proto\Models\HelperReminder');
     }
@@ -104,11 +104,12 @@ class Committee extends Model
     }
 
     /** @return User[] */
-    public function getHelperReminderSubscribersAttribute()
+    public function HelperReminderSubscribers()
     {
         $users = [];
-        foreach ($this->helperReminderSubscribers() as $subscriber) {
-            $users[] = $subscriber->user;
+        $subscriptions = $this->helperReminderSubscriptions()->get();
+        foreach ($subscriptions as $subscription) {
+            $users[] = $subscription->user;
         }
         return $users;
     }
@@ -119,7 +120,7 @@ class Committee extends Model
      */
     public function wantsToReceiveHelperReminder($user)
     {
-        return HelperReminder::where('user_id', $user->id)->where('committee_id', $this->id)->count() > 0;
+        return $this->helperReminderSubscriptions()->where('user_id', $user->id)->count() > 0;
     }
 
     /** @return Collection|Event[] */


### PR DESCRIPTION
HOLY SHIT I wasted hours of my time not knowing that you have to restart the queue command when you change any code that is used by the queue worker. But, hopefully this will finally (actually) fix the helper subscriber emails.
[![image](https://user-images.githubusercontent.com/21026046/156371344-6b6501a8-e200-449a-9be7-04cf5cd298ca.png)](https://stackoverflow.com/questions/66871991/laravel-mailable-trying-to-get-property-email-of-non-object)
