### PR TITLE
WIP: Fixed withdrawals for users without bank information

### DIFF
--- a/app/Http/Controllers/WithdrawalController.php
+++ b/app/Http/Controllers/WithdrawalController.php
@@ -322,7 +322,7 @@ class WithdrawalController extends Controller
         }
 
         foreach ($withdrawal->users() as $user) {
-            if (!isset($user->bank)) {
+            if (! isset($user->bank)) {
                 Session::flash('flash_message', 'Cannot export! A user in this withdrawal is missing bank information.');
                 return Redirect::back();
             }

--- a/app/Models/OrderLine.php
+++ b/app/Models/OrderLine.php
@@ -122,7 +122,7 @@ class OrderLine extends Model
     public function generateHistoryStatus()
     {
         if ($this->payed_with_loss) {
-            return "Loss";
+            return 'Loss';
         } elseif ($this->payed_with_withdrawal !== null) {
             return "Withdrawal <a href='".
                 route('omnomcom::mywithdrawal', ['id' => $this->payed_with_withdrawal]).

--- a/app/Models/OrderLine.php
+++ b/app/Models/OrderLine.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property string|null $payed_with_bank_card
  * @property int|null $payed_with_mollie
  * @property int|null $payed_with_withdrawal
+ * @property bool $payed_with_loss
  * @property string|null $description
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -95,14 +96,16 @@ class OrderLine extends Model
         return $this->hasOne('Proto\Models\TicketPurchase', 'orderline_id');
     }
 
-   /** @return bool */
-   public function isPayed()
-   {
+    /** @return bool */
+    public function isPayed()
+    {
        $mollie_payment = false;
        if ($this->payed_with_mollie !== null) {
            $mollie_payment = $this->molliePayment->translatedStatus();
        }
-       return $this->total_price == 0 ||
+       return
+           $this->total_price == 0 ||
+           $this->payed_with_loss ||
            $this->payed_with_cash !== null ||
            $this->payed_with_withdrawal !== null ||
            $mollie_payment == 'paid' ||
@@ -115,50 +118,52 @@ class OrderLine extends Model
         return $this->total_price == 0 || ! $this->isPayed();
     }
 
-     /** @return string */
-     public function generateHistoryStatus()
-     {
-         if ($this->payed_with_withdrawal !== null) {
-             return "Withdrawal <a href='".
-                 route('omnomcom::mywithdrawal', ['id' => $this->payed_with_withdrawal]).
-                 "'>#".
-                 $this->payed_with_withdrawal.
-                 '</a>';
-         } elseif ($this->payed_with_cash !== null) {
-             return 'Cash';
-         } elseif ($this->payed_with_bank_card !== null) {
-             return 'Bank Card';
-         } elseif ($this->payed_with_mollie !== null) {
-             switch ($this->molliePayment->translatedStatus()) {
-                 case 'paid':
-                     return '<i class="fas fa-check ml-2 text-success"></i>'." - <a href='".
-                         route('omnomcom::mollie::status', ['id' => $this->payed_with_mollie]).
-                         "'>#".
-                         $this->payed_with_mollie.
-                         '</a>';
-                 case 'failed':
-                     return '<i class="fas fa-times ml-2 text-danger"></i>'." - <a href='".
-                         route('omnomcom::mollie::status', ['id' => $this->payed_with_mollie]).
-                         "'>#".
-                         $this->payed_with_mollie.
-                         '</a>';
-                 case 'open':
-                     return '<i class="fas fa-spinner ml-2 text-normal"></i>'." - <a href='".
-                         route('omnomcom::mollie::status', ['id' => $this->payed_with_mollie]).
-                         "'>#".
-                         $this->payed_with_mollie.
-                         '</a>';
-                 default:
-                     return '<i class="fas fa-question ml-2 text-normal"></i>'." - <a href='".
-                         route('omnomcom::mollie::status', ['id' => $this->payed_with_mollie]).
-                         "'>#".
-                         $this->payed_with_mollie.
-                         '</a>';
-             }
-         } elseif ($this->total_price == 0) {
-             return 'Free!';
-         } else {
-             return 'Unpaid';
-         }
-     }
- }
+    /** @return string */
+    public function generateHistoryStatus()
+    {
+        if ($this->payed_with_loss) {
+            return "Loss";
+        } elseif ($this->payed_with_withdrawal !== null) {
+            return "Withdrawal <a href='".
+                route('omnomcom::mywithdrawal', ['id' => $this->payed_with_withdrawal]).
+                "'>#".
+                $this->payed_with_withdrawal.
+                '</a>';
+        } elseif ($this->payed_with_cash !== null) {
+            return 'Cash';
+        } elseif ($this->payed_with_bank_card !== null) {
+            return 'Bank Card';
+        } elseif ($this->payed_with_mollie !== null) {
+            switch ($this->molliePayment->translatedStatus()) {
+                case 'paid':
+                    return '<i class="fas fa-check ml-2 text-success"></i>'." - <a href='".
+                        route('omnomcom::mollie::status', ['id' => $this->payed_with_mollie]).
+                        "'>#".
+                        $this->payed_with_mollie.
+                        '</a>';
+                case 'failed':
+                    return '<i class="fas fa-times ml-2 text-danger"></i>'." - <a href='".
+                        route('omnomcom::mollie::status', ['id' => $this->payed_with_mollie]).
+                        "'>#".
+                        $this->payed_with_mollie.
+                        '</a>';
+                case 'open':
+                    return '<i class="fas fa-spinner ml-2 text-normal"></i>'." - <a href='".
+                        route('omnomcom::mollie::status', ['id' => $this->payed_with_mollie]).
+                        "'>#".
+                        $this->payed_with_mollie.
+                        '</a>';
+                default:
+                    return '<i class="fas fa-question ml-2 text-normal"></i>'." - <a href='".
+                        route('omnomcom::mollie::status', ['id' => $this->payed_with_mollie]).
+                        "'>#".
+                        $this->payed_with_mollie.
+                        '</a>';
+            }
+        } elseif ($this->total_price == 0) {
+            return 'Free!';
+        } else {
+            return 'Unpaid';
+        }
+    }
+}

--- a/database/migrations/2022_11_13_161109_add_payed_with_loss_to_orderlines.php
+++ b/database/migrations/2022_11_13_161109_add_payed_with_loss_to_orderlines.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPayedWithLossToOrderlines extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('orderlines', function (Blueprint $table) {
+            $table->boolean('payed_with_loss')->after('payed_with_withdrawal');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('orderlines', function (Blueprint $table) {
+            $table->dropColumn('payed_with_loss');
+        });
+    }
+}

--- a/resources/views/omnomcom/withdrawals/show.blade.php
+++ b/resources/views/omnomcom/withdrawals/show.blade.php
@@ -10,6 +10,11 @@
 
         <div class="col-md-3">
 
+            <a href="{{ route('omnomcom::withdrawal::list') }}" class="btn btn-block btn-dark mb-2">
+                <i class="fas fa-back"></i>
+                Return to overview
+            </a>
+
             <form method="post" action="{{ route('omnomcom::withdrawal::edit', ['id' => $withdrawal->id]) }}">
 
                 {!! csrf_field() !!}
@@ -52,44 +57,47 @@
                             'name' => 'date',
                             'label' => 'Change date:',
                             'placeholder' => strtotime($withdrawal->date),
-                            'format' => 'date'
+                            'format' => 'date',
                         ])
