### PR TITLE
Feature/copy event with signup details

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
 use Proto\Http\Requests\StoreEventRequest;
 use Proto\Models\Account;
@@ -19,7 +20,6 @@ use Proto\Models\PhotoAlbum;
 use Proto\Models\Product;
 use Proto\Models\StorageEntry;
 use Proto\Models\User;
-use Redirect;
 use Response;
 use Session;
 
@@ -667,5 +667,19 @@ class EventController extends Controller
 
         Session::flash('flash_message', 'The category '.$category->name.' has been deleted.');
         return Redirect::route('event::category::admin', ['category' => null]);
+    }
+
+    public function copyEvent($id){
+        $event = Event::findOrFail($id);
+        $newEvent = $event->replicate();
+        $newEvent->title=$newEvent->title." [copy]";
+        $newEvent->save();
+
+        if($event->activity) {
+            $newActivity = $event->activity->replicate();
+            $newActivity->event_id=$newEvent->id;
+            $newActivity->save();
+        }
+        return view('event.edit', ['event' => $newEvent]);
     }
 }

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -3,6 +3,7 @@
 namespace Proto\Http\Controllers;
 
 use Auth;
+use Carbon\Carbon;
 use Exception;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\RedirectResponse;
@@ -669,17 +670,38 @@ class EventController extends Controller
         return Redirect::route('event::category::admin', ['category' => null]);
     }
 
-    public function copyEvent($id){
-        $event = Event::findOrFail($id);
+    public function copyEvent(Request $request){
+        $event = Event::findOrFail($request->id);
         $newEvent = $event->replicate();
         $newEvent->title=$newEvent->title." [copy]";
+
+        $oldStart=Carbon::createFromTimestamp($event->start);
+        $newDate=Carbon::createFromFormat('Y-m-d',$request->input('newDate'));
+        $newDate=$newDate->setHour($oldStart->hour)->setMinute($oldStart->minute)->setSecond($oldStart->second)->timestamp;
+        $diff=$newDate-$event->start;
+
+        $newEvent->start=$newDate;
+        $newEvent->end=$event->end + $diff;
+        $newEvent->secret=true;
+        if($event->publication){
+            $newEvent->publication=$event->publication + $diff;
+            $newEvent->secret=false;
+        }
+
         $newEvent->save();
 
         if($event->activity) {
             $newActivity = $event->activity->replicate();
             $newActivity->event_id=$newEvent->id;
+
+            $newActivity->registration_start=$event->activity->registration_start+$diff;
+            $newActivity->registration_end=$event->activity->registration_end+$diff;
+            $newActivity->deregistration_end=$event->activity->deregistration_end+$diff;
+
             $newActivity->save();
         }
+
+        Session::flash('flash_message', "Copied the event!");
         return view('event.edit', ['event' => $newEvent]);
     }
 }

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -670,38 +670,38 @@ class EventController extends Controller
         return Redirect::route('event::category::admin', ['category' => null]);
     }
 
-    public function copyEvent(Request $request){
+    public function copyEvent(Request $request) {
         $event = Event::findOrFail($request->id);
         $newEvent = $event->replicate();
-        $newEvent->title=$newEvent->title." [copy]";
+        $newEvent->title = $newEvent->title.' [copy]';
 
-        $oldStart=Carbon::createFromTimestamp($event->start);
-        $newDate=Carbon::createFromFormat('Y-m-d',$request->input('newDate'));
-        $newDate=$newDate->setHour($oldStart->hour)->setMinute($oldStart->minute)->setSecond($oldStart->second)->timestamp;
-        $diff=$newDate-$event->start;
+        $oldStart = Carbon::createFromTimestamp($event->start);
+        $newDate = Carbon::createFromFormat('Y-m-d',$request->input('newDate'));
+        $newDate = $newDate->setHour($oldStart->hour)->setMinute($oldStart->minute)->setSecond($oldStart->second)->timestamp;
+        $diff = $newDate - $event->start;
 
-        $newEvent->start=$newDate;
-        $newEvent->end=$event->end + $diff;
-        $newEvent->secret=true;
+        $newEvent->start = $newDate;
+        $newEvent->end = $event->end + $diff;
+        $newEvent->secret = true;
         if($event->publication){
-            $newEvent->publication=$event->publication + $diff;
-            $newEvent->secret=false;
+            $newEvent->publication = $event->publication + $diff;
+            $newEvent->secret = false;
         }
 
         $newEvent->save();
 
         if($event->activity) {
             $newActivity = $event->activity->replicate();
-            $newActivity->event_id=$newEvent->id;
+            $newActivity->event_id = $newEvent->id;
 
-            $newActivity->registration_start=$event->activity->registration_start+$diff;
-            $newActivity->registration_end=$event->activity->registration_end+$diff;
-            $newActivity->deregistration_end=$event->activity->deregistration_end+$diff;
+            $newActivity->registration_start = $event->activity->registration_start + $diff;
+            $newActivity->registration_end = $event->activity->registration_end + $diff;
+            $newActivity->deregistration_end = $event->activity->deregistration_end + $diff;
 
             $newActivity->save();
         }
 
-        Session::flash('flash_message', "Copied the event!");
+        Session::flash('flash_message', 'Copied the event!');
         return view('event.edit', ['event' => $newEvent]);
     }
 }

