### PR TITLE
Update opening times in emails

### DIFF
--- a/resources/views/emails/template.blade.php
+++ b/resources/views/emails/template.blade.php
@@ -33,7 +33,8 @@
         </td>
         <td style="color: #fff; padding: 0;">
             <br>
-            Mon-Fri, 09:30-16:30<br>
+            Mon&Fri, 08:30-16:00<br>
+            Tue-Thu, 08:30-17:30<br>
             <a style="color: #fff; text-decoration: none;" href="tel:+31534894423">+31 (0)53 489 4423</a><br>
             <a style="color: #fff; text-decoration: none;" href="mailto:board@proto.utwente.nl">
                 board@proto.utwente.nl


### PR DESCRIPTION
It now looks approximately like this:
![image](https://user-images.githubusercontent.com/94912220/217637033-508fb2b4-c736-41f9-983d-88c8fc5bb62f.png)

I'm not sure where the official time can be referenced, so it is taken from the website.
(Mon and Fri -> 8:30-16:00
 Tue to Thu -> 8:30-17:30)

