### PR TITLE
add a back to calendar button and show the publication time in the card for events

### DIFF
--- a/resources/views/event/display_includes/event_details.blade.php
+++ b/resources/views/event/display_includes/event_details.blade.php
@@ -6,6 +6,7 @@
     <div class="alert alert-warning" role="alert">
         This event is scheduled and not shown yet on the site.
         For now you can only access it directly via the URL.
+        It is scheduled for <i>{{Carbon::createFromTimestamp($event->publication)->format('l j F Y, H:i')}}</i>
     </div>
 @endif
 
@@ -26,6 +27,13 @@
     </div>
 
 @endif
+
+
+<div class="card mb-3">
+    <a href="{{ route("event::list", ['id'=>$event->id]) }}" class="btn btn-default">
+        Back to calendar
+    </a>
+</div>
 
 <div class="card mb-3">
 

--- a/resources/views/event/edit_includes/buttonbar.blade.php
+++ b/resources/views/event/edit_includes/buttonbar.blade.php
@@ -1,6 +1,6 @@
 @if($event)
     <button type="submit" class="btn btn-success float-end ms-2">
-        Update
+        Update event details
     </button>
     @include('website.layouts.macros.confirm-modal', [
         'action' => route("event::delete", ['id' => $event->id]),


### PR DESCRIPTION
show the publication time and add a back to calendar button on events, also clarify that the save button only saves the event details.