### PR TITLE
Show an open lock icon when a user can signup for an event

### DIFF
--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -86,13 +86,21 @@ Auth::check() && (($event->activity && $event->activity->isParticipating(Auth::u
                 </span>
             @endif
 
-            @if($event->activity && $event->activity->users->count()>0)
-               <br>
-               <span>
+                @if($event->activity)
+                    <div class= "d-flex justify-content-between">
+                        @if($event->activity->users->count()>0)
+                            <span>
                     <i class="fas fa-user-alt fa-fw" aria-hidden="true"></i>
                     {{$event->activity->users->count()}}
                 </span>
-            @endif
+                        @endif
+                        @if($event->activity->canSubscribe())
+                            <span>
+                        <i class="fas fa-lock-open"></i>
+                        </span>
+                        @endif
+                    </div>
+                @endif
 
         </div>
 


### PR DESCRIPTION
When the user can signup an open lock will now be shown in the event include block