### PR TITLE
Add back-up list check for setting event status

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -560,7 +560,7 @@ class EventController extends Controller
                     if ($event->activity->isHelping($user)) {
                         $status = 'Helping';
                         $info_text .= ' You are helping with this activity.';
-                    } elseif ($event->activity->isOnBackupList()){
+                    } elseif ($event->activity->isOnBackupList($user)){
                         $status = 'On back-up list';
                         $info_text .= ' You are on the back-up list for this activity';
                     }elseif ($event->activity->isParticipating($user) || $event->hasBoughtTickets($user)) {

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -560,7 +560,10 @@ class EventController extends Controller
                     if ($event->activity->isHelping($user)) {
                         $status = 'Helping';
                         $info_text .= ' You are helping with this activity.';
-                    } elseif ($event->activity->isParticipating($user) || $event->hasBoughtTickets($user)) {
+                    } elseif ($event->activity->isOnBackupList()){
+                        $status = 'On back-up list';
+                        $info_text .= ' You are on the back-up list for this activity';
+                    }elseif ($event->activity->isParticipating($user) || $event->hasBoughtTickets($user)) {
                         $status = 'Participating';
                         $info_text .= ' You are participating in this activity.';
                     }


### PR DESCRIPTION
This branch makes it, so the exported calendar properly denotes if the user is on the back-up list for an event. Fixes issue #1868.