### PR TITLE
Exclude the image url from the products in the live data seeder

### DIFF
--- a/database/seeders/ImportLiveDataSeeder.php
+++ b/database/seeders/ImportLiveDataSeeder.php
@@ -82,7 +82,7 @@ class ImportLiveDataSeeder extends Seeder
             ['name' => 'events', 'excluded_columns' => ['formatted_date', 'is_future']],
             ['name' => 'mailinglists'],
             ['name' => 'menuitems'],
-            ['name' => 'products'],
+            ['name' => 'products', 'excluded_columns' => ['image_url']],
             ['name' => 'products_categories'],
             ['name' => 'product_categories'],
             ['name' => 'tickets'],


### PR DESCRIPTION
The appends 'image_url' from the omnomcom wrapped broke the livedataseeder. This fixes it. 