### PR TITLE
Http to https automatically redirect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,12 @@ services:
     ports:
       - 127.0.0.1:${DOCKER_HTTP_PORT}:443
     volumes:
-      - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./docker/nginx/nginx.conf:/etc/nginx/templates/nginx.conf.template
       - ./docker/nginx-log:/var/log/nginx
       - .:/var/www
+    environment:
+      - NGINX_HTTP_PORT=${DOCKER_HTTP_PORT}
+      - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
 
   phpmyadmin:
     container_name: ${DOCKER_NAME}-pma

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -2,6 +2,8 @@ http {
     server {
         listen 443 ssl;
 
+        error_page 497 https://$host:${NGINX_HTTP_PORT}$request_uri;
+
         server_name localhost;
         root /var/www/public;
 


### PR DESCRIPTION
Docker nginx is modified to automatically redirect non-https requests to https so you don't have to type https://... every time