### PR TITLE
Prevent users being plucked from the backup-list prematurely

### DIFF
--- a/app/Http/Controllers/ParticipationController.php
+++ b/app/Http/Controllers/ParticipationController.php
@@ -172,7 +172,7 @@ class ParticipationController extends Controller
 
             $participation->delete();
 
-            if ($participation->backup == false) {
+            if ($participation->backup == false &&  $participation->activity->users()->count() < $participation->activity->participants) {
                 self::transferOneBackupUser($participation->activity);
             }
         } else {

--- a/app/Http/Controllers/ParticipationController.php
+++ b/app/Http/Controllers/ParticipationController.php
@@ -172,7 +172,7 @@ class ParticipationController extends Controller
 
             $participation->delete();
 
-            if ($participation->backup == false &&  $participation->activity->users()->count() < $participation->activity->participants) {
+            if ($participation->backup == false && $participation->activity->users()->count() < $participation->activity->participants) {
                 self::transferOneBackupUser($participation->activity);
             }
         } else {


### PR DESCRIPTION
This happened when there were too many users on the event (accidental duplicates from our website being overloaded).
If there were more users than places and one got deleted there would be one moved from the backuplist even if there was no space for them.