### PR TITLE
Heigthen the value of max_input_vars for the handle function of DA-sync

### DIFF
--- a/app/Console/Commands/DirectAdminSync.php
+++ b/app/Console/Commands/DirectAdminSync.php
@@ -40,6 +40,7 @@ class DirectAdminSync extends Command
      */
     public function handle()
     {
+        ini_set('max_input_vars', 2000);
         $da = new DirectAdmin();
         $da->connect(getenv('DA_HOSTNAME'), getenv('DA_PORT'));
         $da->set_login(getenv('DA_USERNAME'), getenv('DA_PASSWORD'));


### PR DESCRIPTION
Hopefully fixes the sentry error that the DA sync goes over the parse_string limit of 1000.