### PR TITLE
Fix spelling mistake clientside

### DIFF
--- a/resources/views/omnomcom/withdrawals/userhistory.blade.php
+++ b/resources/views/omnomcom/withdrawals/userhistory.blade.php
@@ -2,7 +2,7 @@
 
 @section('page-title')
     Personal Overview for the {{ date('d-m-Y', strtotime($withdrawal->date)) }} Withdrawal
-    <br>Withdrawal status: {{$withdrawal->closed?'Closed':'Payed'}}
+    <br>Withdrawal status: {{$withdrawal->closed?'Closed':'Paid'}}
 @endsection
 
 @section('container')


### PR DESCRIPTION
Past tense of "pay" is "paid", not "payed"

This pull request only fixes this mistake for the client,
but this mistake is also present in the code and the database.
Fixing that requires a migration. 


