### PR TITLE
Member sign-out with delay

### DIFF
--- a/app/Console/Commands/EndMemberships.php
+++ b/app/Console/Commands/EndMemberships.php
@@ -41,8 +41,8 @@ class EndMemberships extends Command
      */
     public function handle()
     {
-        foreach(Member::all()->whereNotNull('member_until') as $member){
-            if(Carbon::createFromTimestamp($member->member_until) < Carbon::now()->timestamp){
+        foreach(Member::all()->whereNotNull('until') as $member){
+            if(Carbon::createFromTimestamp($member->until) < Carbon::now()->timestamp){
                 (new UserAdminController())->endMembership($member->user->id);
                 $this->info("Membership from $member->proto_username ended!");
             }

--- a/app/Console/Commands/EndMemberships.php
+++ b/app/Console/Commands/EndMemberships.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Proto\Console\Commands;
+
+use Carbon;
+use Exception;
+use Illuminate\Console\Command;
+use Proto\Http\Controllers\UserAdminController;
+use Proto\Models\Member;
+
+class EndMemberships extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'proto:endmemberships';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command terminates all memberships that have an end date in the past';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @throws Exception
+     */
+    public function handle()
+    {
+        foreach(Member::all()->whereNotNull('member_until') as $member){
+            if(Carbon::createFromTimestamp($member->member_until)<Carbon::now()->timestamp){
+                (new UserAdminController)->endMembership($member->user->id);
+                $this->info("Membership from $member->proto_username ended!");
+            }
+        }
+    }
+}

--- a/app/Console/Commands/EndMemberships.php
+++ b/app/Console/Commands/EndMemberships.php
@@ -42,8 +42,8 @@ class EndMemberships extends Command
     public function handle()
     {
         foreach(Member::all()->whereNotNull('member_until') as $member){
-            if(Carbon::createFromTimestamp($member->member_until)<Carbon::now()->timestamp){
-                (new UserAdminController)->endMembership($member->user->id);
+            if(Carbon::createFromTimestamp($member->member_until) < Carbon::now()->timestamp){
+                (new UserAdminController())->endMembership($member->user->id);
                 $this->info("Membership from $member->proto_username ended!");
             }
         }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -40,6 +40,7 @@ class Kernel extends ConsoleKernel
         Commands\SyncWikiAccounts::class,
         Commands\MemberCleanup::class,
         Commands\AddSysadmin::class,
+        Commands\EndMemberships::class,
     ];
 
     /**
@@ -57,11 +58,12 @@ class Kernel extends ConsoleKernel
         $schedule->command('proto:birthdaycron')->daily()->at('00:01');
         $schedule->command('proto:achievementscron')->daily()->at('00:10');
         $schedule->command('proto:clearsessions')->daily()->at('01:00');
-        $schedule->command('proto:feecron')->daily()->at('02:00');
-        $schedule->command('proto:membercleanup')->daily()->at('3:00');
-        $schedule->command('proto:filecleanup')->daily()->at('04:00');
-        $schedule->command('proto:spotifysync')->daily()->at('05:00');
-        $schedule->command('proto:omnomcleanup')->daily()->at('06:00');
+        $schedule->command('proto:endmemberships')->hourly()->at('02:00');
+        $schedule->command('proto:feecron')->daily()->at('03:00');
+        $schedule->command('proto:membercleanup')->daily()->at('04:00');
+        $schedule->command('proto:filecleanup')->daily()->at('05:00');
+        $schedule->command('proto:spotifysync')->daily()->at('06:00');
+        $schedule->command('proto:omnomcleanup')->daily()->at('07:00');
         $schedule->command('proto:helperremindercron')->daily()->at('08:00');
         $schedule->command('proto:helpernotificationcron')->daily()->at('10:00');
 //        $schedule->command('proto:playsound '.config('proto.soundboardSounds')['1337'])->daily()->at('13:37');

--- a/app/Http/Controllers/UserAdminController.php
+++ b/app/Http/Controllers/UserAdminController.php
@@ -12,6 +12,7 @@ use Mail;
 use PDF;
 use Proto\Mail\MembershipEnded;
 use Proto\Mail\MembershipEndSet;
+use Proto\Mail\MembershipStarted;
 use Proto\Models\HashMapItem;
 use Proto\Models\Member;
 use Proto\Models\User;
@@ -198,7 +199,7 @@ class UserAdminController extends Controller
         $member->proto_username = $alias;
         $member->save();
 
-        Mail::to($user)->queue((new MembershipEndSet($user))->onQueue('high'));
+        Mail::to($user)->queue((new MembershipStarted($user))->onQueue('high'));
 
         EmailListController::autoSubscribeToLists('autoSubscribeMember', $user);
 
@@ -244,7 +245,7 @@ class UserAdminController extends Controller
             return Redirect::back();
         }
 
-        $user->member->member_until = Carbon::create('Last day of September')->endOfDay()->subDay()->timestamp;
+        $user->member->until = Carbon::create('Last day of September')->endOfDay()->subDay()->timestamp;
         $user->member->save();
         Mail::to($user)->queue((new MemberShipEndSet($user))->onQueue('high'));
         Session::flash('flash_message', "End date for membership of $user->name set to the end of september!");
@@ -258,7 +259,7 @@ class UserAdminController extends Controller
             Session::flash('flash_message', 'The user needs to be a member for its membership to receive an end date!');
             return Redirect::back();
         }
-        $user->member->member_until = null;
+        $user->member->until = null;
         $user->member->save();
         Session::flash('flash_message', "End date for membership of $user->name removed!");
         return Redirect::back();

--- a/app/Http/Controllers/UserAdminController.php
+++ b/app/Http/Controllers/UserAdminController.php
@@ -238,9 +238,9 @@ class UserAdminController extends Controller
 
     public function EndMembershipInSeptember($id): RedirectResponse
     {
-        $user=User::findOrFail($id);
-        if(!$user->is_member) {
-            Session::flash('flash_message', "The user needs to be a member for its membership to receive an end date!");
+        $user = User::findOrFail($id);
+        if(! $user->is_member) {
+            Session::flash('flash_message', 'The user needs to be a member for its membership to receive an end date!');
             return Redirect::back();
         }
 
@@ -253,9 +253,9 @@ class UserAdminController extends Controller
 
     public function removeMembershipEnd($id): RedirectResponse
     {
-        $user=User::findOrFail($id);
-        if(!$user->is_member) {
-            Session::flash('flash_message', "The user needs to be a member for its membership to receive an end date!");
+        $user = User::findOrFail($id);
+        if(! $user->is_member) {
+            Session::flash('flash_message', 'The user needs to be a member for its membership to receive an end date!');
             return Redirect::back();
         }
         $user->member->member_until = null;

--- a/app/Http/Controllers/UserAdminController.php
+++ b/app/Http/Controllers/UserAdminController.php
@@ -236,6 +236,27 @@ class UserAdminController extends Controller
         return Redirect::back();
     }
 
+    public function EndMembershipInSeptember($id): RedirectResponse
+    {
+        $user=User::findOrFail($id);
+        if($user->is_member) {
+            $user->member->member_until = Carbon::create('Last day of September')->endOfDay()->subDay()->timestamp;
+            $user->member->save();
+        }
+        Session::flash('flash_message', "End date for membership of $user->name set to the end of september!");
+        return Redirect::back();
+    }
+
+    public function removeMembershipEnd($id){
+        $user=User::findOrFail($id);
+        if($user->is_member) {
+            $user->member->member_until = null;
+            $user->member->save();
+        }
+        Session::flash('flash_message', "End date for membership of $user->name removed!");
+        return Redirect::back();
+    }
+
     /**
      * @param Request $request
      * @param int $id

--- a/app/Mail/MembershipEndSet.php
+++ b/app/Mail/MembershipEndSet.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Proto\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Proto\Models\User;
+
+class MembershipEndSet extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public $user;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this
+            ->from('secretary@proto.utwente.nl', config('proto.secretary').' (Secretary)')
+            ->subject('An end date is set for your membership of Proto.')
+            ->view('emails.membershipenddate');
+    }
+}

--- a/database/migrations/2023_01_20_211900_add_member_until_to_member.php
+++ b/database/migrations/2023_01_20_211900_add_member_until_to_member.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMemberUntilToMember extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->bigInteger('member_until')->after('is_pending')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->dropColumn('member_until');
+        });
+    }
+}

--- a/database/migrations/2023_01_20_211900_add_member_until_to_member.php
+++ b/database/migrations/2023_01_20_211900_add_member_until_to_member.php
@@ -14,7 +14,7 @@ class AddMemberUntilToMember extends Migration
     public function up()
     {
         Schema::table('members', function (Blueprint $table) {
-            $table->bigInteger('member_until')->after('is_pending')->nullable();
+            $table->bigInteger('until')->after('is_pending')->nullable();
         });
     }
 
@@ -26,7 +26,7 @@ class AddMemberUntilToMember extends Migration
     public function down()
     {
         Schema::table('members', function (Blueprint $table) {
-            $table->dropColumn('member_until');
+            $table->dropColumn('until');
         });
     }
 }

--- a/resources/views/emails/membershipenddate.blade.php
+++ b/resources/views/emails/membershipenddate.blade.php
@@ -1,0 +1,29 @@
+@extends('emails.template')
+
+@section('body')
+
+<p>
+    Dear {{ $user->name }},
+</p>
+
+<p>
+    I am writing to you to let you know that the secretary has set an end date for your membership at S.A. Proto.
+</p>
+<p>
+    Your membership will end at: <b>{{Carbon::createFromTimestamp($user->member->member_untill)->format('d-m-Y')}}.</b><br>
+    This means you are a full member before this date, but will not be for the following academic year.
+    If you think this was a mistake and would like your membership to continue please contact me before this date.
+    When you're membership actually ends you will get a follow-up e-mail from me.
+</p>
+<p>
+    I hope to have informed you well via this e-mail, but should you have any questions left you can always come by
+    at the Protopolis or send me an e-mail.
+</p>
+
+<p>
+    Kind regards,<br>
+    {{ config('proto.secretary') }}<br>
+    <i>On behalf of the board of Study Association Proto</i>
+</p>
+
+@endsection

--- a/resources/views/emails/membershipenddate.blade.php
+++ b/resources/views/emails/membershipenddate.blade.php
@@ -10,8 +10,8 @@
     I am writing to you to let you know that the secretary has set an end date for your membership at S.A. Proto.
 </p>
 <p>
-    Your membership will end at: <b>{{Carbon::createFromTimestamp($user->member->member_untill)->format('d-m-Y')}}.</b><br>
-    This means you are a full member before this date, but will not be for the following academic year.
+    Your membership will end at: <b>{{Carbon::createFromTimestamp($user->member->until)->format('d-m-Y')}}.</b><br>
+    This means that your membership is valid up until this date and will then be terminated.
     If you think this was a mistake and would like your membership to continue please contact me before this date.
     When you're membership actually ends you will get a follow-up e-mail from me.
 </p>

--- a/resources/views/users/admin/admin_includes/membership.blade.php
+++ b/resources/views/users/admin/admin_includes/membership.blade.php
@@ -11,7 +11,7 @@
             </li>
 
             @if($user->is_member)
-                @if(!$user->member->member_until)
+                @if(!$user->member->until)
                     @include('website.layouts.macros.confirm-modal', [
                              'action' => route("user::member::endinseptember", ['id'=>$user->id]),
                              'method' => 'POST',
@@ -39,8 +39,8 @@
                            'action' => route("user::member::removeend", ['id'=>$user->id]),
                            'method' => 'POST',
                            'classes' => 'list-group-item text-danger',
-                           'text' => 'Remove membership end!',
-                           'message' => "Are you sure you want to remove then end of the membership of $user->name?"
+                           'text' => 'Cancel membership removal!',
+                           'message' => "Are you sure you do not want to let the membership of $user->name end anymore?"
                        ])
                 @endif
 
@@ -119,10 +119,10 @@
                             </tr>
                         </tbody>
                         <trow>
-                        @if($user->member->member_until)
+                        @if($user->member->until)
                             <tr>
                                 <td>
-                                    <b>Until: </b><i>{{Carbon::createFromTimestamp($user->member->member_until)->format('d M Y')}}</i>
+                                    <b>Until: </b><i>{{Carbon::createFromTimestamp($user->member->until)->format('d M Y')}}</i>
                                 </td>
                             </tr>
                         @endif

--- a/resources/views/users/admin/admin_includes/membership.blade.php
+++ b/resources/views/users/admin/admin_includes/membership.blade.php
@@ -11,13 +11,21 @@
             </li>
 
             @if($user->is_member)
-                @include('website.layouts.macros.confirm-modal', [
-                    'action' => route("user::member::remove", ['id'=>$user->id]),
-                    'method' => 'POST',
-                    'classes' => 'list-group-item text-danger',
-                    'text' => 'End membership',
-                    'message' => "Are you sure you want to end the membership of $user->name?"
-                ])
+                @if(!$user->member->member_until)
+                    @include('website.layouts.macros.confirm-modal', [
+                             'action' => route("user::member::endinseptember", ['id'=>$user->id]),
+                             'method' => 'POST',
+                             'classes' => 'list-group-item text-warning',
+                             'text' => 'End membership at the end of September',
+                             'message' => "Are you sure you want to end the membership of $user->name at the end of September?"
+                         ])
+                    @include('website.layouts.macros.confirm-modal', [
+                            'action' => route("user::member::remove", ['id'=>$user->id]),
+                            'method' => 'POST',
+                            'classes' => 'list-group-item text-danger',
+                            'text' => 'End membership immediately!',
+                            'message' => "Are you sure you want to end the membership of $user->name?"
+                        ])
                 <a href="#" class="list-group-item text-warning" data-bs-toggle="modal" data-bs-target="#setMembershipType">
                     Change membership type
                 </a>
@@ -25,6 +33,16 @@
                    class="list-group-item">
                     Preview membership card
                 </a>
+
+                @else
+                    @include('website.layouts.macros.confirm-modal', [
+                           'action' => route("user::member::removeend", ['id'=>$user->id]),
+                           'method' => 'POST',
+                           'classes' => 'list-group-item text-danger',
+                           'text' => 'Remove membership end!',
+                           'message' => "Are you sure you want to remove then end of the membership of $user->name?"
+                       ])
+                @endif
 
                 @include('website.layouts.macros.confirm-modal', [
                     'action' => route("membercard::print", ['id'=>$user->id]),
@@ -100,6 +118,15 @@
                                 </td>
                             </tr>
                         </tbody>
+                        <trow>
+                        @if($user->member->member_until)
+                            <tr>
+                                <td>
+                                    <b>Until: </b><i>{{Carbon::createFromTimestamp($user->member->member_until)->format('d M Y')}}</i>
+                                </td>
+                            </tr>
+                        @endif
+                        </trow>
                     </table>
                 </li>
 

--- a/resources/views/users/dashboard/includes/membership.blade.php
+++ b/resources/views/users/dashboard/includes/membership.blade.php
@@ -17,12 +17,12 @@
                             @endif
                         </td>
                     </tr>
-                    @if($user->member->member_until)
+                    @if($user->member->until)
                         <tr>
                             <th><b>Member until</b></th>
                             <td>
                                 <span class="badge rounded-pill bg-danger">
-                                {{Carbon::createFromTimestamp($user->member->member_until)->format('d-m-Y')}}
+                                {{Carbon::createFromTimestamp($user->member->until)->format('d-m-Y')}}
                                 </span>
                             </td>
                         </tr>

--- a/resources/views/users/dashboard/includes/membership.blade.php
+++ b/resources/views/users/dashboard/includes/membership.blade.php
@@ -17,6 +17,16 @@
                             @endif
                         </td>
                     </tr>
+                    @if($user->member->member_until)
+                        <tr>
+                            <th><b>Member until</b></th>
+                            <td>
+                                <span class="badge rounded-pill bg-danger">
+                                {{Carbon::createFromTimestamp($user->member->member_until)->format('d-m-Y')}}
+                                </span>
+                            </td>
+                        </tr>
+                        @endif
                     <tr>
                         <th>Proto username</th>
                         <td>{{ $user->member->proto_username }}</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,6 +83,8 @@ Route::group(['middleware' => ['forcedomain']], function () {
 
             Route::post('add', ['as' => 'add', 'uses' => 'UserAdminController@addMembership']);
             Route::post('remove', ['as' => 'remove', 'uses' => 'UserAdminController@endMembership']);
+            Route::post('end_in_september', ['as' => 'endinseptember', 'uses' => 'UserAdminController@EndMembershipInSeptember']);
+            Route::post('remove_end', ['as' => 'removeend', 'uses' => 'UserAdminController@removeMembershipEnd']);
             Route::post('settype', ['as' => 'settype', 'uses' => 'UserAdminController@setMembershipType']);
         });
 


### PR DESCRIPTION
It adds the ability to stop someone's membership at an arbitrary date and adds an easy button to end it at the end of September, which is right before October when we renew our memberships and charge the fees.
Fixes #1536.
