### PR TITLE
Migrate dinnerform discount to double instead of an int

### DIFF
--- a/database/migrations/2022_10_03_160141_dinnerform_int_to_float.php
+++ b/database/migrations/2022_10_03_160141_dinnerform_int_to_float.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DinnerformIntToFloat extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('dinnerforms', function (Blueprint $table) {
+            $table->float('discount')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('dinnerforms', function (Blueprint $table) {
+            $table->integer('discount')->change();
+        });
+    }
+}


### PR DESCRIPTION
Fixes the casting of discount to an integer
Fixes #1703 