### PR TITLE
Make tooltip orange when on backuplist

### DIFF
--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -191,6 +191,10 @@ class Activity extends Validatable
         return $this->getParticipation($user) !== null;
     }
 
+    public function isOnBackupList($user){
+        return in_array($user->id,$this->backupUsers()->pluck("users.id")->toArray());
+    }
+
     /**
      * @param User $user
      * @param  HelpingCommittee|null $h

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -191,8 +191,8 @@ class Activity extends Validatable
         return $this->getParticipation($user) !== null;
     }
 
-    public function isOnBackupList($user){
-        return in_array($user->id,$this->backupUsers()->pluck("users.id")->toArray());
+    public function isOnBackupList($user) {
+        return in_array($user->id,$this->backupUsers()->pluck('users.id')->toArray());
     }
 
     /**

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -28,10 +28,13 @@ Auth::check() && (($event->activity && $event->activity->isParticipating(Auth::u
                    data-toggle="tooltip" data-placement="top" title="This is a featured activity!"></i>
             @endif
             @if($event->activity && Auth::check())
-                @if($event->activity->isParticipating(Auth::user()))
-                    <i class="fas fa-check text-primary fa-fw" aria-hidden="true"
-                       data-toggle="tooltip" data-placement="top" title="You are participating!"></i>
-                @endif
+                    @if(in_array(Auth::user()->id,$event->activity->backupUsers()->pluck("users.id")->toArray()))
+                        <i class="fas fa-check text-warning fa-fw" aria-hidden="true"
+                           data-bs-toggle="tooltip" data-bs-placement="top" title="You are on the backuplist!"></i>
+                    @else
+                        <i class="fas fa-check text-primary fa-fw" aria-hidden="true"
+                           data-bs-toggle="tooltip" data-bs-placement="top" title="You are participating!"></i>
+                    @endif
                 @if($event->activity->isHelping(Auth::user()))
                     <i class="fas fa-life-ring fa-fw" style="color: red;" aria-hidden="true"
                        data-toggle="tooltip" data-placement="top" title="You are helping!"></i>

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -28,7 +28,7 @@ Auth::check() && (($event->activity && $event->activity->isParticipating(Auth::u
                    data-toggle="tooltip" data-placement="top" title="This is a featured activity!"></i>
             @endif
             @if($event->activity && Auth::check())
-                    @if(in_array(Auth::user()->id,$event->activity->backupUsers()->pluck("users.id")->toArray()))
+                    @if($event->activity->isOnBackupList(Auth::user()))
                         <i class="fas fa-check text-warning fa-fw" aria-hidden="true"
                            data-bs-toggle="tooltip" data-bs-placement="top" title="You are on the backuplist!"></i>
                     @else

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -27,7 +27,7 @@ Auth::check() && (($event->activity && $event->activity->isParticipating(Auth::u
                 <i class="fas fa-star fa-fw" aria-hidden="true" style="color: gold"
                    data-toggle="tooltip" data-placement="top" title="This is a featured activity!"></i>
             @endif
-            @if($event->activity && Auth::check())
+            @if($event->activity && Auth::check() && $event->activity->isParticipating(Auth::user()))
                     @if($event->activity->isOnBackupList(Auth::user()))
                         <i class="fas fa-check text-warning fa-fw" aria-hidden="true"
                            data-bs-toggle="tooltip" data-bs-placement="top" title="You are on the backuplist!"></i>


### PR DESCRIPTION
Change the tooltip on the included events-block from green to orange when on the backup list and announce that you are on the backuplist with the tooltip. Avoids confusion.