### PR TITLE
Clarify the outstanding amount and make it so you can see the activies which still have to be processed

### DIFF
--- a/app/Http/Controllers/OrderLineController.php
+++ b/app/Http/Controllers/OrderLineController.php
@@ -66,8 +66,12 @@ class OrderLineController extends Controller
 
         $outstanding = Activity::whereHas('users', function (Builder $query) {
             $query->where('user_id', Auth::user()->id);
-        })->where('closed', false)->sum('price');
+        })->where('closed', false);
 
+        $outstandingAmount=$outstanding->sum('price');
+        $outstanding=$outstanding->select('event_id', 'price')->with('Event', function($q){
+            $q->select('id', 'title');
+        })->where('price', '>', 0)->get();
 
         $payment_methods = MollieController::getPaymentMethods();
         return view('omnomcom.orders.myhistory', [
@@ -79,6 +83,7 @@ class OrderLineController extends Controller
             'total' => $total,
             'methods' => $payment_methods ?? [],
             'use_fees' => config('omnomcom.mollie')['use_fees'],
+            'outstandingAmount' => $outstandingAmount,
             'outstanding' => $outstanding,
         ]);
     }

--- a/resources/views/omnomcom/orders/includes/payment-details.blade.php
+++ b/resources/views/omnomcom/orders/includes/payment-details.blade.php
@@ -36,14 +36,38 @@
 
         @endif
 
-        @if($outstanding>0)
-        <p class="card-text">
-            Remaining outstanding amount
-        </p>
+        @if($outstandingAmount>0)
+            <p class="card-text">
+                Remaining outstanding
+                <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="right" title="The amount caught up in activities you signed up for that still have to be processed. This will not be in the next withdrawal but you will have to pay this this money somewhere in the future."></i>
+            </p>
+            <ul class="list-group list-group-flush" id="outstanding-accordion">
 
-        <h3 class="card-title">
-            &euro; {{ number_format($outstanding, 2, '.', '') }}
-        </h3>
+                    <li class="cursor-pointer" data-bs-toggle="collapse"
+                        data-bs-target="#outstanding">
+                        <h3 class="card-title">
+                            &euro; {{ number_format($outstandingAmount, 2, '.', '') }}
+                        </h3>
+                    </li>
+                    <div id="outstanding" class="collapse" data-parent="#outstanding-accordion">
+                        <table class="table table-borderless table-hover table-sm mt-1">
+                            <thead>
+                            <tr>
+                                <th scope="col">Activity</th>
+                                <th scope="col">Amount</th>
+                            </tr>
+                            </thead>
+                            <tbody
+                                @foreach($outstanding as $outstandingActivity)
+                                    <tr>
+                                        <td>{{ $outstandingActivity->event->title }}</td>
+                                        <td>&euro; {{ number_format($outstandingActivity->price, 2, '.', '') }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+            </ul>
         @endif
     </div>
     

--- a/resources/views/omnomcom/orders/includes/payment-details.blade.php
+++ b/resources/views/omnomcom/orders/includes/payment-details.blade.php
@@ -39,7 +39,7 @@
         @if($outstandingAmount>0)
             <p class="card-text">
                 Remaining outstanding
-                <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="right" title="The amount caught up in activities you signed up for that still have to be processed. This will not be in the next withdrawal but you will have to pay this this money somewhere in the future."></i>
+                <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="right" title="The amount caught up in activities you signed up for that still have to be processed. This will not be in the next withdrawal AND you CAN NOT pay this now, but you will have to pay this this money somewhere in the future."></i>
             </p>
             <ul class="list-group list-group-flush" id="outstanding-accordion">
 


### PR DESCRIPTION
Implements #1869 
The clarification under the tooltip:
![image](https://user-images.githubusercontent.com/72889753/219875014-e10488df-bd73-4dd1-816e-a16aebc0d9ec.png)
The activity accordion when clicked on the amount:
![image](https://user-images.githubusercontent.com/72889753/219875035-cb884d1e-7db3-447d-92d7-6911ea6b6406.png)
