### PR TITLE
Add a Withdrawal Seeder

### DIFF
--- a/database/migrations/2022_11_11_122455_add_provider_column_to_oauth_clients_table.php
+++ b/database/migrations/2022_11_11_122455_add_provider_column_to_oauth_clients_table.php
@@ -13,7 +13,7 @@ class AddProviderColumnToOauthClientsTable extends Migration
      */
     public function up()
     {
-        if(!Schema::hasColumn('oauth_clients', 'provider')) {
+        if(! Schema::hasColumn('oauth_clients', 'provider')) {
             Schema::table('oauth_clients', function (Blueprint $table) {
                 $table->string('provider')->after('secret')->nullable();
             });

--- a/database/seeders/OtherDataSeeder.php
+++ b/database/seeders/OtherDataSeeder.php
@@ -81,8 +81,8 @@ class OtherDataSeeder extends Seeder
         echo PHP_EOL."\e[32mCreated:\e[0m   ".$n.' orderlines '.'('.round(($time_end - $time_start), 2).'s)'.PHP_EOL;
 
         // Create withdrawals
-        $n = 1;
-        $orderlines_per_withdrawal = 4;
+        $n = 2;
+        $orderlines_per_withdrawal = 5;
         $max_withdrawal_amount = 100;
         $orderlines_associated = 0;
 
@@ -222,7 +222,7 @@ class OtherDataSeeder extends Seeder
 
             $totalPerUser[$orderline->user->id] += $orderline->total_price;
             $totalOrderlinesPerUser[$orderline->user->id] += 1;
-            
+
             echo "\e[32mCollecting:\e[0m  ".$totalOrderlinesAdded.' orderlines into withdrawal set '.$index."\r";
         }
 

--- a/database/seeders/OtherDataSeeder.php
+++ b/database/seeders/OtherDataSeeder.php
@@ -88,7 +88,7 @@ class OtherDataSeeder extends Seeder
 
         $time_start = microtime(true);
 
-        foreach (range(0,$n) as $index){
+        foreach (range(1,$n) as $index){
             $orderlines_associated += $this->seedWithdrawals($index, $max_withdrawal_amount,$orderlines_per_withdrawal);
         }
         $time_end = microtime(true);

--- a/database/seeders/OtherDataSeeder.php
+++ b/database/seeders/OtherDataSeeder.php
@@ -92,7 +92,7 @@ class OtherDataSeeder extends Seeder
             $orderlines_associated += $this->seedWithdrawals($index, $max_withdrawal_amount,$orderlines_per_withdrawal);
         }
         $time_end = microtime(true);
-        echo PHP_EOL."\e[32mAssociated:\e[0m  ".$orderlines_associated.' orderlines to '.$n.' rounds of withdrawals'.'('.round(($time_end - $time_start), 2).'s)'.PHP_EOL;
+        echo PHP_EOL."\e[32mAssociated:\e[0m".$orderlines_associated.' orderlines to '.$n.' rounds of withdrawals'.' ('.round(($time_end - $time_start), 2).'s)'.PHP_EOL;
 
         // Create AchievementOwnership
         $n = 200;
@@ -223,7 +223,7 @@ class OtherDataSeeder extends Seeder
             $totalPerUser[$orderline->user->id] += $orderline->total_price;
             $totalOrderlinesPerUser[$orderline->user->id] += 1;
 
-            echo "\e[32mCollecting:\e[0m  ".$totalOrderlinesAdded.' orderlines into withdrawal set '.$index."\r";
+            echo "\e[33mAdding:\e[0m    ".$totalOrderlinesAdded.' orderlines to withdrawals (round '.$index.")   \r";
         }
 
         // Prevent negative withdrawals
@@ -236,7 +236,7 @@ class OtherDataSeeder extends Seeder
                     $orderline->save();
 
                     $totalOrderlinesAdded--;
-                    echo "\e[33mReducing:\e[0m  The amount of orderlines in withdrawal round ".$index.'to'.$totalOrderlinesAdded." orderlines \r";
+                    echo "\e[33mReducing:\e[0mThe amount of orderlines in withdrawal round ".$index.'to'.$totalOrderlinesAdded." orderlines   \r";
                 }
             }
         }


### PR DESCRIPTION
**Adds a seeding mechanism for withdrawals in the OtherDataSeeder**
This lets the developers look for mistakes in styling, layout etc.,
without having to seed the withdrawals manually. 

*Note: This seeder does not seed for the local admin user*