### PR TITLE
Actually exclude all stars on mobile

### DIFF
--- a/resources/assets/js/nightMode.js
+++ b/resources/assets/js/nightMode.js
@@ -1,4 +1,6 @@
 window.nightMode = _ => {
+    if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) return;
+
     window.addEventListener('resize', (event) => {
         create()
     });
@@ -70,7 +72,6 @@ window.nightMode = _ => {
     create()
 
     function update() {
-        if (!/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
             ctx.clearRect(0, 0, canvas.width, canvas.height)
             stars.forEach((star, index) => {
                 star.update()
@@ -78,7 +79,6 @@ window.nightMode = _ => {
             })
             window.requestAnimationFrame(update);
         }
-    }
     window.requestAnimationFrame(update);
 }
 


### PR DESCRIPTION
now they do not only not update but do not run the whole js at all (you couldn't see the non updating mini stars really anyway on mobile)