### PR TITLE
Fix activity relation breaking ImportLiveDataSeeder for non-admin developers

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -75,6 +75,12 @@ class ExportController extends Controller
                         return $event->mayViewEvent($user);
                     });
                 }
+
+                // Exclude 'activity' relation
+                foreach($data as $key => $val){
+                    unset($val->activity);
+                }
+
                 break;
             case 'mailinglists':
                 $data = EmailList::all();

--- a/database/seeders/ImportLiveDataSeeder.php
+++ b/database/seeders/ImportLiveDataSeeder.php
@@ -79,7 +79,7 @@ class ImportLiveDataSeeder extends Seeder
             ['name' => 'committees'],
             ['name' => 'committees_activities'],
             ['name' => 'companies'],
-            ['name' => 'events', 'excluded_columns' => ['formatted_date', 'is_future']],
+            ['name' => 'events', 'excluded_columns' => ['formatted_date', 'is_future', 'activity']],
             ['name' => 'mailinglists'],
             ['name' => 'menuitems'],
             ['name' => 'products', 'excluded_columns' => ['image_url']],


### PR DESCRIPTION
This seems to fix the error:
```
Object of class stdClass could not be converted to string
```
This error occurs when inserting imported events. 

I don't see the reason why this only occurs on non-admin accounts, but this seems to fix it for them. 