--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -15,6 +15,7 @@
         </div>
 
         <div class="col-md-4">
+            @include('event.edit_includes.copy')
 
             @include('event.edit_includes.activity')
 

--- a/resources/views/event/edit_includes/buttonbar.blade.php
+++ b/resources/views/event/edit_includes/buttonbar.blade.php
@@ -1,9 +1,5 @@
 @if($event)
 
-    <a href="{{ route('event::copy', ['id' => $event->id]) }}" class="btn btn-default btn-warning float-end ms-2">
-        Copy
-    </a>
-
     <button type="submit" class="btn btn-success float-end ms-2">
         Update event details
     </button>

--- a/resources/views/event/edit_includes/buttonbar.blade.php
+++ b/resources/views/event/edit_includes/buttonbar.blade.php
@@ -1,20 +1,29 @@
 @if($event)
+
+    <a href="{{ route('event::copy', ['id' => $event->id]) }}" class="btn btn-default btn-warning float-end ms-2">
+        Copy
+    </a>
+
     <button type="submit" class="btn btn-success float-end ms-2">
         Update event details
     </button>
+
     @include('website.layouts.macros.confirm-modal', [
         'action' => route("event::delete", ['id' => $event->id]),
         'classes' => 'btn btn-danger float-end ms-2',
         'text' => 'Delete',
         'message' => 'Are you sure you want to delete this event?',
     ])
+
     <a href="{{ route('event::show', ['id' => $event->getPublicId()]) }}" class="btn btn-default float-end">
         Back to event
     </a>
+
 @else
     <button type="submit" class="btn btn-success float-end ms-2">
         Create
     </button>
+
     <a href="{{ route('event::list') }}" class="btn btn-default float-end">
         Back to calendar
     </a>

--- a/resources/views/event/edit_includes/copy.blade.php
+++ b/resources/views/event/edit_includes/copy.blade.php
@@ -1,0 +1,34 @@
+@if($event)
+
+    <div class="card mb-3">
+
+        <div class="card-header bg-dark text-white">
+            Copy event<i class="fas fa-info-circle ms-1" data-bs-toggle="tooltip" data-bs-placement="right" title="The event and its signup will be copied starting at the specified date, all the other dates will be moved relatively to the start date!"></i>
+        </div>
+
+        <form method="post" action="{{ route('event::copy', ['id'=> $event->id]) }}">
+
+            {!! csrf_field() !!}
+
+            <div class="card-body">
+
+                @include('website.layouts.macros.datetimepicker', [
+                                'name' => 'newDate',
+                                'label' => 'This will copy the event and move the start to:',
+                                'placeholder' => Carbon::createFromTimestamp($event->start)->addWeek()->timestamp,
+                                'format'=>'date',
+                            ])
+            </div>
+
+
+                <div class="card-footer">
+
+                    <input type="submit" class="btn btn-success btn-block" value="{{$event->activity ? "Copy the event and signup!" : "Copy the event!"}}">
+
+                </div>
+
+        </form>
+
+    </div>
+
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -372,7 +372,7 @@ Route::group(['middleware' => ['forcedomain']], function () {
         // Show event
         Route::get('{id}', ['as' => 'show', 'uses' => 'EventController@show']);
 
-        Route::get('copy/{id}', ['as' => 'copy', 'uses' => 'EventController@copyEvent']);
+        Route::post('copy', ['as' => 'copy', 'uses' => 'EventController@copyEvent']);
 
         // Force login for event
         Route::get('{id}/login', ['as' => 'login', 'middleware' => ['auth'], 'uses' => 'EventController@forceLogin']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -372,6 +372,8 @@ Route::group(['middleware' => ['forcedomain']], function () {
         // Show event
         Route::get('{id}', ['as' => 'show', 'uses' => 'EventController@show']);
 
+        Route::get('copy/{id}', ['as' => 'copy', 'uses' => 'EventController@copyEvent']);
+
         // Force login for event
         Route::get('{id}/login', ['as' => 'login', 'middleware' => ['auth'], 'uses' => 'EventController@forceLogin']);
     });


### PR DESCRIPTION
Adds the ability to make a copy of an event, and set the start date to a specified date. 
The copy automatically copies the event registration as well and moves all dates relative to the start date.
This means that if the signup date is a week in advance and you copy the event to a week later the new signup date will still be a week in advance relative to the new start date. Illuminates the need for a more complicated event templating system.
