### PR TITLE
check if there are actually helpingcommittee instances

### DIFF
--- a/resources/views/event/display.blade.php
+++ b/resources/views/event/display.blade.php
@@ -47,7 +47,7 @@
 
             <div class="col-md-4">
                 <div class="card mb-3">
-                @if(count($event->activity->helpingCommitteeInstances) > 0 )
+                @if($event->activity->helpingCommitteeInstances && count($event->activity->helpingCommitteeInstances) > 0 )
                     @include('event.display_includes.helpers', [
                         'event' => $event
                     ])


### PR DESCRIPTION
fixes the sentry view exception where a dinneform is present but not a helpingcommittee instance