### PR TITLE
removed the double import of redirect in the protube controller

### DIFF
--- a/app/Http/Controllers/ProtubeController.php
+++ b/app/Http/Controllers/ProtubeController.php
@@ -12,7 +12,6 @@ use Illuminate\View\View;
 use Proto\Models\PlayedVideo;
 use Proto\Models\SoundboardSound;
 use Proto\Models\User;
-use Redirect;
 use Session;
 
 class ProtubeController extends Controller


### PR DESCRIPTION
fixes: "Symfony\Component\ErrorHandler\Error\FatalError
Cannot use Redirect as Redirect because the name is already in use"
