### PR TITLE
added a button to the photo admin in the album overview

### DIFF
--- a/resources/views/photos/list.blade.php
+++ b/resources/views/photos/list.blade.php
@@ -7,7 +7,11 @@
 @section('container')
 
     <div class="card mb-3">
-
+        @can('protography')
+            <a href="{{route("photo::admin::index")}}" class="btn btn-info">
+                <i class="fas fa-edit"></i> <span class="d-none d-sm-inline">Photo admin</span>
+            </a>
+        @endcan
         <div class="card-body">
 
             <div class="row">


### PR DESCRIPTION
It really annoys me having to look through all the menu items to find the photo admin when I am on the albums page. Now there just appears a button when protography.