### PR TITLE
Fixed error in personal purchase history

### DIFF
--- a/app/Http/Controllers/OrderLineController.php
+++ b/app/Http/Controllers/OrderLineController.php
@@ -51,14 +51,16 @@ class OrderLineController extends Controller
             if (! array_key_exists($month->year, $available_months)) {
                 $available_months[$month->year] = [];
             }
-            array_push($available_months[$month->year], $month->month);
+            $available_months[$month->year][] = $month->month;
         }
+
+        $current_orderlines = $grouped_orderlines->has($this_month->format('Y-m')) ? $grouped_orderlines[$this_month->format('Y-m')] : null;
 
         return view('omnomcom.orders.myhistory', [
             'user' => $user,
             'available_months' => $available_months,
             'selected_month' => $this_month,
-            'orderlines' => $grouped_orderlines[Carbon::parse($this_month)->format('Y-m')],
+            'orderlines' => $current_orderlines,
             'next_withdrawal' => $next_withdrawal,
             'total' => $total,
         ]);

--- a/resources/views/omnomcom/orders/includes/history.blade.php
+++ b/resources/views/omnomcom/orders/includes/history.blade.php
@@ -4,7 +4,7 @@
         @yield('page-title')
     </div>
 
-    @if(count($orderlines) > 0)
+    @isset($orderlines)
 
         <table class="table table-borderless table-hover table-sm mt-1">
 


### PR DESCRIPTION
Purchase history gave an error when there were no orderlines for the current month