### PR TITLE
Make validation rule so users can not have an utwente email adress

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -125,7 +125,7 @@ class AuthController extends Controller
 
         Session::flash('register_persist', $request->all());
         $this->validate($request, [
-            'email' => ['required','unique:users','email', new NotUtwenteEmail],
+            'email' => ['required', 'unique:users', 'email', new NotUtwenteEmail()],
             'name' => 'required|string',
             'calling_name' => 'required|string',
             'g-recaptcha-response' => 'required|recaptcha',

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -28,6 +28,7 @@ use Proto\Models\PasswordReset;
 use Proto\Models\RfidCard;
 use Proto\Models\User;
 use Proto\Models\WelcomeMessage;
+use Proto\Rules\NotUtwenteEmail;
 use Redirect;
 use Session;
 
@@ -124,7 +125,7 @@ class AuthController extends Controller
 
         Session::flash('register_persist', $request->all());
         $this->validate($request, [
-            'email' => 'required|email|unique:users',
+            'email' => ['required','unique:users','email', new NotUtwenteEmail],
             'name' => 'required|string',
             'calling_name' => 'required|string',
             'g-recaptcha-response' => 'required|recaptcha',

--- a/app/Http/Controllers/UserDashboardController.php
+++ b/app/Http/Controllers/UserDashboardController.php
@@ -62,7 +62,7 @@ class UserDashboardController extends Controller
 
         if ($new_email !== $user->email) {
             $validator = Validator::make($request->only(['email']), [
-                'email' => ['required','unique:users','email:rfc', new NotUtwenteEmail],
+                'email' => ['required', 'unique:users', 'email:rfc', new NotUtwenteEmail()],
             ]);
             if ($validator->fails()) {
                 return Redirect::route('user::dashboard')->withErrors($validator);

--- a/app/Http/Controllers/UserDashboardController.php
+++ b/app/Http/Controllers/UserDashboardController.php
@@ -16,6 +16,7 @@ use Proto\Mail\UserMailChange;
 use Proto\Models\Member;
 use Proto\Models\StorageEntry;
 use Proto\Models\User;
+use Proto\Rules\NotUtwenteEmail;
 use Redirect;
 use Session;
 use Validator;
@@ -61,7 +62,7 @@ class UserDashboardController extends Controller
 
         if ($new_email !== $user->email) {
             $validator = Validator::make($request->only(['email']), [
-                'email' => 'required|email|unique:users',
+                'email' => ['required','unique:users','email:rfc', new NotUtwenteEmail],
             ]);
             if ($validator->fails()) {
                 return Redirect::route('user::dashboard')->withErrors($validator);

--- a/app/Rules/NotUtwenteEmail.php
+++ b/app/Rules/NotUtwenteEmail.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Proto\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class NotUtwenteEmail implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        $domainPart = explode('@', $value)[1] ?? null;
+
+        if (!$domainPart) {
+            return false;
+        }
+
+        if (str_contains(strtolower($domainPart), 'utwente')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The :attribute may not be a utwente email-address';
+    }
+}

--- a/app/Rules/NotUtwenteEmail.php
+++ b/app/Rules/NotUtwenteEmail.php
@@ -27,7 +27,7 @@ class NotUtwenteEmail implements Rule
     {
         $domainPart = explode('@', $value)[1] ?? null;
 
-        if (!$domainPart) {
+        if (! $domainPart) {
             return false;
         }
 

--- a/resources/views/users/dashboard/includes/account.blade.php
+++ b/resources/views/users/dashboard/includes/account.blade.php
@@ -13,6 +13,7 @@
             <p>
                 Here you can change your e-mail address. You'll receive an e-mail on both the old and new address for
                 confirmation. You need your password to change your e-mail address.
+                <br><i>Note: For practical reasons you cannot set your e-mail address to an ".utwente.nl" account.</i>
             </p>
 
             <table class="table table-borderless table-sm mb-0">

--- a/resources/views/users/register.blade.php
+++ b/resources/views/users/register.blade.php
@@ -45,6 +45,7 @@
         <p>
             Your e-mail address will also be your username. Please enter a valid e-mail address as your password will be
             sent to this e-mail address.
+            <br><i>Note: For practical reasons you cannot set your e-mail address to an ".utwente.nl" account.</i>
         </p>
 
         <hr>


### PR DESCRIPTION
This is necessary because it happens too often that people stop studying here and our email rejects.
Note: this does not fix the issue when creating an account with your utwente account. When we fix that (#1817) we should look into making an extra screen where you input a non-utwente account as well.
Partially fixes #1815.
