### PR TITLE
Add an extra control bar at the bottom of a quotepage with >10 quotes

### DIFF
--- a/resources/views/quotecorner/allquotes.blade.php
+++ b/resources/views/quotecorner/allquotes.blade.php
@@ -28,4 +28,9 @@
 
     </div>
 
+    @if(count($data)>10)
+    <div class="card-header pb-0 overflow-auto">
+        {{ $data->links() }}
+    </div>
+    @endif
 </div>


### PR DESCRIPTION
This way you do not have to scroll all the way to the top again when done with reading this page