### PR TITLE
Feature/random public photo api endpoint

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -3,12 +3,14 @@
 namespace Proto\Http\Controllers;
 
 use Auth;
+use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Proto\Models\AchievementOwnership;
 use Proto\Models\ActivityParticipation;
 use Proto\Models\EmailListSubscription;
 use Proto\Models\OrderLine;
+use Proto\Models\Photo;
 use Proto\Models\PhotoLikes;
 use Proto\Models\PlayedVideo;
 use Proto\Models\Quote;
@@ -116,6 +118,22 @@ class ApiController extends Controller
         } else {
             return response()->json($response);
         }
+    }
+
+    public function randomPhoto(){
+        $photo= Photo::where('private', false)->whereHas('album', function ($query) {
+            $query->where('published', true)->where('private', false);
+        })->inRandomOrder()->with('album')->first();
+
+        if(!$photo){
+            return response()->json(['error' => 'No public photos found!.'], 404);
+        }
+
+        return response()->JSON([
+            'url'=>$photo->url,
+            'album_name'=>$photo->album->name,
+            'date_taken'=>Carbon::createFromTimestamp($photo->date_taken)->format('d-m-Y'),
+        ]);
     }
 
     /** @return void */

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -120,12 +120,12 @@ class ApiController extends Controller
         }
     }
 
-    public function randomPhoto(){
-        $photo= Photo::where('private', false)->whereHas('album', function ($query) {
+    public function randomPhoto() {
+        $photo = Photo::where('private', false)->whereHas('album', function ($query) {
             $query->where('published', true)->where('private', false);
         })->inRandomOrder()->with('album')->first();
 
-        if(!$photo){
+        if(! $photo){
             return response()->json(['error' => 'No public photos found!.'], 404);
         }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -53,6 +53,7 @@ Route::group(['middleware' => ['forcedomain'], 'as' => 'api::'], function () {
             Route::get('photos_api', ['as' => 'albums', 'uses' => 'PhotoController@apiIndex']);
             Route::get('photos_api/{id?}', ['as' => 'albumList', 'uses' => 'PhotoController@apiShow']);
         });
+        Route::get('random_photo', ['as' => 'randomPhoto', 'uses' => 'ApiController@randomPhoto']);
         Route::group(['middleware' => ['web']], function () {
             Route::get('photos', ['as' => 'albums', 'uses' => 'PhotoController@apiIndex']);
             Route::get('photos/{id?}', ['as' => 'albumList', 'uses' => 'PhotoController@apiShow']);


### PR DESCRIPTION
Made an endpoint where you fetch a JSON object with the URL to a random public photo, the date it is taken and the album name it belongs to.
Necessary to implement the feature on ProTube where we will show a random public photo when the queue is empty. See https://github.com/saproto/ProTube/pull/73 for the feature.