### PR TITLE
fixed events defaulting to public when saved and saved again

### DIFF
--- a/resources/views/event/edit_includes/event-details.blade.php
+++ b/resources/views/event/edit_includes/event-details.blade.php
@@ -63,10 +63,10 @@
 
                             <label for="secret">Event visibility:</label>
                             <select id="secret" name="secret" class="form-control" required>
-                                <option value="1" {{ (old('secret')==1||$event != null && $event->secret ? 'selected' : '') }}>
+                                <option value="1" {{ (old('secret')===1||$event != null && $event->secret ? 'selected' : '') }}>
                                     Secret
                                 </option>
-                                <option value="0" {{ (old('secret')==0||$event != null && !$event->secret ? 'selected' : '') }}>
+                                <option value="0" {{ (old('secret')===0||$event != null && !$event->secret ? 'selected' : '') }}>
                                     Public
                                 </option>
                             </select>


### PR DESCRIPTION
accidently making events public because you changed something and did not double check the visibility is not fun. Now fixed