### PR TITLE
Fix $event->activities being null when there is a dinnerform but not a helpingcommiteeinstance in the event view

### DIFF
--- a/resources/views/event/display.blade.php
+++ b/resources/views/event/display.blade.php
@@ -47,7 +47,7 @@
 
             <div class="col-md-4">
                 <div class="card mb-3">
-                @if($event->activity->helpingCommitteeInstances && count($event->activity->helpingCommitteeInstances) > 0 )
+                @if($event->activity && $event->activity->helpingCommitteeInstances && count($event->activity->helpingCommitteeInstances) > 0 )
                     @include('event.display_includes.helpers', [
                         'event' => $event
                     ])


### PR DESCRIPTION
Trying to get property 'helpingCommitteeInstances' of non-object in the view when there is a dinnerform.
Fixes the sentry issue.