+                        <input type="submit" value="Save" class="btn btn-success btn-block mt-2">
                     </div>
 
                     <div class="card-footer">
 
-                        <input type="submit" value="Save" class="btn btn-success btn-block mb-4">
-
                         <a href="{{ route('omnomcom::withdrawal::export', ['id' => $withdrawal->id]) }}"
-                           class="btn btn-outline-success btn-block mb-2">
+                           class="btn btn-outline-success btn-block">
                             Generate XML
                         </a>
 
-                        @include('website.layouts.macros.confirm-modal', [
-                           'action' => route('omnomcom::withdrawal::email', ['id' => $withdrawal->id]),
-                           'classes' => 'btn btn-outline-warning btn-block mb-2',
-                           'text' => 'E-mail Users',
-                           'title' => 'Confirm Send',
-                           'message' => 'Are you sure you want to send an email to all '.$withdrawal->users()->count().' users associated with this withdrawal?',
-                           'confirm' => 'Send',
-                        ])
+                        @if(! $withdrawal->closed)
 
-                        @include('website.layouts.macros.confirm-modal', [
-                           'action' => route('omnomcom::withdrawal::close', ['id' => $withdrawal->id]),
-                           'classes' => 'btn btn-outline-danger btn-block mb-2',
-                           'text' => 'Close Withdrawal',
-                           'title' => 'Confirm Close',
-                           'message' => 'Are you sure you want to close this withdrawal? After closing, you cannot change anything about this withdrawal anymore.',
-                           'confirm' => 'Close',
-                        ])
+                            @include('website.layouts.macros.confirm-modal', [
+                               'action' => route('omnomcom::withdrawal::email', ['id' => $withdrawal->id]),
+                               'classes' => 'btn btn-outline-warning btn-block mt-2',
+                               'text' => 'E-mail Users',
+                               'title' => 'Confirm Send',
+                               'message' => 'Are you sure you want to send an email to all '.$withdrawal->users()->count().' users associated with this withdrawal?',
+                               'confirm' => 'Send',
+                            ])
 
