### PR TITLE
Add a board email to the member untill functionality and fix the cronjob

### DIFF
--- a/app/Console/Commands/EndMemberships.php
+++ b/app/Console/Commands/EndMemberships.php
@@ -5,7 +5,9 @@ namespace Proto\Console\Commands;
 use Carbon;
 use Exception;
 use Illuminate\Console\Command;
+use Mail;
 use Proto\Http\Controllers\UserAdminController;
+use Proto\Mail\MembershipEndedForBoard;
 use Proto\Models\Member;
 
 class EndMemberships extends Command
@@ -41,11 +43,19 @@ class EndMemberships extends Command
      */
     public function handle()
     {
+        $deleted =[];
         foreach(Member::all()->whereNotNull('until') as $member){
-            if(Carbon::createFromTimestamp($member->until) < Carbon::now()->timestamp){
+            if($member->until < Carbon::now()->timestamp){
                 (new UserAdminController())->endMembership($member->user->id);
                 $this->info("Membership from $member->proto_username ended!");
+                $deleted[]=$member;
             }
+        }
+
+        if(count($deleted)>0){
+            Mail::queue((new MembershipEndedForBoard($deleted))->onQueue('high'));
+        }else{
+            $this->info("No users who's membership to end!");
         }
     }
 }

--- a/app/Console/Commands/EndMemberships.php
+++ b/app/Console/Commands/EndMemberships.php
@@ -43,16 +43,16 @@ class EndMemberships extends Command
      */
     public function handle()
     {
-        $deleted =[];
+        $deleted = [];
         foreach(Member::all()->whereNotNull('until') as $member){
             if($member->until < Carbon::now()->timestamp){
                 (new UserAdminController())->endMembership($member->user->id);
                 $this->info("Membership from $member->proto_username ended!");
-                $deleted[]=$member;
+                $deleted[] = $member;
             }
         }
 
-        if(count($deleted)>0){
+        if(count($deleted) > 0){
             Mail::queue((new MembershipEndedForBoard($deleted))->onQueue('high'));
         }else{
             $this->info("No users who's membership to end!");

--- a/app/Mail/MembershipEndedForBoard.php
+++ b/app/Mail/MembershipEndedForBoard.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Proto\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class MembershipEndedForBoard extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public $deleted_memberships;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($deleted_memberships)
+    {
+        $this->deleted_memberships = $deleted_memberships;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this
+            ->to('board@proto.utwente.nl', 'S.A. Proto Memberships update')
+            ->subject('Member ship automatically ended for '.count($this->deleted_memberships).' members! '.date('d-m-Y'))
+            ->view('emails.membershipsendedforboard');
+    }
+}

--- a/app/Mail/MembershipEndedForBoard.php
+++ b/app/Mail/MembershipEndedForBoard.php
@@ -31,7 +31,7 @@ class MembershipEndedForBoard extends Mailable
     public function build()
     {
         return $this
-            ->to('board@proto.utwente.nl', 'S.A. Proto Memberships update')
+            ->to('board@proto.utwente.nl', 'S.A. Proto Membership Terminations')
             ->subject('Member ship automatically ended for '.count($this->deleted_memberships).' members! '.date('d-m-Y'))
             ->view('emails.membershipsendedforboard');
     }

--- a/resources/views/emails/membershipsendedforboard.blade.php
+++ b/resources/views/emails/membershipsendedforboard.blade.php
@@ -21,7 +21,7 @@
 
     <p>
         Kind regards,<br>
-        The Membership Ending Clerk
+        The Membership Terminating Clerk
     </p>
 
 @endsection

--- a/resources/views/emails/membershipsendedforboard.blade.php
+++ b/resources/views/emails/membershipsendedforboard.blade.php
@@ -1,0 +1,27 @@
+@extends('emails.template')
+
+@section('body')
+
+    <p>
+        Hey!
+    </p>
+
+    <p>
+        I just ran the membership cleanup program.
+    </p>
+
+    <p>
+        <strong>Members who had their membership automatically ended:</strong>
+    <ul>
+        @foreach($deleted_memberships as $member)
+            <li>{{ $member->user->name }}</li>
+        @endforeach
+    </ul>
+    </p>
+
+    <p>
+        Kind regards,<br>
+        The Membership Ending Clerk
+    </p>
+
+@endsection


### PR DESCRIPTION
The cronjob accidentally checked a carbon object against an integer.
Also added an email that updates the board with which memberships have been terminated.

![image](https://user-images.githubusercontent.com/72889753/213944944-21884036-8800-4aec-85ad-1ee053ad03fe.png)
