### PR TITLE
Clarify the status of an withdrawal

### DIFF
--- a/resources/views/omnomcom/orders/includes/recent-payments.blade.php
+++ b/resources/views/omnomcom/orders/includes/recent-payments.blade.php
@@ -9,17 +9,21 @@
         <ul class="list-group list-group-flush">
 
             @foreach($user->withdrawals(6) as $withdrawal)
-                <li class="list-group-item">
+                <div class="list-group-item d-flex justify-content-between">
+                    <div>
                     <a href="{{ route('omnomcom::mywithdrawal', ['id' => $withdrawal->id]) }}">
                         {{ date('d-m-Y', strtotime($withdrawal->date)) }}
                     </a>
+                    </div>
                     @if($withdrawal->getFailedWithdrawal($user) || $withdrawal->id == 'temp')
-                        <i class="fas fa-times text-danger ms-2"></i>
+                        <i class="fas fa-times text-danger mt-1"></i>
+                    @else
+                    <div>{{$withdrawal->closed?'Closed':'Pending'}}</div>
                     @endif
-                    <span class="float-end">
+                    <div>
                         &euro;{{ number_format($withdrawal->totalForUser($user), 2, '.', ',') }}
-                    </span>
-                </li>
+                    </div>
+                </div>
             @endforeach
 
         </ul>

--- a/resources/views/omnomcom/withdrawals/userhistory.blade.php
+++ b/resources/views/omnomcom/withdrawals/userhistory.blade.php
@@ -2,6 +2,7 @@
 
 @section('page-title')
     Personal Overview for the {{ date('d-m-Y', strtotime($withdrawal->date)) }} Withdrawal
+    <br>Withdrawal status: {{$withdrawal->closed?'Closed':'Payed'}}
 @endsection
 
 @section('container')

--- a/resources/views/users/dashboard/includes/deleteaccount.blade.php
+++ b/resources/views/users/dashboard/includes/deleteaccount.blade.php
@@ -57,6 +57,7 @@
                     <br>
                     <p>
                         <strong>Note:</strong> If you still have open payments, you <strong>cannot</strong> close your account! You will first have to pay off your expenses.
+                        <br>If there are any withdrawals still on <u>pending</u> you will not be able to close your account until the withdrawal is <u>closed</u>!
                     </p>
                 </div>
 


### PR DESCRIPTION
When users could not close their account due to 'pending' withdrawals they could not see this reason anywhere. Now I have clarified the message and added the status to the withdrawals so the user can actually figure out why they can not close their account.