-                        @include('website.layouts.macros.confirm-modal', [
-                           'action' => route('omnomcom::withdrawal::delete', ['id' => $withdrawal->id]),
-                           'classes' => 'btn btn-outline-danger btn-block mb-2',
-                           'text' => 'Delete',
-                           'title' => 'Confirm Delete',
-                           'message' => 'Are you sure you want to delete this withdrawal?',
-                        ])
+                            @include('website.layouts.macros.confirm-modal', [
+                               'action' => route('omnomcom::withdrawal::close', ['id' => $withdrawal->id]),
+                               'classes' => 'btn btn-outline-danger btn-block mt-2',
+                               'text' => 'Close Withdrawal',
+                               'title' => 'Confirm Close',
+                               'message' => 'Are you sure you want to close this withdrawal? After closing, you cannot change anything about this withdrawal anymore.',
+                               'confirm' => 'Close',
+                            ])
+
+                            @include('website.layouts.macros.confirm-modal', [
+                               'action' => route('omnomcom::withdrawal::delete', ['id' => $withdrawal->id]),
+                               'classes' => 'btn btn-outline-danger btn-block mt-2',
+                               'text' => 'Delete',
+                               'title' => 'Confirm Delete',
+                               'message' => 'Are you sure you want to delete this withdrawal?',
+                            ])
+
+                        @endif
 
                     </div>
 
@@ -127,17 +135,17 @@
 
                         @foreach($withdrawal->totalsPerUser() as $data)
 
-                            <tr class="{{ !isset($data->user->bank) ? 'bg-warning text-white' : '' }}">
+                            <tr>
                                 <td>{{ $data->user->name }}</td>
-                                @if(!$withdrawal->closed)
+                                @if(! $withdrawal->closed)
                                     @isset($data->user->bank)
                                         <td>
-                                            <strong>{{ $data->user->bank->iban }}</strong>
-                                            / {{ $data->user->bank->bic }}
+                                            {{ $data->user->bank->iban }}
+                                            <span class="text-muted">/ {{ $data->user->bank->bic }}</span>
                                         </td>
                                         <td>{{ $data->user->bank->machtigingid }}</td>
                                     @else
-                                        <td>
+                                        <td class="text-warning">
                                             <i class="fa fas fa-exclamation-triangle"></i>
                                             <strong>No bank account!</strong>
                                         </td>
@@ -162,13 +170,23 @@
                                                 Remove
                                             </a>
 
-                                            or
+                                            |
 
                                             @include('website.layouts.macros.confirm-modal', [
                                                'action' => route('omnomcom::withdrawal::markfailed', ['id' => $withdrawal->id, 'user_id' => $data->user->id]),
-                                               'text' => 'Mark Failed',
+                                               'text' => 'Failed',
                                                'title' => 'Confirm Marking Failed',
-                                               'message' => 'Are you sure you want to mark this withdrawal as for '.$data->user->name.' as failed? They <b>will</b> automatically receive an e-mail about this!',
+                                               'message' => 'Are you sure you want to mark this withdrawal for '.$data->user->name.' as failed? They <b>will</b> automatically receive an e-mail about this!',
+                                               'classes' => 'text-white fw-bold underline-on-hover'
+                                            ])
+
+                                            |
+
+                                            @include('website.layouts.macros.confirm-modal', [
+                                               'action' => route('omnomcom::withdrawal::markloss', ['id' => $withdrawal->id, 'user_id' => $data->user->id]),
+                                               'text' => 'Loss',
+                                               'title' => 'Confirm Marking Loss',
+                                               'message' => 'Are you sure you want to mark this withdrawal for '.$data->user->name.' as a loss? <b>This cannot easily be undone!</b>',
                                                'classes' => 'text-white fw-bold underline-on-hover'
                                             ])
                                         @endif

--- a/resources/views/omnomcom/withdrawals/show.blade.php
+++ b/resources/views/omnomcom/withdrawals/show.blade.php
@@ -58,16 +58,16 @@
 
                     <div class="card-footer">
 
