### PR TITLE
add back ability to search by event and small style changes

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -51,11 +51,11 @@ class EventController extends Controller
         $category = EventCategory::find($request->input('category'));
         foreach ($data as $index=>$query){
             if($category){
-                $data[$index]=$query->whereHas('Category', function ($q) use($category) {
+                $data[$index] = $query->whereHas('Category', function ($q) use ($category) {
                     $q->where('id', $category->id)->where('deleted_at', '=', null);
                 });
             }
-            $data[$index]=$query->get();
+            $data[$index] = $query->get();
         }
 
         $years = collect(DB::select('SELECT DISTINCT Year(FROM_UNIXTIME(start)) AS start FROM events ORDER BY Year(FROM_UNIXTIME(start))'))->pluck('start');

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -35,20 +35,29 @@ class EventController extends Controller
         $data[0] = Event::query()
             ->where('start', '>=',strtotime('now'))
             ->orderBy('start')->with('activity')
-            ->where('start', '<=', strtotime('+1 week'))
-            ->get();
+            ->where('start', '<=', strtotime('+1 week'));
+
         $data[1] = Event::query()
             ->where('start', '>=',strtotime('now'))
             ->orderBy('start')->with('activity')
             ->where('start', '>', strtotime('+1 week'))
-            ->where('start', '<=', strtotime('+1 month'))
-            ->get();
+            ->where('start', '<=', strtotime('+1 month'));
+
         $data[2] = Event::query()
             ->where('start', '>=',strtotime('now'))
             ->orderBy('start')->with('activity')
-            ->where('start', '>', strtotime('+1 month'))
-            ->get();
+            ->where('start', '>', strtotime('+1 month'));
+
         $category = EventCategory::find($request->input('category'));
+        foreach ($data as $index=>$query){
+            if($category){
+                $data[$index]=$query->whereHas('Category', function ($q) use($category) {
+                    $q->where('id', $category->id)->where('deleted_at', '=', null);
+                });
+            }
+            $data[$index]=$query->get();
+        }
+
         $years = collect(DB::select('SELECT DISTINCT Year(FROM_UNIXTIME(start)) AS start FROM events ORDER BY Year(FROM_UNIXTIME(start))'))->pluck('start');
 
         if (Auth::check()) {

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -55,8 +55,6 @@
             <strong>{{ $event->title }}</strong>
 
             @if($event->category)
-                <br>
-
                 <span class="badge rounded-pill bg-info px-3 mt-1 d-inline-block mw-100 ellipsis">
                     <i class="{{ $event->category->icon }} fa-fw" aria-hidden="true"></i>
                     {{ $event->category->name }}

--- a/resources/views/event/display_includes/event_details.blade.php
+++ b/resources/views/event/display_includes/event_details.blade.php
@@ -49,8 +49,8 @@
 
         @if($event->category)
             <li class="list-group-item">
-                <span><i class="fas fa-tag fa-fw"></i>Category:</span><br>
-                <span class="badge rounded-pill bg-info px-3 mt-2 d-inline-block mw-100 ellipsis">
+                <span><i class="fas fa-tag fa-fw"></i>Category:</span>
+                <span class="badge rounded-pill bg-info d-inline-block mw-100 ellipsis">
                     <i class="{{ $event->category->icon }} fa-fw" aria-hidden="true"></i>{{ $event->category->name }}
                 </span>
             </li>


### PR DESCRIPTION
By optimizing the calendar accidentally removed the capability to search by event in the current events overview, now fixed