-                        <input type="submit" value="Save" class="btn btn-success btn-block">
+                        <input type="submit" value="Save" class="btn btn-success btn-block mb-4">
 
                         <a href="{{ route('omnomcom::withdrawal::export', ['id' => $withdrawal->id]) }}"
-                           class="btn btn-outline-success btn-block">
+                           class="btn btn-outline-success btn-block mb-2">
                             Generate XML
                         </a>
 
                         @include('website.layouts.macros.confirm-modal', [
                            'action' => route('omnomcom::withdrawal::email', ['id' => $withdrawal->id]),
-                           'classes' => 'btn btn-outline-warning btn-block',
+                           'classes' => 'btn btn-outline-warning btn-block mb-2',
                            'text' => 'E-mail Users',
                            'title' => 'Confirm Send',
                            'message' => 'Are you sure you want to send an email to all '.$withdrawal->users()->count().' users associated with this withdrawal?',
@@ -76,7 +76,7 @@
 
                         @include('website.layouts.macros.confirm-modal', [
                            'action' => route('omnomcom::withdrawal::close', ['id' => $withdrawal->id]),
-                           'classes' => 'btn btn-outline-danger btn-block',
+                           'classes' => 'btn btn-outline-danger btn-block mb-2',
                            'text' => 'Close Withdrawal',
                            'title' => 'Confirm Close',
                            'message' => 'Are you sure you want to close this withdrawal? After closing, you cannot change anything about this withdrawal anymore.',
@@ -85,7 +85,7 @@
 
                         @include('website.layouts.macros.confirm-modal', [
                            'action' => route('omnomcom::withdrawal::delete', ['id' => $withdrawal->id]),
-                           'classes' => 'btn btn-outline-danger btn-block',
+                           'classes' => 'btn btn-outline-danger btn-block mb-2',
                            'text' => 'Delete',
                            'title' => 'Confirm Delete',
                            'message' => 'Are you sure you want to delete this withdrawal?',
@@ -127,7 +127,7 @@
 
                         @foreach($withdrawal->totalsPerUser() as $data)
 
-                            <tr class="{{ !isset($data->user->bank) ? 'bg-warning' : '' }}">
+                            <tr class="{{ !isset($data->user->bank) ? 'bg-warning text-white' : '' }}">
                                 <td>{{ $data->user->name }}</td>
                                 @if(!$withdrawal->closed)
                                     @isset($data->user->bank)
@@ -139,7 +139,7 @@
                                     @else
                                         <td>
                                             <i class="fa fas fa-exclamation-triangle"></i>
-                                            <strong>This user no longer exists</strong>
+                                            <strong>No bank account!</strong>
                                         </td>
                                         <td></td>
                                     @endisset
@@ -158,7 +158,7 @@
                                                'confirm' => 'Revert',
                                             ])
                                         @else
-                                            <a href="{{ route('omnomcom::withdrawal::deleteuser', ['id' => $withdrawal->id, 'user_id' => $data->user->id]) }}">
+                                            <a href="{{ route('omnomcom::withdrawal::deleteuser', ['id' => $withdrawal->id, 'user_id' => $data->user->id]) }}" class="text-white fw-bold underline-on-hover">
                                                 Remove
                                             </a>
 
@@ -169,6 +169,7 @@
                                                'text' => 'Mark Failed',
                                                'title' => 'Confirm Marking Failed',
                                                'message' => 'Are you sure you want to mark this withdrawal as for '.$data->user->name.' as failed? They <b>will</b> automatically receive an e-mail about this!',
+                                               'classes' => 'text-white fw-bold underline-on-hover'
                                             ])
                                         @endif
                                     </td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -593,6 +593,7 @@ Route::group(['middleware' => ['forcedomain']], function () {
 
             Route::get('deletefrom/{id}/{user_id}', ['as' => 'deleteuser', 'uses' => 'WithdrawalController@deleteFrom']);
             Route::get('markfailed/{id}/{user_id}', ['as' => 'markfailed', 'uses' => 'WithdrawalController@markFailed']);
+            Route::get('markloss/{id}/{user_id}', ['as' => 'markloss', 'uses' => 'WithdrawalController@markLoss']);
         });
 
         Route::get('unwithdrawable', ['middleware' => ['permission:finadmin'], 'as' => 'unwithdrawable', 'uses' => 'WithdrawalController@unwithdrawable']);


### PR DESCRIPTION
Now showing orderlines of users without bank information (in case a whoopsy has happened) and added ability to mark a user's withdrawal as loss. Fixes #1772.

_Yes, I know the new DB column is misspelled but I prefer consistency._