### PR TITLE
Move over the web route files to the new syntax (laravel 8)

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -48,9 +48,4 @@ class HomeController extends Controller
 
         return view('website.developers', ['developers' => $developers, 'committee' => $committee]);
     }
-
-    /** @return View Display FishCam. */
-    public function fishcam() {
-        return view('misc.fishcam');
-    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -47,7 +47,6 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapWebRoutes()
     {
         Route::middleware('web')
-            ->namespace($this->namespace)
             ->group(base_path('routes/web.php'));
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,7 @@ use Proto\Http\Controllers\RegistrationHelperController;
 use Proto\Http\Controllers\RfidCardController;
 use Proto\Http\Controllers\SearchController;
 use Proto\Http\Controllers\ShortUrlController;
+use Proto\Http\Controllers\SmartXpScreenController;
 use Proto\Http\Controllers\SoundboardController;
 use Proto\Http\Controllers\SpotifyController;
 use Proto\Http\Controllers\SurfConextController;
@@ -70,8 +71,6 @@ View::composer('*', function ($view) {
     View::share('viewName', $view->getName());
 });
 
-// TODO: change string based controller route definitions to standard PHP callable syntax.
-
 ROute::middleware('forcedomain')->group(function () {
 
     /* The main route for the frontpage. */
@@ -84,7 +83,7 @@ ROute::middleware('forcedomain')->group(function () {
         })->middleware('member')->name('fishcam');
     });
 
-    Route::get('becomeamember', [UserDashboardController::class, 'becomeAMemberOf']);
+    Route::get('becomeamember', [UserDashboardController::class, 'becomeAMemberOf'])->name('becomeamember');
 
     /* Routes related to the header images. */
     Route::prefix('headerimage')->name('headerimage::')->controller(HeaderImageController::class)->middleware(['auth', 'permission:header-image'])->group(function(){
@@ -179,7 +178,7 @@ ROute::middleware('forcedomain')->group(function () {
             });
 
             Route::prefix('admin')->name('admin::')->middleware('permission:board')->group(function(){
-                Route::get('','index')->name('list');
+                Route::get('admin','index')->name('list');
                 Route::get('{id}', 'details')->name('details');
                 Route::post('{id}', 'update')->name('update');
 
@@ -268,7 +267,7 @@ ROute::middleware('forcedomain')->group(function () {
 
     /* Routes related to the Membership Forms */
     Route::prefix('memberform')->name('memberform::')->middleware('auth')->group(function (){
-        Route::controller(UserAdminController::class)->group(function (){
+        Route::controller(UserDashboardController::class)->group(function (){
             Route::get('sign', 'getMemberForm')->name('sign');
             Route::post('sign', 'postMemberForm')->name('sign');
         });
@@ -289,12 +288,11 @@ ROute::middleware('forcedomain')->group(function () {
         Route::get('{id}', 'show')->name('show');
 
         Route::middleware('auth')->group(function(){
-
-            Route::get('{slug}/toggle_helper_reminder', ['as' => 'toggle_helper_reminder', 'middleware' => ['auth'], 'uses' => 'CommitteeController@toggleHelperReminder']);
+            Route::get('{slug/toggle_helper_reminder', 'toggleHelperReminder')->name('toggle_helper_reminder');
 
             Route::middleware('member')->group(function() {
-                Route::get('{id}/send_anonymous_email', ['as' => 'anonymousmail', 'middleware' => ['auth', 'member'], 'uses' => 'CommitteeController@showAnonMailForm']);
-                Route::post('{id}/send_anonymous_email', ['as' => 'anonymousmail', 'middleware' => ['auth', 'member'], 'uses' => 'CommitteeController@postAnonMailForm']);
+                Route::get('{id}/send_anonymous_email', 'showAnonMailForm')->name('anonymousmail');
+                Route::post('{id}/send_anonymous_email', 'postAnonMailForm')->name('anonymousmail');
             });
 
             Route::middleware('permission:board')->group(function() {
@@ -465,9 +463,8 @@ ROute::middleware('forcedomain')->group(function () {
                     Route::get('album/unlink/{album}', 'unlinkAlbum')->name('unlinkalbum');
 
                     Route::prefix('categories')->name('category::')->group(function(){
-                        Route::get('', 'categoryAdmin')->name('admin');
+                        Route::get('admin', 'categoryAdmin')->name('admin');
                         Route::post('add', 'categoryStore')->name('add');
-                        Route::get('edit/{id}', 'categoryEdit')->name('edit');
                         Route::post('edit/{id}', 'categoryUpdate')->name('edit');
                         Route::get('delete/{id}', 'categoryDestroy')->name('delete');
                     });
@@ -524,7 +521,7 @@ ROute::middleware('forcedomain')->group(function () {
 
     /* Routes related to pages. */
     Route::prefix('page')->name('page::')->controller(PageController::class)->group(function(){
-        Route::get('{slug}', ['as' => 'show', 'uses' => 'PageController@show']);
+        Route::get('{slug}', 'show')->name('show');
 
         Route::middleware(['auth','permission:board'])->group(function(){
             Route::get('', 'index')->name('list');
@@ -545,9 +542,8 @@ ROute::middleware('forcedomain')->group(function () {
 
     /* Routes related to news. */
     Route::prefix('news')->name('news::')->controller(NewsController::class)->group(function(){
-
-        Route::get('', 'NewsController@index')->name('list');
-        Route::get('{id}', 'NewsController@show')->name('show');
+        Route::get('', 'index')->name('list');
+        Route::get('{id}', 'show')->name('show');
 
         Route::middleware(['auth', 'permission:board'])->group(function(){
             Route::get('admin', 'admin')->name('admin');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,5 @@
 <?php
+
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 use Proto\Http\Controllers\AccountController;
@@ -58,8 +59,8 @@ use Proto\Http\Controllers\TFAController;
 use Proto\Http\Controllers\TicketController;
 use Proto\Http\Controllers\TIPCieController;
 use Proto\Http\Controllers\UserAdminController;
-use Proto\Http\Controllers\UserProfileController;
 use Proto\Http\Controllers\UserDashboardController;
+use Proto\Http\Controllers\UserProfileController;
 use Proto\Http\Controllers\VideoController;
 use Proto\Http\Controllers\WelcomeController;
 use Proto\Http\Controllers\WithdrawalController;
@@ -75,10 +76,10 @@ ROute::middleware('forcedomain')->group(function () {
 
     /* The main route for the frontpage. */
 
-    Route::controller(HomeController::class)->group(function(){
+    Route::controller(HomeController::class)->group(function () {
         Route::get('', 'show')->name('homepage');
         Route::get('developers', 'developers')->name('developers');
-        Route::get('fishcam', function(){
+        Route::get('fishcam', function () {
             return view('misc.fishcam');
         })->middleware('member')->name('fishcam');
     });
@@ -86,7 +87,7 @@ ROute::middleware('forcedomain')->group(function () {
     Route::get('becomeamember', [UserDashboardController::class, 'becomeAMemberOf'])->name('becomeamember');
 
     /* Routes related to the header images. */
-    Route::prefix('headerimage')->name('headerimage::')->controller(HeaderImageController::class)->middleware(['auth', 'permission:header-image'])->group(function(){
+    Route::prefix('headerimage')->name('headerimage::')->controller(HeaderImageController::class)->middleware(['auth', 'permission:header-image'])->group(function () {
         Route::get('', 'index')->name('index');
         Route::get('add', 'create')->name('add');
         Route::post('add', 'store')->name('add');
@@ -94,7 +95,7 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes for the search function. */
-    Route::controller(SearchController::class)->group(function(){
+    Route::controller(SearchController::class)->group(function () {
         Route::get('search','search')->name('search');
         Route::post('search', 'search')->name('search');
         Route::get('opensearch', 'openSearch')->name('search::opensearch');
@@ -111,19 +112,19 @@ ROute::middleware('forcedomain')->group(function () {
         Route::get('login', 'getLogin')->name('show');
         Route::post('login', 'postLogin')->name('post')->middleware('throttle:5,1');
 
-        Route::prefix('logout')->group(function(){
+        Route::prefix('logout')->group(function () {
             Route::get('', 'getLogout')->name('logout');
             Route::get('redirect', 'getLogoutRedirect')->name('logout::redirect');
         });
 
-        Route::prefix('password')->group(function(){
+        Route::prefix('password')->group(function () {
             Route::get('reset/{token}', 'getPasswordReset')->name('resetpass::token');
             Route::post('reset', 'postPasswordReset')->name('resetpass::submit')->middleware('throttle:5,1');
 
             Route::get('email', 'getPasswordResetEmail')->name('resetpass');
             Route::post('email', 'postPasswordResetEmail')->name('resetpass::send')->middleware('throttle:5,1');
 
-            Route::middleware('auth')->group(function(){
+            Route::middleware('auth')->group(function () {
                 Route::get('sync', 'getPasswordSync')->name('password::sync');
                 Route::post('sync', 'postPasswordSync')->name('password::sync')->middleware('throttle:5,1');
 
@@ -131,17 +132,17 @@ ROute::middleware('forcedomain')->group(function () {
                 Route::post('change', 'postPasswordChange')->name('password::change')->middleware('throttle:5,1');
             });
 
-            Route::prefix('register')->group(function(){
+            Route::prefix('register')->group(function () {
                 Route::get('', 'getRegister')->name('register');
                 Route::post('', 'postRegister')->name('register')->middleware('throttle:5,1');
                 Route::post('surfconext', 'postRegisterSurfConext')->name('register::surfconext')->middleware('throttle:5,1');
             });
 
-            Route::prefix('surfconext')->group(function(){
+            Route::prefix('surfconext')->group(function () {
                 Route::get('', 'startSurfConextAuth')->name('edu');
                 Route::get('post', 'postSurfConextAuth')->name('edupost');
 
-                Route::prefix('username')->group(function() {
+                Route::prefix('username')->group(function () {
                     Route::get('', 'requestUsername')->name('requestusername');
                     Route::post('', 'requestUsername')->name('requestusername')->middleware('throttle:5,1');
                 });
@@ -150,19 +151,19 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to user profiles. */
-    Route::prefix('user')->name('user::')->middleware('auth')->group(function(){
-        Route::controller(AuthController::class)->group(function(){
+    Route::prefix('user')->name('user::')->middleware('auth')->group(function () {
+        Route::controller(AuthController::class)->group(function () {
             Route::post('delete', 'deleteUser')->name('delete');
             Route::post('password', 'updatePassword')->name('changepassword');
         });
 
         Route::get('{id?}', [UserProfileController::class, 'show'])->name('profile')->middleware('member');
 
-        Route::controller(UserAdminController::class)->group(function(){
+        Route::controller(UserAdminController::class)->group(function () {
             Route::get('quit_impersonating', 'quitImpersonating')->name('quitimpersonating');
 
             /* Routes related to members. */
-            Route::name('member::')->prefix('{id}/member')->middleware('permission:registermembers')->group(function(){
+            Route::name('member::')->prefix('{id}/member')->middleware('permission:registermembers')->group(function () {
                 Route::get('impersonate', 'impersonate')->name('impersonate')->middleware('permission:board');
                 Route::post('add', 'addMembership')->name('add');
                 Route::post('remove', 'endMembership')->name('remove');
@@ -171,13 +172,13 @@ ROute::middleware('forcedomain')->group(function () {
                 Route::post('settype', 'setMembershipType')->name('settype');
 
                 /* Routes related to the custom omnomcom sound. */
-                Route::prefix('omnomcomsound')->name('omnomcomsound::')->middleware('permission:board')->group(function(){
+                Route::prefix('omnomcomsound')->name('omnomcomsound::')->middleware('permission:board')->group(function () {
                     Route::post('update', 'uploadOmnomcomSound')->name('update');
                     Route::get('delete', 'deleteOmnomcomSound')->name('delete');
                 });
             });
 
-            Route::prefix('admin')->name('admin::')->middleware('permission:board')->group(function(){
+            Route::prefix('admin')->name('admin::')->middleware('permission:board')->group(function () {
                 Route::get('admin','index')->name('list');
                 Route::get('{id}', 'details')->name('details');
                 Route::post('{id}', 'update')->name('update');
@@ -189,37 +190,37 @@ ROute::middleware('forcedomain')->group(function () {
             });
         });
 
-        Route::controller(UserDashboardController::class)->group(function() {
+        Route::controller(UserDashboardController::class)->group(function () {
             Route::get('personal_key', 'generateKey')->name('personal_key::generate');
             Route::get('dashboard', 'show')->name('dashboard');
             Route::post('dashboard', 'update')->name('dashboard');
             Route::post('change_email', 'updateMail')->name('changemail')->middleware('throttle:3,1');
 
             /* Routes related to the memberprofiles */
-            Route::prefix('memberprofile')->name('memberprofile::')->group(function(){
-                Route::prefix('complete')->group(function(){
+            Route::prefix('memberprofile')->name('memberprofile::')->group(function () {
+                Route::prefix('complete')->group(function () {
                     Route::get('', 'getCompleteProfile')->name('complete');
                     Route::post('', 'postCompleteProfile')->name('complete');
                 });
-                Route::prefix('clear')->group(function(){
+                Route::prefix('clear')->group(function () {
                     Route::get('', 'getClearProfile')->name('clear');
                     Route::post('', 'postClearProfile')->name('clear');
                 });
             });
 
             /* Routes related to diet. */
-            Route::prefix('diet')->name('diet::')->group( function () {
+            Route::prefix('diet')->name('diet::')->group(function () {
                 Route::post('edit', 'editDiet')->name('edit');
             });
         });
 
-        Route::prefix('registrationhelper')->name('registrationhelper::')->middleware('permission:registermembers')->controller(RegistrationHelperController::class)->group(function(){
+        Route::prefix('registrationhelper')->name('registrationhelper::')->middleware('permission:registermembers')->controller(RegistrationHelperController::class)->group(function () {
             Route::get('', 'index')->name('list');
             Route::get('{id}', 'details')->name('details');
         });
 
         /* Routes related to addresses. */
-        Route::prefix('address')->name('address::')->controller(AddressController::class)->group(function(){
+        Route::prefix('address')->name('address::')->controller(AddressController::class)->group(function () {
             Route::get('add', 'add')->name('add');
             Route::post('add', 'store')->name('add');
             Route::get('delete', 'destroy')->name('delete');
@@ -229,7 +230,7 @@ ROute::middleware('forcedomain')->group(function () {
         });
 
         /* Routes related to bank accounts. */
-        Route::prefix('bank')->name('bank::')->controller(BankController::class)->group(function(){
+        Route::prefix('bank')->name('bank::')->controller(BankController::class)->group(function () {
             Route::get('add', 'add')->name('add');
             Route::post('add', 'store')->name('add');
             Route::post('delete', 'destroy')->name('delete');
@@ -238,27 +239,27 @@ ROute::middleware('forcedomain')->group(function () {
         });
 
         /* Routes related to RFID cards. */
-        Route::prefix('rfidcard/{id}')->name('rfid::')->controller(RFIDCardController::class)->group(function(){
+        Route::prefix('rfidcard/{id}')->name('rfid::')->controller(RFIDCardController::class)->group(function () {
             Route::get('delete', 'destroy')->name('delete');
             Route::get('edit', 'edit')->name('edit');
             Route::post('edit', 'update')->name('edit');
         });
 
         /* Routes related to profile pictures. */
-        Route::prefix('profilepic')->name('pic::')->controller(ProfilePictureController::class)->group(function(){
+        Route::prefix('profilepic')->name('pic::')->controller(ProfilePictureController::class)->group(function () {
             Route::post('update', 'update')->name('update');
             Route::get('delete', 'destroy')->name('delete');
         });
 
         /* Routes related to UT accounts. */
-        Route::prefix('edu')->name('edu::')->controller(SurfConextController::class)->group(function(){
+        Route::prefix('edu')->name('edu::')->controller(SurfConextController::class)->group(function () {
             Route::get('delete', 'destroy')->name('delete');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
         });
 
         /* Routes related to 2FA. */
-        Route::prefix('2fa')->name('2fa::')->controller(TFAController::class)->group(function(){
+        Route::prefix('2fa')->name('2fa::')->controller(TFAController::class)->group(function () {
             Route::post('add', 'create')->name('add');
             Route::post('delete', 'destroy')->name('delete');
             Route::post('delete/{id}', 'adminDestroy')->name('admindelete')->middleware('permission:board');
@@ -266,13 +267,13 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to the Membership Forms */
-    Route::prefix('memberform')->name('memberform::')->middleware('auth')->group(function (){
-        Route::controller(UserDashboardController::class)->group(function (){
+    Route::prefix('memberform')->name('memberform::')->middleware('auth')->group(function () {
+        Route::controller(UserDashboardController::class)->group(function () {
             Route::get('sign', 'getMemberForm')->name('sign');
             Route::post('sign', 'postMemberForm')->name('sign');
         });
-        Route::controller(UserAdminController::class)->group(function(){
-            Route::prefix('download')->name('download::')->group(function(){
+        Route::controller(UserAdminController::class)->group(function () {
+            Route::prefix('download')->name('download::')->group(function () {
                 Route::get('new/{id}', 'getNewMemberForm')->name('new');
                 Route::get('signed/{id}', 'getSignedMemberForm')->name('signed');
             });
@@ -282,20 +283,20 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to committees. */
-    Route::prefix('committee')->name('committee::')->controller(CommitteeController::class)->group(function(){
+    Route::prefix('committee')->name('committee::')->controller(CommitteeController::class)->group(function () {
 
         Route::get('list', 'overview')->name('list');
         Route::get('{id}', 'show')->name('show');
 
-        Route::middleware('auth')->group(function(){
+        Route::middleware('auth')->group(function () {
             Route::get('{slug/toggle_helper_reminder', 'toggleHelperReminder')->name('toggle_helper_reminder');
 
-            Route::middleware('member')->group(function() {
+            Route::middleware('member')->group(function () {
                 Route::get('{id}/send_anonymous_email', 'showAnonMailForm')->name('anonymousmail');
                 Route::post('{id}/send_anonymous_email', 'postAnonMailForm')->name('anonymousmail');
             });
 
-            Route::middleware('permission:board')->group(function() {
+            Route::middleware('permission:board')->group(function () {
 
                 Route::get('add', 'add')->name('add');
                 Route::post('add', 'store')->name('add');
@@ -317,15 +318,15 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to societies. */
-    Route::prefix('society')->name('society::')->controller(CommitteeController::class)->group(function(){
+    Route::prefix('society')->name('society::')->controller(CommitteeController::class)->group(function () {
         Route::get('list', 'overview')->name('list')->defaults('showSociety', true);
         Route::get('{id}', 'show')->name('show');
     });
 
     /* Routes related to narrowcasting. */
-    Route::prefix('narrowcasting')->name('narrowcasting::')->controller(NarrowcastingController::class)->group(function(){
+    Route::prefix('narrowcasting')->name('narrowcasting::')->controller(NarrowcastingController::class)->group(function () {
         Route::get('', 'display')->name('display');
-        Route::middleware(['auth', 'permission:board'])->group(function(){
+        Route::middleware(['auth', 'permission:board'])->group(function () {
             Route::get('list', 'index')->name('list');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
@@ -337,12 +338,12 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to companies. */
-    Route::prefix('companies')->name('companies::')->controller('CompanyController')->group(function(){
+    Route::prefix('companies')->name('companies::')->controller('CompanyController')->group(function () {
 
         Route::get('', 'index')->name('index');
         Route::get('{id}', 'show')->name('show');
 
-        Route::middleware(['auth', 'permission:board'])->group(function(){
+        Route::middleware(['auth', 'permission:board'])->group(function () {
             Route::get('list', 'adminIndex')->name('admin');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
@@ -356,24 +357,24 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to membercard. */
-    Route::prefix('membercard')->name('membercard::')->group(function(){
-       Route::controller(MemberCardController::class)->group(function(){
+    Route::prefix('membercard')->name('membercard::')->group(function () {
+       Route::controller(MemberCardController::class)->group(function () {
            Route::get('print', 'startPrint')->name('print')->middleware(['auth', 'permission:board']);
            Route::get('download/{id}', 'download')->name('download');
        });
 
-        Route::controller(CompanyController::class)->group(function(){
+        Route::controller(CompanyController::class)->group(function () {
             Route::get('', 'indexmembercard')->name('index');
             Route::get('{id}', 'showmembercard')->name('show');
         });
     });
 
     /* Routes related to joboffers. */
-    Route::prefix('joboffers')->name('joboffers::')->controller(JobofferController::class)->group(function(){
+    Route::prefix('joboffers')->name('joboffers::')->controller(JobofferController::class)->group(function () {
         Route::get('', 'index')->name('index');
         Route::get('{id}', 'show')->name('show');
 
-        Route::middleware(['auth', 'permission:board'])->group(function(){
+        Route::middleware(['auth', 'permission:board'])->group(function () {
             Route::get('list', 'adminIndex')->name('admin');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
@@ -384,11 +385,11 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to leaderboards. */
-    Route::prefix('leaderboard')->name('leaderboards::')->middleware(['auth', 'member'])->controller(LeaderboardController::class)->group(function(){
+    Route::prefix('leaderboard')->name('leaderboards::')->middleware(['auth', 'member'])->controller(LeaderboardController::class)->group(function () {
 
         Route::get('', 'index')->name('index');
 
-        Route::middleware(['permission:board'])->group(function(){
+        Route::middleware(['permission:board'])->group(function () {
             Route::get('list', 'adminIndex')->name('admin');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
@@ -396,7 +397,7 @@ ROute::middleware('forcedomain')->group(function () {
             Route::post('edit/{id}', 'update')->name('edit');
             Route::get('delete/{id}', 'destroy')->name('delete');
 
-            Route::prefix('entries')->name('entries::')->group(function(){
+            Route::prefix('entries')->name('entries::')->group(function () {
                 Route::post('add', 'store')->name('add');
                 Route::post('update', 'update')->name('update');
                 Route::get('delete/{id}', 'destroy')->name('delete');
@@ -405,9 +406,9 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to dinnerforms. */
-    Route::prefix('dinnerform')->name('dinnerform::')->middleware('auth')->controller(DinnerformController::class)->group(function(){
+    Route::prefix('dinnerform')->name('dinnerform::')->middleware('auth')->controller(DinnerformController::class)->group(function () {
         Route::get('{id}', 'show')->name('show');
-        Route::middleware('permission:tipcie')->group(function(){
+        Route::middleware('permission:tipcie')->group(function () {
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
             Route::get('edit/{id}', 'edit')->name('edit');
@@ -418,7 +419,7 @@ ROute::middleware('forcedomain')->group(function () {
             Route::get('process/{id}', 'process')->name('process');
         });
 
-        Route::prefix('orderline')->name('orderline::')->group(function(){
+        Route::prefix('orderline')->name('orderline::')->group(function () {
             Route::get('delete/{id}', 'delete')->name('delete');
             Route::get('edit/{id}', 'edit')->name('edit');
             Route::post('add/{id}', 'store')->name('add');
@@ -430,9 +431,9 @@ ROute::middleware('forcedomain')->group(function () {
      * Routes related to events.
      * Important: routes in this block always use event_id or a relevant other ID. activity_id is in principle never used.
      */
-    Route::prefix('events')->name('event::')->group(function (){
+    Route::prefix('events')->name('event::')->group(function () {
 
-        Route::controller(EventController::class)->group(function(){
+        Route::controller(EventController::class)->group(function () {
             //show event overview pages
             Route::get('', 'index')->name('list');
             Route::get('archive/{year}', 'archive')->name('archive');
@@ -440,7 +441,7 @@ ROute::middleware('forcedomain')->group(function () {
             // Show events
             Route::get('{id}', 'show')->name('show');
 
-            Route::middleware('auth')->group(function(){
+            Route::middleware('auth')->group(function () {
                 Route::post('set_reminder', 'setReminder')->name('set_reminder');
                 Route::get('toggle_relevant_only', 'toggleRelevantOnly')->name('toggle_relevant_only');
 
@@ -449,7 +450,7 @@ ROute::middleware('forcedomain')->group(function () {
                 // Force login for event
                 Route::get('{id}/login', 'forceLogin')->name('login');
 
-                Route::middleware('permission:board')->group(function() {
+                Route::middleware('permission:board')->group(function () {
                     Route::get('add', 'create')->name('add');
                     Route::post('add', 'store')->name('add');
 
@@ -462,7 +463,7 @@ ROute::middleware('forcedomain')->group(function () {
                     Route::post('album/{event}/link', 'linkAlbum')->name('linkalbum');
                     Route::get('album/unlink/{album}', 'unlinkAlbum')->name('unlinkalbum');
 
-                    Route::prefix('categories')->name('category::')->group(function(){
+                    Route::prefix('categories')->name('category::')->group(function () {
                         Route::get('admin', 'categoryAdmin')->name('admin');
                         Route::post('add', 'categoryStore')->name('add');
                         Route::post('edit/{id}', 'categoryUpdate')->name('edit');
@@ -470,17 +471,17 @@ ROute::middleware('forcedomain')->group(function () {
                     });
                 });
 
-                Route::prefix('financial')->name('financial::')->middleware('permission:finadmin')->group(function(){
+                Route::prefix('financial')->name('financial::')->middleware('permission:finadmin')->group(function () {
                     Route::get('', 'finindex')->name('list');
                     Route::post('close/{id}', 'finclose')->name('close');
                 });
             });
         });
         // Related to participation
-        Route::controller(ParticipationController::class)->middleware('auth')->group(function(){
+        Route::controller(ParticipationController::class)->middleware('auth')->group(function () {
             Route::get('unparticipate/{participation_id}', 'destroy')->name('deleteparticipation');
 
-            Route::middleware('member')->group(function(){
+            Route::middleware('member')->group(function () {
                 Route::get('participate/{id}', 'create')->name('addparticipation');
                 Route::get('togglepresence/{id}', 'togglePresence')->name('togglepresence');
             });
@@ -488,11 +489,11 @@ ROute::middleware('forcedomain')->group(function () {
             Route::post('participatefor/{id}', 'createFor')->name('addparticipationfor')->middleware('permission:board');
         });
 
-        Route::controller(ActivityController::class)->group(function(){
+        Route::controller(ActivityController::class)->group(function () {
 
             Route::get('checklist/{id}','checklist')->name('checklist');
 
-            Route::middleware('permission:board')->group(function(){
+            Route::middleware('permission:board')->group(function () {
                 // Related to activities
                 Route::get('signup/{id}', 'store')->name('addsignup');
                 Route::get('signup/{id}/delete', 'destroy')->name('deletesignup');
@@ -509,9 +510,9 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to the newsletter */
-    Route::prefix('newsletter')->name('newsletter::')->middleware('auth')->controller(NewsController::class)->group(function(){
+    Route::prefix('newsletter')->name('newsletter::')->middleware('auth')->controller(NewsController::class)->group(function () {
         Route::get('', 'newsletterPreview')->name('preview');
-        Route::middleware('permission:board')->group(function(){
+        Route::middleware('permission:board')->group(function () {
             Route::get('content', 'getInNewsletter')->name('show');
             Route::get('toggle/{id}', 'toggleInNewsletter')->name('toggle');
             Route::post('send', 'sendNewsletter')->name('send');
@@ -520,16 +521,16 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to pages. */
-    Route::prefix('page')->name('page::')->controller(PageController::class)->group(function(){
+    Route::prefix('page')->name('page::')->controller(PageController::class)->group(function () {
         Route::get('{slug}', 'show')->name('show');
 
-        Route::middleware(['auth','permission:board'])->group(function(){
+        Route::middleware(['auth', 'permission:board'])->group(function () {
             Route::get('', 'index')->name('list');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
             Route::get('delete/{id}', 'destroy')->name('delete');
 
-            Route::prefix('/edit/{id}')->group(function(){
+            Route::prefix('/edit/{id}')->group(function () {
                 Route::get('', 'edit')->name('edit');
                 Route::post('', 'update')->name('edit');
                 Route::post('image', 'featuredImage')->name('image');
@@ -541,11 +542,11 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to news. */
-    Route::prefix('news')->name('news::')->controller(NewsController::class)->group(function(){
+    Route::prefix('news')->name('news::')->controller(NewsController::class)->group(function () {
         Route::get('', 'index')->name('list');
         Route::get('{id}', 'show')->name('show');
 
-        Route::middleware(['auth', 'permission:board'])->group(function(){
+        Route::middleware(['auth', 'permission:board'])->group(function () {
             Route::get('admin', 'admin')->name('admin');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
@@ -553,7 +554,7 @@ ROute::middleware('forcedomain')->group(function () {
             Route::post('edit/{id}', 'update')->name('edit');
             Route::get('delete/{id}', 'destroy')->name('delete');
 
-            Route::prefix('edit/{id}')->group(function(){
+            Route::prefix('edit/{id}')->group(function () {
                 Route::get('', 'edit')->name('edit');
                 Route::post('', 'update')->name('edit');
                 Route::post('image', 'featuredImage')->name('image');
@@ -561,7 +562,7 @@ ROute::middleware('forcedomain')->group(function () {
         });
     });
     /* Routes related to menu. */
-    Route::prefix('menu')->name('menu::')->middleware(['auth', 'permission:board'])->controller(MenuController::class)->group(function(){
+    Route::prefix('menu')->name('menu::')->middleware(['auth', 'permission:board'])->controller(MenuController::class)->group(function () {
         Route::get('', 'index')->name('list');
         Route::get('add', 'create')->name('add');
         Route::post('add', 'store')->name('add');
@@ -575,13 +576,13 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to tickets. */
-    Route::prefix('tickets')->name('tickets::')->middleware(['auth'])->controller(TicketController::class)->group(function(){
+    Route::prefix('tickets')->name('tickets::')->middleware(['auth'])->controller(TicketController::class)->group(function () {
 
         Route::get('scan/{barcode}', 'scan')->name('scan');
         Route::get('unscan/{barcode?}', 'unscan')->name('unscan');
         Route::get('download/{id}','download')->name('download');
 
-        Route::middleware(['auth', 'permission:board'])->group(function(){
+        Route::middleware(['auth', 'permission:board'])->group(function () {
             Route::get('', 'index')->name('list');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
@@ -596,9 +597,9 @@ ROute::middleware('forcedomain')->group(function () {
 
     Route::get('unsubscribe/{hash}', [EmailListController::class, 'unsubscribeLink'])->name('unsubscribefromlist');
 
-    Route::prefix('email')->name('email::')->middleware(['auth', 'permission:board'])->group(function(){
+    Route::prefix('email')->name('email::')->middleware(['auth', 'permission:board'])->group(function () {
 
-        Route::controller(EmailController::class)->group(function(){
+        Route::controller(EmailController::class)->group(function () {
             Route::get('', 'index')->name('admin');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
@@ -608,13 +609,13 @@ ROute::middleware('forcedomain')->group(function () {
             Route::get('toggleready/{id}', 'toggleReady')->name('toggleready');
             Route::get('delete/{id}', 'destroy')->name('delete');
 
-            Route::prefix('{id}/attachment')->name('attachment::')->group(function(){
+            Route::prefix('{id}/attachment')->name('attachment::')->group(function () {
                 Route::post('add', 'addAttachment')->name('add');
                 Route::get('delete/{file_id}', 'deleteAttachment')->name('delete');
             });
         });
 
-        Route::prefix('list')->name('list::')->controller(EmaillistController::class)->group(function(){
+        Route::prefix('list')->name('list::')->controller(EmaillistController::class)->group(function () {
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
             Route::get('edit/{id}', 'edit')->name('edit');
@@ -624,7 +625,7 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to the Quote Corner. */
-    Route::prefix('quotes')->name('quotes::')->middleware(['member'])->controller(QuoteCornerController::class)->group(function(){
+    Route::prefix('quotes')->name('quotes::')->middleware(['member'])->controller(QuoteCornerController::class)->group(function () {
         Route::get('', 'overview')->name('list');
         Route::post('add', 'add')->name('add');
         Route::get('delete/{id}', 'destroy')->name('delete');
@@ -633,7 +634,7 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to the Good Idea Board. */
-    Route::prefix('goodideas')->name('goodideas::')->middleware(['member'])->controller(GoodIdeaController::class)->group(function(){
+    Route::prefix('goodideas')->name('goodideas::')->middleware(['member'])->controller(GoodIdeaController::class)->group(function () {
         Route::get('', 'index')->name('index');
         Route::post('add', 'add')->name('add');
         Route::get('delete/{id}', 'delete')->name('delete');
@@ -642,12 +643,12 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to the OmNomCom. */
-    Route::prefix('omnomcom')->name('omnomcom::')->group(function(){
+    Route::prefix('omnomcom')->name('omnomcom::')->group(function () {
         Route::get('minisite', [OmNomController::class, 'miniSite'])->name('minisite');
 
         /* Routes related to OmNomCom stores. */
-        Route::prefix('store')->name('store::')->group(function(){
-            Route::controller(OmNomController::class)->group(function(){
+        Route::prefix('store')->name('store::')->group(function () {
+            Route::controller(OmNomController::class)->group(function () {
                 Route::get('', 'choose')->name('choose')->middleware(['auth']);
                 Route::get('{store?}', 'display')->name('show');
                 Route::post('{store}/buy', 'buy')->name('buy');
@@ -657,10 +658,10 @@ ROute::middleware('forcedomain')->group(function () {
         });
 
         /* Routes related to OmNomCom orders. */
-        Route::prefix('orders')->name('orders::')->middleware(['auth'])->controller(OrderLineController::class)->group(function(){
+        Route::prefix('orders')->name('orders::')->middleware(['auth'])->controller(OrderLineController::class)->group(function () {
             Route::get('history/{date?}', 'index')->name('list');
 
-            Route::middleware(['permission:omnomcom'])->group(function(){
+            Route::middleware(['permission:omnomcom'])->group(function () {
                 Route::post('add/bulk', 'bulkStore')->name('addbulk');
                 Route::post('add/single', 'store')->name('add');
                 Route::get('delete/{id}', 'destroy')->name('delete');
@@ -668,19 +669,19 @@ ROute::middleware('forcedomain')->group(function () {
             });
 
 
-            Route::prefix('filter')->name('filter::')->middleware(['permission:omnomcom'])->group(function(){
+            Route::prefix('filter')->name('filter::')->middleware(['permission:omnomcom'])->group(function () {
                 Route::get('name/{name?}', 'filterByUser')->name('name');
                 Route::get('date/{date?}', 'filterByDate')->name('date');
             });
         });
 
         /* Routes related to the TIPCie OmNomCom store. */
-        Route::prefix('tipcie')->name('tipcie::')->middleware(['auth', 'permission:tipcie'])->group(function(){
+        Route::prefix('tipcie')->name('tipcie::')->middleware(['auth', 'permission:tipcie'])->group(function () {
             Route::get('', [TIPCieController::class, 'orderIndex'])->name('orderhistory');
         });
 
         /* Routes related to Financial Accounts. */
-        Route::prefix('accounts')->name('accounts::')->middleware(['permission:finadmin'])->controller(AccountController::class)->group(function(){
+        Route::prefix('accounts')->name('accounts::')->middleware(['permission:finadmin'])->controller(AccountController::class)->group(function () {
             Route::get('', 'index')->name('list');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
@@ -692,14 +693,14 @@ ROute::middleware('forcedomain')->group(function () {
         });
 
         /* Routes related to Payment Statistics. */
-        Route::prefix('payments')->name('payments::')->middleware(['permission:finadmin'])->controller(OrderLineController::class)->group(function(){
+        Route::prefix('payments')->name('payments::')->middleware(['permission:finadmin'])->controller(OrderLineController::class)->group(function () {
             Route::get('statistics', 'showPaymentStatistics')->name('statistics');
             Route::post('statistics', 'showPaymentStatistics')->name('statistics');
         });
 
         /* Routes related to Products. */
-        Route::prefix('products')->name('products::')->middleware(['permission:omnomcom'])->group(function(){
-            Route::controller(ProductController::class)->group(function(){
+        Route::prefix('products')->name('products::')->middleware(['permission:omnomcom'])->group(function () {
+            Route::controller(ProductController::class)->group(function () {
                 Route::get('', 'index')->name('list');
                 Route::get('add', 'create')->name('add');
                 Route::post('add', 'store')->name('add');
@@ -710,14 +711,14 @@ ROute::middleware('forcedomain')->group(function () {
                 Route::get('export/csv', 'generateCsv')->name('export_csv');
                 Route::post('update/bulk', 'bulkUpdate')->name('bulkupdate');
             });
-            Route::controller(AccountController::class)->group(function(){
+            Route::controller(AccountController::class)->group(function () {
                 Route::get('statistics', 'showOmnomcomStatistics')->name('statistics');
                 Route::post('statistics', 'showOmnomcomStatistics')->name('statistics');
             });
         });
 
         /* Routes related to OmNomCom Categories. */
-        Route::prefix('categories')->name('categories::')->middleware(['permission:omnomcom'])->controller(ProductCategoryController::class)->group(function(){
+        Route::prefix('categories')->name('categories::')->middleware(['permission:omnomcom'])->controller(ProductCategoryController::class)->group(function () {
                 Route::get('', 'index')->name('list');
                 Route::get('add', 'create')->name('add');
                 Route::post('add', 'store')->name('add');
@@ -727,7 +728,7 @@ ROute::middleware('forcedomain')->group(function () {
         });
 
         /* Routes related to Withdrawals. */
-        Route::prefix('withdrawals')->name('withdrawal::')->middleware(['permission:finadmin'])->controller(WithdrawalController::class)->group(function(){
+        Route::prefix('withdrawals')->name('withdrawal::')->middleware(['permission:finadmin'])->controller(WithdrawalController::class)->group(function () {
             Route::get('', 'index')->name('list');
             Route::get('add', 'create')->name('add');
             Route::post('add', 'store')->name('add');
@@ -748,11 +749,11 @@ ROute::middleware('forcedomain')->group(function () {
         Route::get('unwithdrawable', [WithdrawalController::class, 'unwithdrawable'])->name('unwithdrawable')->middleware(['permission:finadmin']);
 
         /* Routes related to Mollie. */
-        Route::prefix('mollie')->name('mollie::')->middleware(['auth'])->controller(MollieController::class)->group(function(){
+        Route::prefix('mollie')->name('mollie::')->middleware(['auth'])->controller(MollieController::class)->group(function () {
             Route::post('pay', 'pay')->name('pay');
             Route::get('status/{id}', 'status')->name('status');
             Route::get('receive/{id}', 'receive')->name('receive');
-            Route::middleware(['permission:finadmin'])->group(function(){
+            Route::middleware(['permission:finadmin'])->group(function () {
                 Route::get('list', 'index')->name('list');
                 Route::get('monthly/{month}', 'monthly')->name('monthly');
             });
@@ -796,8 +797,8 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to photos. */
-    Route::prefix('photos')->name('photo::')->group(function(){
-        Route::controller(PhotoController::class)->group(function() {
+    Route::prefix('photos')->name('photo::')->group(function () {
+        Route::controller(PhotoController::class)->group(function () {
             Route::get('', 'index')->name('albums');
             Route::get('slideshow', 'slideshow')->name('slideshow');
 
@@ -810,14 +811,14 @@ ROute::middleware('forcedomain')->group(function () {
             Route::get('photo/{id}', 'photo')->name('view');
         });
 
-        Route::prefix('admin')->name('admin::')->middleware(['permission:protography'])->controller(PhotoAdminController::class)->group(function(){
+        Route::prefix('admin')->name('admin::')->middleware(['permission:protography'])->controller(PhotoAdminController::class)->group(function () {
             Route::get('index', 'index')->name('index');
             Route::post('index', 'search')->name('index');
             Route::post('add', 'create')->name('add');
             Route::get('edit/{id}', 'edit')->name('edit');
             Route::post('edit/{id}/action', 'action')->name('action');
             Route::post('edit/{id}/upload', 'upload')->name('upload');
-            Route::middleware(['permission:publishalbums'])->group(function(){
+            Route::middleware(['permission:publishalbums'])->group(function () {
                 Route::post('edit/{id}', 'update')->name('edit');
                 Route::get('edit/{id}/delete', 'delete')->name('delete');
                 Route::get('publish/{id}', 'publish')->name('publish');
@@ -866,20 +867,20 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* The route for the SmartXp Screen. */
-    Route::controller(SmartXPScreenController::class)->group(function(){
+    Route::controller(SmartXPScreenController::class)->group(function () {
         Route::get('smartxp','show')->name('smartxp');
         Route::get('caniworkinthesmartxp', 'canWork');
     });
 
     /* The routes for Protube. */
-    Route::prefix('protube')->name('protube::')->group(function(){
-        Route::controller(ProtubeController::class)->group(function(){
+    Route::prefix('protube')->name('protube::')->group(function () {
+        Route::controller(ProtubeController::class)->group(function () {
             Route::get('screen', 'screen')->name('screen');
             Route::get('offline', 'offline')->name('offline');
             Route::get('top', 'top')->name('top');
             Route::get('{id?}', 'remote')->name('remote');
 
-            Route::middleware('auth')->group(function(){
+            Route::middleware('auth')->group(function () {
                 Route::get('admin', 'admin')->name('admin');
                 Route::get('dashboard', 'dashboard')->name('dashboard');
                 Route::get('togglehistory', 'toggleHistory')->name('togglehistory');
@@ -888,14 +889,14 @@ ROute::middleware('forcedomain')->group(function () {
             });
         });
         /* Routes related to the Protube Radio */
-        Route::prefix('radio')->name('radio::')->middleware(['auth', 'permission:sysadmin'])->controller(RadioController::class)->group(function(){
+        Route::prefix('radio')->name('radio::')->middleware(['auth', 'permission:sysadmin'])->controller(RadioController::class)->group(function () {
             Route::get('index', 'index')->name('index');
             Route::post('store', 'store')->name('store');
             Route::get('delete/{id}', 'destroy')->name('delete');
         });
 
         /* Routes related to the Protube displays */
-        Route::prefix('display')->name('display::')->middleware(['permission:sysadmin'])->controller(DisplayController::class)->group(function(){
+        Route::prefix('display')->name('display::')->middleware(['permission:sysadmin'])->controller(DisplayController::class)->group(function () {
             Route::get('index', 'index')->name('index');
             Route::post('store', 'store')->name('store');
             Route::post('update/{id}', 'update')->name('update');
@@ -903,7 +904,7 @@ ROute::middleware('forcedomain')->group(function () {
         });
 
         /* Routes related to the Soundboard */
-        Route::prefix('soundboard')->name('soundboard::')->middleware(['permission:sysadmin'])->controller(SoundboardController::class)->group(function(){
+        Route::prefix('soundboard')->name('soundboard::')->middleware(['permission:sysadmin'])->controller(SoundboardController::class)->group(function () {
             Route::get('index', 'index')->name('index');
             Route::post('store', 'store')->name('store');
             Route::get('delete/{id}', 'destroy')->name('delete');
@@ -917,9 +918,9 @@ ROute::middleware('forcedomain')->group(function () {
     });
 
     /* Routes related to the Achievement system. */
-    Route::controller(AchievementController::class)->group(function(){
+    Route::controller(AchievementController::class)->group(function () {
         Route::prefix('achievement')->name('achievement::')->group(function () {
-            Route::middleware(['auth', 'permission:board'])->group(function(){
+            Route::middleware(['auth', 'permission:board'])->group(function () {
                 Route::get('', 'overview')->name('list');
                 Route::get('add', 'create')->name('add');
                 Route::post('add', 'store')->name('add');
@@ -968,7 +969,7 @@ ROute::middleware('forcedomain')->group(function () {
 
     /* Routes related to the Short URL Service */
     Route::name('short_url::')->controller(ShortUrlController::class)->group(function () {
-        Route::prefix('short_url')->middleware(['auth', 'permission:board'])->group(function (){
+        Route::prefix('short_url')->middleware(['auth', 'permission:board'])->group(function () {
             Route::get('', 'index')->name('index');
             Route::get('edit/{id}', 'edit')->name('edit');
             Route::post('edit/{id}', 'update')->name('edit');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,67 @@
 <?php
-
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
+use Proto\Http\Controllers\AccountController;
+use Proto\Http\Controllers\AchievementController;
+use Proto\Http\Controllers\ActivityController;
+use Proto\Http\Controllers\AddressController;
+use Proto\Http\Controllers\AliasController;
+use Proto\Http\Controllers\AnnouncementController;
+use Proto\Http\Controllers\AuthController;
+use Proto\Http\Controllers\AuthorizationController;
+use Proto\Http\Controllers\BankController;
+use Proto\Http\Controllers\CommitteeController;
+use Proto\Http\Controllers\CompanyController;
+use Proto\Http\Controllers\DinnerformController;
+use Proto\Http\Controllers\DisplayController;
+use Proto\Http\Controllers\DmxController;
+use Proto\Http\Controllers\EmailController;
+use Proto\Http\Controllers\EmailListController;
+use Proto\Http\Controllers\EventController;
+use Proto\Http\Controllers\FileController;
+use Proto\Http\Controllers\GoodIdeaController;
+use Proto\Http\Controllers\HeaderImageController;
+use Proto\Http\Controllers\HomeController;
+use Proto\Http\Controllers\IsAlfredThereController;
+use Proto\Http\Controllers\JobofferController;
+use Proto\Http\Controllers\LeaderboardController;
+use Proto\Http\Controllers\MemberCardController;
+use Proto\Http\Controllers\MenuController;
+use Proto\Http\Controllers\MollieController;
+use Proto\Http\Controllers\NarrowcastingController;
+use Proto\Http\Controllers\NewsController;
+use Proto\Http\Controllers\OmNomController;
+use Proto\Http\Controllers\OrderLineController;
+use Proto\Http\Controllers\PageController;
+use Proto\Http\Controllers\ParticipationController;
+use Proto\Http\Controllers\PasswordController;
+use Proto\Http\Controllers\PhotoAdminController;
+use Proto\Http\Controllers\PhotoController;
+use Proto\Http\Controllers\ProductCategoryController;
+use Proto\Http\Controllers\ProductController;
+use Proto\Http\Controllers\ProfilePictureController;
+use Proto\Http\Controllers\ProtubeController;
+use Proto\Http\Controllers\QrAuthController;
+use Proto\Http\Controllers\QueryController;
+use Proto\Http\Controllers\QuoteCornerController;
+use Proto\Http\Controllers\RadioController;
+use Proto\Http\Controllers\RegistrationHelperController;
+use Proto\Http\Controllers\RfidCardController;
+use Proto\Http\Controllers\SearchController;
+use Proto\Http\Controllers\ShortUrlController;
+use Proto\Http\Controllers\SoundboardController;
+use Proto\Http\Controllers\SpotifyController;
+use Proto\Http\Controllers\SurfConextController;
+use Proto\Http\Controllers\TempAdminController;
+use Proto\Http\Controllers\TFAController;
+use Proto\Http\Controllers\TicketController;
+use Proto\Http\Controllers\TIPCieController;
+use Proto\Http\Controllers\UserAdminController;
+use Proto\Http\Controllers\UserProfileController;
+use Proto\Http\Controllers\UserDashboardController;
+use Proto\Http\Controllers\VideoController;
+use Proto\Http\Controllers\WelcomeController;
+use Proto\Http\Controllers\WithdrawalController;
 
 require 'minisites.php';
 
@@ -12,851 +72,947 @@ View::composer('*', function ($view) {
 
 // TODO: change string based controller route definitions to standard PHP callable syntax.
 
-Route::group(['middleware' => ['forcedomain']], function () {
+ROute::middleware('forcedomain')->group(function () {
 
     /* The main route for the frontpage. */
-    Route::get('', ['as' => 'homepage', 'uses' => 'HomeController@show']);
-    Route::get('developers', ['uses' => 'HomeController@developers']);
-    Route::get('becomeamember', ['as' => 'becomeamember', 'uses' => 'UserDashboardController@becomeAMemberOf']);
 
-    Route::get('fishcam', ['as' => 'fishcam', 'middleware' => ['member'], 'uses' => 'HomeController@fishcam']);
+    Route::controller(HomeController::class)->group(function(){
+        Route::get('', 'show')->name('homepage');
+        Route::get('developers', 'developers')->name('developers');
+        Route::get('fishcam', function(){
+            return view('misc.fishcam');
+        })->middleware('member')->name('fishcam');
+    });
+
+    Route::get('becomeamember', [UserDashboardController::class, 'becomeAMemberOf']);
 
     /* Routes related to the header images. */
-    Route::group(['prefix' => 'headerimage', 'middleware' => ['auth', 'permission:header-image'], 'as' => 'headerimage::'], function () {
-        Route::get('', ['as' => 'index', 'uses' => 'HeaderImageController@index']);
-        Route::get('add', ['as' => 'add', 'uses' => 'HeaderImageController@create']);
-        Route::post('add', ['as' => 'add', 'uses' => 'HeaderImageController@store']);
-        Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'HeaderImageController@destroy']);
+    Route::prefix('headerimage')->name('headerimage::')->controller(HeaderImageController::class)->middleware(['auth', 'permission:header-image'])->group(function(){
+        Route::get('', 'index')->name('index');
+        Route::get('add', 'create')->name('add');
+        Route::post('add', 'store')->name('add');
+        Route::get('delete/{id}', 'destroy')->name('delete');
     });
 
     /* Routes for the search function. */
-    Route::get('search', ['as' => 'search', 'uses' => 'SearchController@search']);
-    Route::post('search', ['as' => 'search', 'uses' => 'SearchController@search']);
-    Route::get('opensearch', ['as' => 'search::opensearch', 'uses' => 'SearchController@openSearch']);
+    Route::controller(SearchController::class)->group(function(){
+        Route::get('search','search')->name('search');
+        Route::post('search', 'search')->name('search');
+        Route::get('opensearch', 'openSearch')->name('search::opensearch');
 
-    /* Routes for the UTwente address book. */
-    Route::group(['prefix' => 'ldap', 'as' => 'ldap::', 'middleware' => ['utwente']], function () {
-        Route::get('search', ['as' => 'search', 'uses' => 'SearchController@ldapSearch']);
-        Route::post('search', ['as' => 'search', 'uses' => 'SearchController@ldapSearch']);
+        /* Routes for the UTwente address book. */
+        Route::prefix('ldap')->name('ldap::')->middleware('utwente')->group(function () {
+            Route::get('search','ldapSearch')->name('search');
+            Route::post('search', 'ldapSearch')->name('search');
+        });
     });
 
     /* Routes related to authentication. */
-    Route::group(['as' => 'login::'], function () {
-        Route::get('login', ['as' => 'show', 'uses' => 'AuthController@getLogin']);
-        Route::post('login', ['as' => 'post', 'middleware' => ['throttle:5,1'], 'uses' => 'AuthController@postLogin']);
-        Route::get('logout', ['as' => 'logout', 'uses' => 'AuthController@getLogout']);
-        Route::get('logout/redirect', ['as' => 'logout::redirect', 'uses' => 'AuthController@getLogoutRedirect']);
+    Route::name('login::')->controller(AuthController::class)->group(function () {
+        Route::get('login', 'getLogin')->name('show');
+        Route::post('login', 'postLogin')->name('post')->middleware('throttle:5,1');
 
-        Route::get('password/reset/{token}', ['as' => 'resetpass::token', 'uses' => 'AuthController@getPasswordReset']);
-        Route::post('password/reset', ['as' => 'resetpass::submit', 'middleware' => ['throttle:5,1'], 'uses' => 'AuthController@postPasswordReset']);
+        Route::prefix('logout')->group(function(){
+            Route::get('', 'getLogout')->name('logout');
+            Route::get('redirect', 'getLogoutRedirect')->name('logout::redirect');
+        });
 
-        Route::get('password/email', ['as' => 'resetpass', 'uses' => 'AuthController@getPasswordResetEmail']);
-        Route::post('password/email', ['as' => 'resetpass::send', 'middleware' => ['throttle:5,1'], 'uses' => 'AuthController@postPasswordResetEmail']);
+        Route::prefix('password')->group(function(){
+            Route::get('reset/{token}', 'getPasswordReset')->name('resetpass::token');
+            Route::post('reset', 'postPasswordReset')->name('resetpass::submit')->middleware('throttle:5,1');
 
-        Route::get('password/sync', ['as' => 'password::sync', 'middleware' => ['auth'], 'uses' => 'AuthController@getPasswordSync']);
-        Route::post('password/sync', ['as' => 'password::sync', 'middleware' => ['throttle:5,1', 'auth'], 'uses' => 'AuthController@postPasswordSync']);
+            Route::get('email', 'getPasswordResetEmail')->name('resetpass');
+            Route::post('email', 'postPasswordResetEmail')->name('resetpass::send')->middleware('throttle:5,1');
 
-        Route::get('password/change', ['as' => 'password::change', 'middleware' => ['auth'], 'uses' => 'AuthController@getPasswordChange']);
-        Route::post('password/change', ['as' => 'password::change', 'middleware' => ['throttle:5,1', 'auth'], 'uses' => 'AuthController@postPasswordChange']);
+            Route::middleware('auth')->group(function(){
+                Route::get('sync', 'getPasswordSync')->name('password::sync');
+                Route::post('sync', 'postPasswordSync')->name('password::sync')->middleware('throttle:5,1');
 
-        Route::get('register', ['as' => 'register', 'uses' => 'AuthController@getRegister']);
-        Route::post('register', ['as' => 'register', 'middleware' => ['throttle:5,1'], 'uses' => 'AuthController@postRegister']);
-        Route::post('register/surfconext', ['as' => 'register::surfconext', 'middleware' => ['throttle:5,1'], 'uses' => 'AuthController@postRegisterSurfConext']);
+                Route::get('change', 'getPasswordChange')->name('password::change');
+                Route::post('change', 'postPasswordChange')->name('password::change')->middleware('throttle:5,1');
+            });
 
-        Route::get('surfconext', ['as' => 'edu', 'uses' => 'AuthController@startSurfConextAuth']);
-        Route::get('surfconext/post', ['as' => 'edupost', 'uses' => 'AuthController@postSurfConextAuth']);
+            Route::prefix('register')->group(function(){
+                Route::get('', 'getRegister')->name('register');
+                Route::post('', 'postRegister')->name('register')->middleware('throttle:5,1');
+                Route::post('surfconext', 'postRegisterSurfConext')->name('register::surfconext')->middleware('throttle:5,1');
+            });
 
-        Route::get('username', ['as' => 'requestusername', 'uses' => 'AuthController@requestUsername']);
-        Route::post('username', ['as' => 'requestusername', 'middleware' => ['throttle:5,1'], 'uses' => 'AuthController@requestUsername']);
+            Route::prefix('surfconext')->group(function(){
+                Route::get('', 'startSurfConextAuth')->name('edu');
+                Route::get('post', 'postSurfConextAuth')->name('edupost');
+
+                Route::prefix('username')->group(function() {
+                    Route::get('', 'requestUsername')->name('requestusername');
+                    Route::post('', 'requestUsername')->name('requestusername')->middleware('throttle:5,1');
+                });
+            });
+        });
     });
 
     /* Routes related to user profiles. */
-    Route::group(['prefix' => 'user', 'as' => 'user::', 'middleware' => ['auth']], function () {
-        Route::post('delete', ['as' => 'delete', 'uses' => 'AuthController@deleteUser']);
-        Route::post('password', ['as' => 'changepassword', 'uses' => 'AuthController@updatePassword']);
+    Route::prefix('user')->name('user::')->middleware('auth')->group(function(){
+        Route::controller(AuthController::class)->group(function(){
+            Route::post('delete', 'deleteUser')->name('delete');
+            Route::post('password', 'updatePassword')->name('changepassword');
+        });
 
-        Route::get('personal_key', ['as' => 'personal_key::generate', 'uses' => 'UserDashboardController@generateKey']);
+        Route::get('{id?}', [UserProfileController::class, 'show'])->name('profile')->middleware('member');
 
-        /* Routes related to members. */
-        Route::group(['prefix' => '{id}/member', 'as' => 'member::', 'middleware' => ['auth', 'permission:registermembers']], function () {
-            Route::get('impersonate', ['as' => 'impersonate', 'middleware' => ['auth', 'permission:board'], 'uses' => 'UserAdminController@impersonate']);
+        Route::controller(UserAdminController::class)->group(function(){
+            Route::get('quit_impersonating', 'quitImpersonating')->name('quitimpersonating');
 
-            Route::post('add', ['as' => 'add', 'uses' => 'UserAdminController@addMembership']);
-            Route::post('remove', ['as' => 'remove', 'uses' => 'UserAdminController@endMembership']);
-            Route::post('end_in_september', ['as' => 'endinseptember', 'uses' => 'UserAdminController@EndMembershipInSeptember']);
-            Route::post('remove_end', ['as' => 'removeend', 'uses' => 'UserAdminController@removeMembershipEnd']);
-            Route::post('settype', ['as' => 'settype', 'uses' => 'UserAdminController@setMembershipType']);
+            /* Routes related to members. */
+            Route::name('member::')->prefix('{id}/member')->middleware('permission:registermembers')->group(function(){
+                Route::get('impersonate', 'impersonate')->name('impersonate')->middleware('permission:board');
+                Route::post('add', 'addMembership')->name('add');
+                Route::post('remove', 'endMembership')->name('remove');
+                Route::post('end_in_september', 'EndMembershipInSeptember')->name('endinseptember');
+                Route::post('remove_end', 'removeMembershipEnd')->name('removeend');
+                Route::post('settype', 'setMembershipType')->name('settype');
 
-            /* Routes related to the custom omnomcom sound. */
-            Route::group(['prefix' => 'omnomcomsound', 'as' => 'omnomcomsound::', 'middleware' => ['auth', 'permission:board']], function () {
-                Route::post('update', ['as' => 'update', 'uses' => 'UserAdminController@uploadOmnomcomSound']);
-                Route::get('delete', ['as' => 'delete', 'uses' => 'UserAdminController@deleteOmnomcomSound']);
+                /* Routes related to the custom omnomcom sound. */
+                Route::prefix('omnomcomsound')->name('omnomcomsound::')->middleware('permission:board')->group(function(){
+                    Route::post('update', 'uploadOmnomcomSound')->name('update');
+                    Route::get('delete', 'deleteOmnomcomSound')->name('delete');
+                });
+            });
+
+            Route::prefix('admin')->name('admin::')->middleware('permission:board')->group(function(){
+                Route::get('','index')->name('list');
+                Route::get('{id}', 'details')->name('details');
+                Route::post('{id}', 'update')->name('update');
+
+                Route::get('studied_create/{id}', 'toggleStudiedCreate')->name('toggle_studied_create');
+                Route::get('studied_itech/{id}', 'toggleStudiedITech')->name('toggle_studied_itech');
+                Route::get('nda/{id}', 'toggleNda')->name('toggle_nda');
+                Route::get('unblock_omnomcom/{id}', 'unblockOmnomcom')->name('unblock_omnomcom');
             });
         });
 
-        Route::group(['prefix' => 'memberprofile', 'as' => 'memberprofile::', 'middleware' => ['auth']], function () {
-            Route::get('complete', ['as' => 'complete', 'uses' => 'UserDashboardController@getCompleteProfile']);
-            Route::post('complete', ['as' => 'complete', 'uses' => 'UserDashboardController@postCompleteProfile']);
-            Route::get('clear', ['as' => 'clear', 'uses' => 'UserDashboardController@getClearProfile']);
-            Route::post('clear', ['as' => 'clear', 'uses' => 'UserDashboardController@postClearProfile']);
+        Route::controller(UserDashboardController::class)->group(function() {
+            Route::get('personal_key', 'generateKey')->name('personal_key::generate');
+            Route::get('dashboard', 'show')->name('dashboard');
+            Route::post('dashboard', 'update')->name('dashboard');
+            Route::post('change_email', 'updateMail')->name('changemail')->middleware('throttle:3,1');
+
+            /* Routes related to the memberprofiles */
+            Route::prefix('memberprofile')->name('memberprofile::')->group(function(){
+                Route::prefix('complete')->group(function(){
+                    Route::get('', 'getCompleteProfile')->name('complete');
+                    Route::post('', 'postCompleteProfile')->name('complete');
+                });
+                Route::prefix('clear')->group(function(){
+                    Route::get('', 'getClearProfile')->name('clear');
+                    Route::post('', 'postClearProfile')->name('clear');
+                });
+            });
+
+            /* Routes related to diet. */
+            Route::prefix('diet')->name('diet::')->group( function () {
+                Route::post('edit', 'editDiet')->name('edit');
+            });
         });
 
-        Route::group(['prefix' => 'admin', 'as' => 'admin::', 'middleware' => ['auth', 'permission:board']], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'UserAdminController@index']);
-            Route::get('{id}', ['as' => 'details', 'uses' => 'UserAdminController@details']);
-            Route::post('{id}', ['as' => 'update', 'uses' => 'UserAdminController@update']);
-
-            Route::get('studied_create/{id}', ['as' => 'toggle_studied_create', 'uses' => 'UserAdminController@toggleStudiedCreate']);
-            Route::get('studied_itech/{id}', ['as' => 'toggle_studied_itech', 'uses' => 'UserAdminController@toggleStudiedITech']);
-            Route::get('nda/{id}', ['as' => 'toggle_nda', 'middleware' => ['permission:board'], 'uses' => 'UserAdminController@toggleNda']);
-            Route::get('unblock_omnomcom/{id}', ['as' => 'unblock_omnomcom', 'uses' => 'UserAdminController@unblockOmnomcom']);
+        Route::prefix('registrationhelper')->name('registrationhelper::')->middleware('permission:registermembers')->controller(RegistrationHelperController::class)->group(function(){
+            Route::get('', 'index')->name('list');
+            Route::get('{id}', 'details')->name('details');
         });
-
-        Route::group(['prefix' => 'registrationhelper', 'as' => 'registrationhelper::', 'middleware' => ['auth' => 'permission:registermembers']], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'RegistrationHelperController@index']);
-            Route::get('{id}', ['as' => 'details', 'uses' => 'RegistrationHelperController@details']);
-        });
-
-        Route::get('quit_impersonating', ['as' => 'quitimpersonating', 'uses' => 'UserAdminController@quitImpersonating']);
-
-        Route::post('change_email', ['as' => 'changemail', 'middleware' => ['throttle:3,1'], 'uses' => 'UserDashboardController@updateMail']);
-
-        Route::get('dashboard', ['as' => 'dashboard', 'uses' => 'UserDashboardController@show']);
-        Route::post('dashboard', ['as' => 'dashboard', 'uses' => 'UserDashboardController@update']);
-
-        Route::get('{id?}', ['as' => 'profile', 'middleware' => ['member'], 'uses' => 'UserProfileController@show']);
 
         /* Routes related to addresses. */
-        Route::group(['prefix' => 'address', 'as' => 'address::'], function () {
-            Route::get('add', ['as' => 'add', 'uses' => 'AddressController@add']);
-            Route::post('add', ['as' => 'add', 'uses' => 'AddressController@store']);
-            Route::get('delete', ['as' => 'delete', 'uses' => 'AddressController@destroy']);
-            Route::get('edit', ['as' => 'edit', 'uses' => 'AddressController@edit']);
-            Route::post('edit', ['as' => 'edit', 'uses' => 'AddressController@update']);
-            Route::get('togglehidden', ['as' => 'togglehidden', 'uses' => 'AddressController@toggleHidden']);
-        });
-
-        /* Routes related to diet. */
-        Route::group(['prefix' => 'diet', 'as' => 'diet::'], function () {
-            Route::post('edit', ['as' => 'edit', 'uses' => 'UserDashboardController@editDiet']);
+        Route::prefix('address')->name('address::')->controller(AddressController::class)->group(function(){
+            Route::get('add', 'add')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('delete', 'destroy')->name('delete');
+            Route::get('edit', 'edit')->name('edit');
+            Route::post('edit', 'update')->name('edit');
+            Route::get('togglehidden', 'toggleHidden')->name('togglehidden');
         });
 
         /* Routes related to bank accounts. */
-        Route::group(['prefix' => 'bank', 'as' => 'bank::'], function () {
-            Route::get('add', ['as' => 'add', 'uses' => 'BankController@add']);
-            Route::post('add', ['as' => 'add', 'uses' => 'BankController@store']);
-            Route::post('delete', ['as' => 'delete', 'uses' => 'BankController@destroy']);
-            Route::get('edit', ['as' => 'edit', 'uses' => 'BankController@edit']);
-            Route::post('edit', ['as' => 'edit', 'uses' => 'BankController@update']);
+        Route::prefix('bank')->name('bank::')->controller(BankController::class)->group(function(){
+            Route::get('add', 'add')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::post('delete', 'destroy')->name('delete');
+            Route::get('edit', 'edit')->name('edit');
+            Route::post('edit', 'update')->name('edit');
         });
 
         /* Routes related to RFID cards. */
-        Route::group(['prefix' => 'rfidcard/{id}', 'as' => 'rfid::'], function () {
-            Route::get('delete', ['as' => 'delete', 'uses' => 'RfidCardController@destroy']);
-            Route::get('edit', ['as' => 'edit', 'uses' => 'RfidCardController@edit']);
-            Route::post('edit', ['as' => 'edit', 'uses' => 'RfidCardController@update']);
+        Route::prefix('rfidcard/{id}')->name('rfid::')->controller(RFIDCardController::class)->group(function(){
+            Route::get('delete', 'destroy')->name('delete');
+            Route::get('edit', 'edit')->name('edit');
+            Route::post('edit', 'update')->name('edit');
         });
 
         /* Routes related to profile pictures. */
-        Route::group(['prefix' => 'profilepic', 'as' => 'pic::'], function () {
-            Route::post('update', ['as' => 'update', 'uses' => 'ProfilePictureController@update']);
-            Route::get('delete', ['as' => 'delete', 'uses' => 'ProfilePictureController@destroy']);
+        Route::prefix('profilepic')->name('pic::')->controller(ProfilePictureController::class)->group(function(){
+            Route::post('update', 'update')->name('update');
+            Route::get('delete', 'destroy')->name('delete');
         });
 
         /* Routes related to UT accounts. */
-        Route::group(['prefix' => 'edu', 'as' => 'edu::'], function () {
-            Route::get('delete', ['as' => 'delete', 'uses' => 'SurfConextController@destroy']);
-            Route::get('add', ['as' => 'add', 'uses' => 'SurfConextController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'SurfConextController@store']);
+        Route::prefix('edu')->name('edu::')->controller(SurfConextController::class)->group(function(){
+            Route::get('delete', 'destroy')->name('delete');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
         });
 
         /* Routes related to 2FA. */
-        Route::group(['prefix' => '2fa', 'as' => '2fa::'], function () {
-            Route::post('add', ['as' => 'add', 'uses' => 'TFAController@create']);
-            Route::post('delete', ['as' => 'delete', 'uses' => 'TFAController@destroy']);
-            Route::post('delete/{id}', ['as' => 'admindelete', 'middleware' => ['permission:board'], 'uses' => 'TFAController@adminDestroy']);
+        Route::prefix('2fa')->name('2fa::')->controller(TFAController::class)->group(function(){
+            Route::post('add', 'create')->name('add');
+            Route::post('delete', 'destroy')->name('delete');
+            Route::post('delete/{id}', 'adminDestroy')->name('admindelete')->middleware('permission:board');
         });
     });
 
     /* Routes related to the Membership Forms */
-    Route::group(['prefix' => 'memberform', 'as' => 'memberform::', 'middleware' => ['auth']], function () {
-        Route::get('sign', ['as' => 'sign', 'uses' => 'UserDashboardController@getMemberForm']);
-        Route::post('sign', ['as' => 'sign', 'uses' => 'UserDashboardController@postMemberForm']);
-        Route::group(['prefix' => 'download', 'as' => 'download::'], function () {
-            Route::get('new/{id}', ['as' => 'new', 'uses' => 'UserAdminController@getNewMemberForm']);
-            Route::get('signed/{id}', ['as' => 'signed', 'uses' => 'UserAdminController@getSignedMemberForm']);
+    Route::prefix('memberform')->name('memberform::')->middleware('auth')->group(function (){
+        Route::controller(UserAdminController::class)->group(function (){
+            Route::get('sign', 'getMemberForm')->name('sign');
+            Route::post('sign', 'postMemberForm')->name('sign');
         });
-        Route::post('print/{id}', ['as' => 'print', 'middleware' => ['permission:board'], 'uses' => 'UserAdminController@printMemberForm']);
-        Route::post('delete/{id}', ['as' => 'delete', 'middleware' => ['permission:board'], 'uses' => 'UserAdminController@destroyMemberForm']);
+        Route::controller(UserAdminController::class)->group(function(){
+            Route::prefix('download')->name('download::')->group(function(){
+                Route::get('new/{id}', 'getNewMemberForm')->name('new');
+                Route::get('signed/{id}', 'getSignedMemberForm')->name('signed');
+            });
+            Route::post('print/{id}', 'printMemberForm')->name('print')->middleware('permission:board');
+            Route::post('delete/{id}', 'destroyMemberForm')->name('delete')->middleware('permission:board');
+        });
     });
 
     /* Routes related to committees. */
-    Route::group(['prefix' => 'committee', 'as' => 'committee::'], function () {
-        Route::group(['prefix' => 'membership', 'as' => 'membership::', 'middleware' => ['auth', 'permission:board']], function () {
-            Route::post('add', ['as' => 'add', 'uses' => 'CommitteeController@addMembership']);
-            Route::get('{id}/delete', ['as' => 'delete', 'uses' => 'CommitteeController@deleteMembership']);
-            Route::get('{id}', ['as' => 'edit', 'uses' => 'CommitteeController@editMembershipForm']);
-            Route::post('{id}', ['as' => 'edit', 'uses' => 'CommitteeController@editMembership']);
-            Route::get('end/{committee}/{edition}', ['as' => 'endedition', 'uses' => 'CommitteeController@endEdition']);
+    Route::prefix('committee')->name('committee::')->controller(CommitteeController::class)->group(function(){
+
+        Route::get('list', 'overview')->name('list');
+        Route::get('{id}', 'show')->name('show');
+
+        Route::middleware('auth')->group(function(){
+
+            Route::get('{slug}/toggle_helper_reminder', ['as' => 'toggle_helper_reminder', 'middleware' => ['auth'], 'uses' => 'CommitteeController@toggleHelperReminder']);
+
+            Route::middleware('member')->group(function() {
+                Route::get('{id}/send_anonymous_email', ['as' => 'anonymousmail', 'middleware' => ['auth', 'member'], 'uses' => 'CommitteeController@showAnonMailForm']);
+                Route::post('{id}/send_anonymous_email', ['as' => 'anonymousmail', 'middleware' => ['auth', 'member'], 'uses' => 'CommitteeController@postAnonMailForm']);
+            });
+
+            Route::middleware('permission:board')->group(function() {
+
+                Route::get('add', 'add')->name('add');
+                Route::post('add', 'store')->name('add');
+
+                Route::get('{id}/edit', 'edit')->name('edit');
+                Route::post('{id}/edit', 'update')->name('edit');
+
+                Route::post('{id}/image', 'image')->name('image');
+
+                Route::prefix('membership')->name('membership::')->group(function () {
+                    Route::post('add', 'addMembership')->name('add');
+                    Route::get('{id}/delete', 'deleteMembership')->name('delete');
+                    Route::get('{id}', 'editMembershipForm')->name('edit');
+                    Route::post('{id}', 'editMembership')->name('edit');
+                    Route::get('end/{committee}/{edition}', 'endEdition')->name('endedition');
+                });
+            });
         });
-
-        Route::get('list', ['as' => 'list', 'uses' => 'CommitteeController@overview']);
-
-        Route::get('add', ['as' => 'add', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CommitteeController@add']);
-        Route::post('add', ['as' => 'add', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CommitteeController@store']);
-
-        Route::get('{id}', ['as' => 'show', 'uses' => 'CommitteeController@show']);
-
-        Route::get('{id}/send_anonymous_email', ['as' => 'anonymousmail', 'middleware' => ['auth', 'member'], 'uses' => 'CommitteeController@showAnonMailForm']);
-        Route::post('{id}/send_anonymous_email', ['as' => 'anonymousmail', 'middleware' => ['auth', 'member'], 'uses' => 'CommitteeController@postAnonMailForm']);
-
-        Route::get('{id}/edit', ['as' => 'edit', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CommitteeController@edit']);
-        Route::post('{id}/edit', ['as' => 'edit', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CommitteeController@update']);
-
-        Route::post('{id}/image', ['as' => 'image', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CommitteeController@image']);
-
-        Route::get('{slug}/toggle_helper_reminder', ['as' => 'toggle_helper_reminder', 'middleware' => ['auth'], 'uses' => 'CommitteeController@toggleHelperReminder']);
     });
 
     /* Routes related to societies. */
-    Route::group(['prefix' => 'society', 'as' => 'society::'], function () {
-        Route::get('list', ['as' => 'list', 'uses' => 'CommitteeController@overview'])->defaults('showSociety', true);
-        Route::get('{id}', ['as' => 'show', 'uses' => 'CommitteeController@show']);
+    Route::prefix('society')->name('society::')->controller(CommitteeController::class)->group(function(){
+        Route::get('list', 'overview')->name('list')->defaults('showSociety', true);
+        Route::get('{id}', 'show')->name('show');
     });
 
     /* Routes related to narrowcasting. */
-    Route::group(['prefix' => 'narrowcasting', 'as' => 'narrowcasting::'], function () {
-        Route::get('', ['as' => 'display', 'uses' => 'NarrowcastingController@display']);
-        Route::get('list', ['as' => 'list', 'middleware' => ['auth', 'permission:board'], 'uses' => 'NarrowcastingController@index']);
-        Route::get('add', ['as' => 'add', 'middleware' => ['auth', 'permission:board'], 'uses' => 'NarrowcastingController@create']);
-        Route::post('add', ['as' => 'add', 'middleware' => ['auth', 'permission:board'], 'uses' => 'NarrowcastingController@store']);
-        Route::get('edit/{id}', ['as' => 'edit', 'middleware' => ['auth', 'permission:board'], 'uses' => 'NarrowcastingController@edit']);
-        Route::post('edit/{id}', ['as' => 'edit', 'middleware' => ['auth', 'permission:board'], 'uses' => 'NarrowcastingController@update']);
-        Route::get('delete/{id}', ['as' => 'delete', 'middleware' => ['auth', 'permission:board'], 'uses' => 'NarrowcastingController@destroy']);
-        Route::get('clear', ['as' => 'clear', 'middleware' => ['auth', 'permission:board'], 'uses' => 'NarrowcastingController@clear']);
+    Route::prefix('narrowcasting')->name('narrowcasting::')->controller(NarrowcastingController::class)->group(function(){
+        Route::get('', 'display')->name('display');
+        Route::middleware(['auth', 'permission:board'])->group(function(){
+            Route::get('list', 'index')->name('list');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+            Route::get('clear', 'clear')->name('clear');
+        });
     });
 
     /* Routes related to companies. */
-    Route::group(['prefix' => 'companies', 'as' => 'companies::'], function () {
-        Route::get('list', ['as' => 'admin', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CompanyController@adminIndex']);
-        Route::get('add', ['as' => 'add', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CompanyController@create']);
-        Route::post('add', ['as' => 'add', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CompanyController@store']);
-        Route::get('edit/{id}', ['as' => 'edit', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CompanyController@edit']);
-        Route::post('edit/{id}', ['as' => 'edit', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CompanyController@update']);
-        Route::get('delete/{id}', ['as' => 'delete', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CompanyController@destroy']);
+    Route::prefix('companies')->name('companies::')->controller('CompanyController')->group(function(){
 
-        Route::get('up/{id}', ['as' => 'orderUp', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CompanyController@orderUp']);
-        Route::get('down/{id}', ['as' => 'orderDown', 'middleware' => ['auth', 'permission:board'], 'uses' => 'CompanyController@orderDown']);
+        Route::get('', 'index')->name('index');
+        Route::get('{id}', 'show')->name('show');
 
-        Route::get('', ['as' => 'index', 'uses' => 'CompanyController@index']);
-        Route::get('{id}', ['as' => 'show', 'uses' => 'CompanyController@show']);
+        Route::middleware(['auth', 'permission:board'])->group(function(){
+            Route::get('list', 'adminIndex')->name('admin');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+
+            Route::get('up/{id}', 'orderUp')->name('orderUp');
+            Route::get('down/{id}', 'orderDown')->name('orderDown');
+        });
     });
 
     /* Routes related to membercard. */
-    Route::group(['prefix' => 'membercard', 'as' => 'membercard::'], function () {
-        Route::get('', ['as' => 'index', 'uses' => 'CompanyController@indexmembercard']);
+    Route::prefix('membercard')->name('membercard::')->group(function(){
+       Route::controller(MemberCardController::class)->group(function(){
+           Route::get('print', 'startPrint')->name('print')->middleware(['auth', 'permission:board']);
+           Route::get('download/{id}', 'download')->name('download');
+       });
 
-        Route::post('print', ['as' => 'print', 'middleware' => ['auth', 'permission:board'], 'uses' => 'MemberCardController@startPrint']);
-        Route::get('download/{id}', ['as' => 'download', 'uses' => 'MemberCardController@download']);
-
-        Route::get('{id}', ['as' => 'show', 'uses' => 'CompanyController@showmembercard']);
+        Route::controller(CompanyController::class)->group(function(){
+            Route::get('', 'indexmembercard')->name('index');
+            Route::get('{id}', 'showmembercard')->name('show');
+        });
     });
 
     /* Routes related to joboffers. */
-    Route::group(['prefix' => 'joboffers', 'as' => 'joboffers::'], function () {
-        Route::get('', ['as' => 'index', 'uses' => 'JobofferController@index']);
-        Route::get('list', ['as' => 'admin', 'middleware' => ['auth', 'permission:board'], 'uses' => 'JobofferController@adminIndex']);
+    Route::prefix('joboffers')->name('joboffers::')->controller(JobofferController::class)->group(function(){
+        Route::get('', 'index')->name('index');
+        Route::get('{id}', 'show')->name('show');
 
-        Route::get('add', ['as' => 'add', 'middleware' => ['auth', 'permission:board'], 'uses' => 'JobofferController@create']);
-        Route::post('add', ['as' => 'add', 'middleware' => ['auth', 'permission:board'], 'uses' => 'JobofferController@store']);
-
-        Route::get('edit/{id}', ['as' => 'edit', 'middleware' => ['auth', 'permission:board'], 'uses' => 'JobofferController@edit']);
-        Route::post('edit/{id}', ['as' => 'edit', 'middleware' => ['auth', 'permission:board'], 'uses' => 'JobofferController@update']);
-
-        Route::get('delete/{id}', ['as' => 'delete', 'middleware' => ['auth', 'permission:board'], 'uses' => 'JobofferController@destroy']);
-
-        Route::get('{id}', ['as' => 'show', 'uses' => 'JobofferController@show']);
+        Route::middleware(['auth', 'permission:board'])->group(function(){
+            Route::get('list', 'adminIndex')->name('admin');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+        });
     });
 
     /* Routes related to leaderboards. */
-    Route::group(['prefix' => 'leaderboards', 'as' => 'leaderboards::', 'middleware' => ['auth', 'member']], function () {
-        Route::get('', ['as' => 'index', 'uses' => 'LeaderboardController@index']);
+    Route::prefix('leaderboard')->name('leaderboards::')->middleware(['auth', 'member'])->controller(LeaderboardController::class)->group(function(){
 
-        Route::group(['middleware' => ['permission:board']], function () {
-            Route::get('list', ['as' => 'admin', 'uses' => 'LeaderboardController@adminIndex']);
-            Route::get('add', ['as' => 'add', 'uses' => 'LeaderboardController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'LeaderboardController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'LeaderboardController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'LeaderboardController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'LeaderboardController@destroy']);
-        });
+        Route::get('', 'index')->name('index');
 
-        Route::group(['prefix' => 'entries', 'as' => 'entries::', 'middleware' => ['permission:board']], function () {
-            Route::post('add', ['as' => 'add', 'uses' => 'LeaderboardEntryController@store']);
-            Route::post('update', ['as' => 'update', 'uses' => 'LeaderboardEntryController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'LeaderboardEntryController@destroy']);
+        Route::middleware(['permission:board'])->group(function(){
+            Route::get('list', 'adminIndex')->name('admin');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+
+            Route::prefix('entries')->name('entries::')->group(function(){
+                Route::post('add', 'store')->name('add');
+                Route::post('update', 'update')->name('update');
+                Route::get('delete/{id}', 'destroy')->name('delete');
+            });
         });
     });
 
     /* Routes related to dinnerforms. */
-    Route::group(['prefix' => 'dinnerform', 'as' => 'dinnerform::',  'middleware' => ['auth']], function () {
-        Route::group(['middleware' => ['permission:tipcie']], function () {
-            Route::get('add', ['as' => 'add', 'uses' => 'DinnerformController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'DinnerformController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'DinnerformController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'DinnerformController@update']);
-            Route::get('close/{id}', ['as' => 'close', 'uses' => 'DinnerformController@close']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'DinnerformController@destroy']);
-            Route::get('admin/{id}', ['as' => 'admin', 'uses' => 'DinnerformController@admin']);
-            Route::get('process/{id}', ['as' => 'process', 'uses' => 'DinnerformController@process']);
+    Route::prefix('dinnerform')->name('dinnerform::')->middleware('auth')->controller(DinnerformController::class)->group(function(){
+        Route::get('{id}', 'show')->name('show');
+        Route::middleware('permission:tipcie')->group(function(){
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('close/{id}', 'close')->name('close');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+            Route::get('admin/{id}', 'admin')->name('admin');
+            Route::get('process/{id}', 'process')->name('process');
         });
-        Route::group(['prefix' => 'orderline', 'as' => 'orderline::'], function () {
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'DinnerformOrderlineController@delete']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'DinnerformOrderlineController@edit']);
-            Route::post('add/{id}', ['as' => 'add', 'uses' => 'DinnerformOrderlineController@store']);
-            Route::post('update/{id}', ['as' => 'update', 'middleware' => ['permission:tipcie'], 'uses' => 'DinnerformOrderlineController@update']);
+
+        Route::prefix('orderline')->name('orderline::')->group(function(){
+            Route::get('delete/{id}', 'delete')->name('delete');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('add/{id}', 'store')->name('add');
+            Route::post('update/{id}', 'update')->name('update')->middleware('permission:tipcie');
         });
-        Route::get('{id}', ['as' => 'show', 'uses' => 'DinnerformController@show']);
     });
 
     /*
      * Routes related to events.
      * Important: routes in this block always use event_id or a relevant other ID. activity_id is in principle never used.
      */
-    Route::group(['prefix' => 'events', 'as' => 'event::'], function () {
-        Route::group(['prefix' => 'financial', 'as' => 'financial::', 'middleware' => ['permission:finadmin']], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'EventController@finindex']);
-            Route::post('close/{id}', ['as' => 'close', 'uses' => 'EventController@finclose']);
+    Route::prefix('events')->name('event::')->group(function (){
+
+        Route::controller(EventController::class)->group(function(){
+            //show event overview pages
+            Route::get('', 'index')->name('list');
+            Route::get('archive/{year}', 'archive')->name('archive');
+
+            // Show events
+            Route::get('{id}', 'show')->name('show');
+
+            Route::middleware('auth')->group(function(){
+                Route::post('set_reminder', 'setReminder')->name('set_reminder');
+                Route::get('toggle_relevant_only', 'toggleRelevantOnly')->name('toggle_relevant_only');
+
+                Route::get('admin/{id}', 'admin')->name('admin');
+                Route::get('scan/{id}', 'scan')->name('scan');
+                // Force login for event
+                Route::get('{id}/login', 'forceLogin')->name('login');
+
+                Route::middleware('permission:board')->group(function() {
+                    Route::get('add', 'create')->name('add');
+                    Route::post('add', 'store')->name('add');
+
+                    Route::get('edit/{id}', 'edit')->name('edit');
+                    Route::post('edit/{id}', 'update')->name('edit');
+
+                    Route::get('delete/{id}', 'destroy')->name('delete');
+                    Route::get('copy', 'copyEvent')->name('copy');
+
+                    Route::post('album/{event}/link', 'linkAlbum')->name('linkalbum');
+                    Route::get('album/unlink/{album}', 'unlinkAlbum')->name('unlinkalbum');
+
+                    Route::prefix('categories')->name('category::')->group(function(){
+                        Route::get('', 'categoryAdmin')->name('admin');
+                        Route::post('add', 'categoryStore')->name('add');
+                        Route::get('edit/{id}', 'categoryEdit')->name('edit');
+                        Route::post('edit/{id}', 'categoryUpdate')->name('edit');
+                        Route::get('delete/{id}', 'categoryDestroy')->name('delete');
+                    });
+                });
+
+                Route::prefix('financial')->name('financial::')->middleware('permission:finadmin')->group(function(){
+                    Route::get('', 'finindex')->name('list');
+                    Route::post('close/{id}', 'finclose')->name('close');
+                });
+            });
         });
-
-        Route::group(['prefix' => 'categories', 'middleware' => ['permission:board'], 'as' => 'category::'], function () {
-            Route::get('', ['as' => 'admin', 'uses' => 'EventController@categoryAdmin']);
-            Route::post('add', ['as' => 'add', 'uses' => 'EventController@categoryStore']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'EventController@categoryEdit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'EventController@categoryUpdate']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'EventController@categoryDestroy']);
-        });
-
-        Route::get('', ['as' => 'list', 'uses' => 'EventController@index']);
-        Route::get('add', ['as' => 'add', 'middleware' => ['permission:board'], 'uses' => 'EventController@create']);
-        Route::post('add', ['as' => 'add', 'middleware' => ['permission:board'], 'uses' => 'EventController@store']);
-        Route::get('edit/{id}', ['as' => 'edit', 'middleware' => ['permission:board'], 'uses' => 'EventController@edit']);
-        Route::post('edit/{id}', ['as' => 'edit', 'middleware' => ['permission:board'], 'uses' => 'EventController@update']);
-        Route::get('delete/{id}', ['as' => 'delete', 'middleware' => ['permission:board'], 'uses' => 'EventController@destroy']);
-
-        Route::post('set_reminder', ['as' => 'set_reminder', 'middleware' => ['auth'], 'uses' => 'EventController@setReminder']);
-        Route::get('toggle_relevant_only', ['as' => 'toggle_relevant_only', 'middleware' => ['auth'], 'uses' => 'EventController@toggleRelevantOnly']);
-
-        Route::post('album/{event}/link', ['as' => 'linkalbum', 'middleware' => ['permission:board'], 'uses' => 'EventController@linkAlbum']);
-        Route::get('album/unlink/{album}', ['as' => 'unlinkalbum', 'middleware' => ['permission:board'], 'uses' => 'EventController@unlinkAlbum']);
-
-        Route::get('admin/{id}', ['as' => 'admin', 'middleware' => ['auth'], 'uses' => 'EventController@admin']);
-        Route::get('scan/{id}', ['as' => 'scan', 'middleware' => ['auth'], 'uses' => 'EventController@scan']);
-
-        Route::get('checklist/{id}', ['as' => 'checklist', 'uses' => 'ActivityController@checklist']);
-
-        Route::get('archive/{year}', ['as' => 'archive', 'uses' => 'EventController@archive']);
-
-        // Related to presence
-        Route::get('togglepresence/{id}', ['as' => 'togglepresence', 'middleware' => ['auth'], 'uses' => 'ParticipationController@togglePresence']);
-
         // Related to participation
-        Route::get('participate/{id}', ['as' => 'addparticipation', 'middleware' => ['member'], 'uses' => 'ParticipationController@create']);
-        Route::get('unparticipate/{participation_id}', ['as' => 'deleteparticipation', 'uses' => 'ParticipationController@destroy']);
+        Route::controller(ParticipationController::class)->middleware('auth')->group(function(){
+            Route::get('unparticipate/{participation_id}', 'destroy')->name('deleteparticipation');
 
-        Route::post('participatefor/{id}', ['as' => 'addparticipationfor', 'middleware' => ['permission:board'], 'uses' => 'ParticipationController@createFor']);
+            Route::middleware('member')->group(function(){
+                Route::get('participate/{id}', 'create')->name('addparticipation');
+                Route::get('togglepresence/{id}', 'togglePresence')->name('togglepresence');
+            });
 
-        // Related to activities
-        Route::post('signup/{id}', ['as' => 'addsignup', 'middleware' => ['permission:board'], 'uses' => 'ActivityController@store']);
-        Route::get('signup/{id}/delete', ['as' => 'deletesignup', 'middleware' => ['permission:board'], 'uses' => 'ActivityController@destroy']);
-
-        // Related to helping committees
-        Route::post('addhelp/{id}', ['as' => 'addhelp', 'middleware' => ['permission:board'], 'uses' => 'ActivityController@addHelp']);
-        Route::post('updatehelp/{id}', ['as' => 'updatehelp', 'middleware' => ['permission:board'], 'uses' => 'ActivityController@updateHelp']);
-        Route::get('deletehelp/{id}', ['as' => 'deletehelp', 'middleware' => ['permission:board'], 'uses' => 'ActivityController@deleteHelp']);
-
-        // Buy tickets for an event
-        Route::post('buytickets/{id}', ['as' => 'buytickets', 'middleware' => ['auth'], 'uses' => 'TicketController@buyForEvent']);
-
-        // Show event
-        Route::get('{id}', ['as' => 'show', 'uses' => 'EventController@show']);
-
-        Route::post('copy', ['as' => 'copy', 'uses' => 'EventController@copyEvent']);
-
-        // Force login for event
-        Route::get('{id}/login', ['as' => 'login', 'middleware' => ['auth'], 'uses' => 'EventController@forceLogin']);
-    });
-
-    /* Routes related to the newsletter */
-    Route::group(['prefix' => 'newsletter', 'as' => 'newsletter::'], function () {
-        Route::get('', ['as' => 'preview', 'middleware' => ['auth'], 'uses' => 'NewsletterController@newsletterPreview']);
-        Route::group(['middleware' => ['permission:board']], function () {
-            Route::get('content', ['as' => 'show', 'uses' => 'NewsletterController@getInNewsletter']);
-            Route::get('toggle/{id}', ['as' => 'toggle', 'uses' => 'NewsletterController@toggleInNewsletter']);
-            Route::post('send', ['as' => 'send', 'uses' => 'NewsletterController@sendNewsletter']);
-            Route::post('text', ['as' => 'text', 'uses' => 'NewsletterController@saveNewsletterText']);
+            Route::post('participatefor/{id}', 'createFor')->name('addparticipationfor')->middleware('permission:board');
         });
-    });
 
-    /* Routes related to pages. */
-    Route::group(['prefix' => 'page', 'as' => 'page::'], function () {
-        Route::group(['middleware' => ['auth', 'permission:board']], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'PageController@index']);
-            Route::get('add', ['as' => 'add', 'uses' => 'PageController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'PageController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'PageController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'PageController@update']);
-            Route::post('edit/{id}/image', ['as' => 'image', 'uses' => 'PageController@featuredImage']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'PageController@destroy']);
+        Route::controller(ActivityController::class)->group(function(){
 
-            Route::group(['prefix' => '/edit/{id}/file', 'as' => 'file::'], function () {
-                Route::post('add', ['as' => 'add', 'uses' => 'PageController@addFile']);
-                Route::get('{file_id}/delete', ['as' => 'delete', 'uses' => 'PageController@deleteFile']);
+            Route::get('checklist/{id}','checklist')->name('checklist');
+
+            Route::middleware('permission:board')->group(function(){
+                // Related to activities
+                Route::get('signup/{id}', 'store')->name('addsignup');
+                Route::get('signup/{id}/delete', 'destroy')->name('deletesignup');
+
+                // Related to helping committees
+                Route::post('addhelp/{id}', 'addHelp')->name('addhelp');
+                Route::post('updatehelp/{id}', 'updateHelp')->name('updatehelp');
+                Route::get('deletehelp/{id}', 'deleteHelp')->name('deletehelp');
             });
         });
 
-        Route::get('{slug}', ['as' => 'show', 'uses' => 'PageController@show']);
+        // Buy tickets for an event
+        Route::post('buytickets/{id}', [TicketController::class, 'buyForEvent'])->name('buytickets')->middleware('member');
+    });
+
+    /* Routes related to the newsletter */
+    Route::prefix('newsletter')->name('newsletter::')->middleware('auth')->controller(NewsController::class)->group(function(){
+        Route::get('', 'newsletterPreview')->name('preview');
+        Route::middleware('permission:board')->group(function(){
+            Route::get('content', 'getInNewsletter')->name('show');
+            Route::get('toggle/{id}', 'toggleInNewsletter')->name('toggle');
+            Route::post('send', 'sendNewsletter')->name('send');
+            Route::post('text', 'saveNewsletterText')->name('text');
+        });
     });
 
     /* Routes related to pages. */
-    Route::group(['prefix' => 'news', 'as' => 'news::'], function () {
-        Route::group(['middleware' => ['auth', 'permission:board']], function () {
-            Route::get('admin', ['as' => 'admin', 'uses' => 'NewsController@admin']);
-            Route::get('add', ['as' => 'add', 'uses' => 'NewsController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'NewsController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'NewsController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'NewsController@update']);
-            Route::post('edit/{id}/image', ['as' => 'image', 'uses' => 'NewsController@featuredImage']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'NewsController@destroy']);
-        });
+    Route::prefix('page')->name('page::')->controller(PageController::class)->group(function(){
+        Route::get('{slug}', ['as' => 'show', 'uses' => 'PageController@show']);
 
-        Route::get('', ['as' => 'list', 'uses' => 'NewsController@index']);
-        Route::get('{id}', ['as' => 'show', 'uses' => 'NewsController@show']);
+        Route::middleware(['auth','permission:board'])->group(function(){
+            Route::get('', 'index')->name('list');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+
+            Route::prefix('/edit/{id}')->group(function(){
+                Route::get('', 'edit')->name('edit');
+                Route::post('', 'update')->name('edit');
+                Route::post('image', 'featuredImage')->name('image');
+
+                Route::post('file/add', 'addFile')->name('add');
+                Route::get('file/{file_id}/delete', 'deleteFile')->name('delete');
+            });
+        });
     });
 
+    /* Routes related to news. */
+    Route::prefix('news')->name('news::')->controller(NewsController::class)->group(function(){
+
+        Route::get('', 'NewsController@index')->name('list');
+        Route::get('{id}', 'NewsController@show')->name('show');
+
+        Route::middleware(['auth', 'permission:board'])->group(function(){
+            Route::get('admin', 'admin')->name('admin');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+
+            Route::prefix('edit/{id}')->group(function(){
+                Route::get('', 'edit')->name('edit');
+                Route::post('', 'update')->name('edit');
+                Route::post('image', 'featuredImage')->name('image');
+            });
+        });
+    });
     /* Routes related to menu. */
-    Route::group(['prefix' => 'menu', 'as' => 'menu::', 'middleware' => ['auth', 'permission:board']], function () {
-        Route::get('', ['as' => 'list', 'uses' => 'MenuController@index']);
-        Route::get('add', ['as' => 'add', 'uses' => 'MenuController@create']);
-        Route::post('add', ['as' => 'add', 'uses' => 'MenuController@store']);
+    Route::prefix('menu')->name('menu::')->middleware(['auth', 'permission:board'])->controller(MenuController::class)->group(function(){
+        Route::get('', 'index')->name('list');
+        Route::get('add', 'create')->name('add');
+        Route::post('add', 'store')->name('add');
 
-        Route::get('up/{id}', ['as' => 'orderUp', 'uses' => 'MenuController@orderUp']);
-        Route::get('down/{id}', ['as' => 'orderDown', 'uses' => 'MenuController@orderDown']);
+        Route::get('up/{id}', 'orderUp')->name('orderUp');
+        Route::get('down/{id}', 'orderDown')->name('orderDown');
 
-        Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'MenuController@edit']);
-        Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'MenuController@update']);
-        Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'MenuController@destroy']);
+        Route::get('edit/{id}', 'edit')->name('edit');
+        Route::post('edit/{id}', 'update')->name('edit');
+        Route::get('delete/{id}', 'destroy')->name('delete');
     });
 
     /* Routes related to tickets. */
-    Route::group(['prefix' => 'tickets', 'middleware' => ['auth'], 'as' => 'tickets::'], function () {
-        Route::group(['middleware' => ['auth', 'permission:board']], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'TicketController@index']);
-            Route::get('add', ['as' => 'add', 'uses' => 'TicketController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'TicketController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'TicketController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'TicketController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'TicketController@destroy']);
-        });
+    Route::prefix('tickets')->name('tickets::')->middleware(['auth'])->controller(TicketController::class)->group(function(){
 
-        Route::get('scan/{barcode}', ['as' => 'scan', 'uses' => 'TicketController@scan']);
-        Route::get('unscan/{barcode?}', ['as' => 'unscan', 'uses' => 'TicketController@unscan']);
-        Route::get('download/{id}', ['as' => 'download', 'uses' => 'TicketController@download']);
+        Route::get('scan/{barcode}', 'scan')->name('scan');
+        Route::get('unscan/{barcode?}', 'unscan')->name('unscan');
+        Route::get('download/{id}','download')->name('download');
+
+        Route::middleware(['auth', 'permission:board'])->group(function(){
+            Route::get('', 'index')->name('list');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+        });
     });
 
     /* Routes related to e-mail. */
-    Route::get('togglelist/{id}', ['as' => 'togglelist', 'middleware' => ['auth'], 'uses' => 'EmailListController@toggleSubscription']);
+    Route::get('togglelist/{id}', [EmailListController::class, 'toggleSubscription'])->name('togglelist')->middleware('auth');
 
-    Route::get('unsubscribe/{hash}', ['as' => 'unsubscribefromlist', 'uses' => 'EmailController@unsubscribeLink']);
+    Route::get('unsubscribe/{hash}', [EmailListController::class, 'unsubscribeLink'])->name('unsubscribefromlist');
 
-    Route::group(['prefix' => 'email', 'middleware' => ['auth', 'permission:board'], 'as' => 'email::'], function () {
-        Route::get('', ['as' => 'admin', 'uses' => 'EmailController@index']);
+    Route::prefix('email')->name('email::')->middleware(['auth', 'permission:board'])->group(function(){
 
-        Route::group(['prefix' => 'list', 'as' => 'list::'], function () {
-            Route::get('add', ['as' => 'add', 'uses' => 'EmailListController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'EmailListController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'EmailListController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'EmailListController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'EmailListController@destroy']);
+        Route::controller(EmailController::class)->group(function(){
+            Route::get('', 'index')->name('admin');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('preview/{id}', 'show')->name('show');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('toggleready/{id}', 'toggleReady')->name('toggleready');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+
+            Route::prefix('{id}/attachment')->name('attachment::')->group(function(){
+                Route::post('add', 'addAttachment')->name('add');
+                Route::get('delete/{file_id}', 'deleteAttachment')->name('delete');
+            });
         });
 
-        Route::get('add', ['as' => 'add', 'uses' => 'EmailController@create']);
-        Route::post('add', ['as' => 'add', 'uses' => 'EmailController@store']);
-        Route::get('preview/{id}', ['as' => 'show', 'uses' => 'EmailController@show']);
-        Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'EmailController@edit']);
-        Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'EmailController@update']);
-        Route::get('toggleready/{id}', ['as' => 'toggleready', 'uses' => 'EmailController@toggleReady']);
-        Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'EmailController@destroy']);
-
-        Route::group(['prefix' => '{id}/attachment', 'as' => 'attachment::'], function () {
-            Route::post('add', ['as' => 'add', 'uses' => 'EmailController@addAttachment']);
-            Route::get('delete/{file_id}', ['as' => 'delete', 'uses' => 'EmailController@deleteAttachment']);
+        Route::prefix('list')->name('list::')->controller(EmaillistController::class)->group(function(){
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
         });
     });
 
     /* Routes related to the Quote Corner. */
-    Route::group(['prefix' => 'quotes', 'middleware' => ['member'], 'as' => 'quotes::'], function () {
-        Route::get('', ['as' => 'list', 'uses' => 'QuoteCornerController@overview']);
-        Route::post('add', ['as' => 'add', 'uses' => 'QuoteCornerController@add']);
-        Route::get('delete/{id}', ['as' => 'delete', 'middleware' => ['permission:board'], 'uses' => 'QuoteCornerController@destroy']);
-        Route::get('like/{id}', ['as' => 'like', 'uses' => 'QuoteCornerController@toggleLike']);
-        Route::get('search/{searchTerm?}', ['as' => 'search', 'uses' => 'QuoteCornerController@search']);
+    Route::prefix('quotes')->name('quotes::')->middleware(['member'])->controller(QuoteCornerController::class)->group(function(){
+        Route::get('', 'overview')->name('list');
+        Route::post('add', 'add')->name('add');
+        Route::get('delete/{id}', 'destroy')->name('delete');
+        Route::get('like/{id}', 'toggleLike')->name('like');
+        Route::get('search/{searchTerm?}', 'search')->name('search');
     });
 
     /* Routes related to the Good Idea Board. */
-    Route::group(['prefix' => 'goodideas', 'middleware' => ['member'], 'as' => 'goodideas::'], function () {
-        Route::get('', ['as' => 'index', 'uses' => 'GoodIdeaController@index']);
-        Route::post('add', ['as' => 'add', 'uses' => 'GoodIdeaController@add']);
-        Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'GoodIdeaController@delete']);
-        Route::post('vote', ['as' => 'vote', 'uses' => 'GoodIdeaController@vote']);
-        Route::get('deleteall', ['as' => 'deleteall', 'middleware' => ['permission:board'], 'uses' => 'GoodIdeaController@deleteall']);
+    Route::prefix('goodideas')->name('goodideas::')->middleware(['member'])->controller(GoodIdeaController::class)->group(function(){
+        Route::get('', 'index')->name('index');
+        Route::post('add', 'add')->name('add');
+        Route::get('delete/{id}', 'delete')->name('delete');
+        Route::post('vote', 'vote')->name('vote');
+        Route::get('deleteall', 'deleteall')->name('deleteall')->middleware(['permission:board']);
     });
 
     /* Routes related to the OmNomCom. */
-    Route::group(['prefix' => 'omnomcom', 'as' => 'omnomcom::'], function () {
-        Route::get('minisite', ['uses' => 'OmNomController@miniSite']);
+    Route::prefix('omnomcom')->name('omnomcom::')->group(function(){
+        Route::get('minisite', [OmNomController::class, 'miniSite'])->name('minisite');
 
         /* Routes related to OmNomCom stores. */
-        Route::group(['prefix' => 'store', 'as' => 'store::'], function () {
-            Route::get('', ['as' => 'show', 'middleware' => ['auth'], 'uses' => 'OmNomController@choose']);
-            Route::get('{store?}', ['as' => 'show', 'uses' => 'OmNomController@display']);
-            Route::post('rfid/add', ['as' => 'rfidadd', 'uses' => 'RfidCardController@store']);
-            Route::post('{store}/buy', ['as' => 'buy', 'uses' => 'OmNomController@buy']);
+        Route::prefix('store')->name('store::')->group(function(){
+            Route::controller(OmNomController::class)->group(function(){
+                Route::get('', 'choose')->name('choose')->middleware(['auth']);
+                Route::get('{store?}', 'display')->name('show');
+                Route::post('{store}/buy', 'buy')->name('buy');
+            });
+
+            Route::post('rfid/add', [RfidCardController::class, 'store'])->name('rfidadd');
         });
 
         /* Routes related to OmNomCom orders. */
-        Route::group(['prefix' => 'orders', 'middleware' => ['auth'], 'as' => 'orders::'], function () {
-            Route::post('add/bulk', ['as' => 'addbulk', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@bulkStore']);
-            Route::post('add/single', ['as' => 'add', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@store']);
-            Route::get('delete/{id}', ['as' => 'delete', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@destroy']);
+        Route::prefix('orders')->name('orders::')->middleware(['auth'])->controller(OrderLineController::class)->group(function(){
+            Route::get('history/{date?}', 'index')->name('list');
 
-            Route::get('history/{date?}', ['as' => 'list', 'uses' => 'OrderLineController@index']);
-            Route::get('', ['as' => 'adminlist', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@adminindex']);
+            Route::middleware(['permission:omnomcom'])->group(function(){
+                Route::post('add/bulk', 'bulkStore')->name('addbulk');
+                Route::post('add/single', 'store')->name('add');
+                Route::get('delete/{id}', 'destroy')->name('delete');
+                Route::get('', 'adminList')->name('adminlist');
+            });
 
-            Route::group(['prefix' => 'filter', 'middleware' => ['permission:omnomcom'], 'as' => 'filter::'], function () {
-                Route::get('name/{name?}', ['as' => 'name', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@filterByUser']);
-                Route::get('date/{date?}', ['as' => 'date', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@filterByDate']);
+
+            Route::prefix('filter')->name('filter::')->middleware(['permission:omnomcom'])->group(function(){
+                Route::get('name/{name?}', 'filterByUser')->name('name');
+                Route::get('date/{date?}', 'filterByDate')->name('date');
             });
         });
 
         /* Routes related to the TIPCie OmNomCom store. */
-        Route::group(['prefix' => 'tipcie', 'middleware' => ['auth', 'permission:tipcie'], 'as' => 'tipcie::'], function () {
-            Route::get('', ['as' => 'orderhistory', 'uses' => 'TIPCieController@orderIndex']);
+        Route::prefix('tipcie')->name('tipcie::')->middleware(['auth', 'permission:tipcie'])->group(function(){
+            Route::get('', [TIPCieController::class, 'orderIndex'])->name('orderhistory');
         });
 
         /* Routes related to Financial Accounts. */
-        Route::group(['prefix' => 'accounts', 'middleware' => ['permission:finadmin'], 'as' => 'accounts::'], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'AccountController@index']);
-            Route::get('add', ['as' => 'add', 'uses' => 'AccountController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'AccountController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'AccountController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'AccountController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'AccountController@destroy']);
-            Route::get('{id}', ['as' => 'show', 'uses' => 'AccountController@show']);
-            Route::post('aggregate/{account}', ['as' => 'aggregate', 'uses' => 'AccountController@showAggregation']);
+        Route::prefix('accounts')->name('accounts::')->middleware(['permission:finadmin'])->controller(AccountController::class)->group(function(){
+            Route::get('', 'index')->name('list');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+            Route::get('{id}', 'show')->name('show');
+            Route::post('aggregate/{account}', 'showAggregation')->name('aggregate');
         });
 
         /* Routes related to Payment Statistics. */
-        Route::group(['prefix' => 'payments', 'middleware' => ['permission:finadmin'], 'as' => 'payments::'], function () {
-            Route::get('statistics', ['as' => 'statistics', 'uses' => 'OrderLineController@showPaymentStatistics']);
-            Route::post('statistics', ['as' => 'statistics', 'uses' => 'OrderLineController@showPaymentStatistics']);
+        Route::prefix('payments')->name('payments::')->middleware(['permission:finadmin'])->controller(OrderLineController::class)->group(function(){
+            Route::get('statistics', 'showPaymentStatistics')->name('statistics');
+            Route::post('statistics', 'showPaymentStatistics')->name('statistics');
         });
 
         /* Routes related to Products. */
-        Route::group(['prefix' => 'products', 'middleware' => ['permission:omnomcom'], 'as' => 'products::'], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'ProductController@index']);
-            Route::get('add', ['as' => 'add', 'uses' => 'ProductController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'ProductController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'ProductController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'ProductController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'ProductController@destroy']);
+        Route::prefix('products')->name('products::')->middleware(['permission:omnomcom'])->group(function(){
+            Route::controller(ProductController::class)->group(function(){
+                Route::get('', 'index')->name('list');
+                Route::get('add', 'create')->name('add');
+                Route::post('add', 'store')->name('add');
+                Route::get('edit/{id}', 'edit')->name('edit');
+                Route::post('edit/{id}', 'update')->name('edit');
+                Route::get('delete/{id}', 'destroy')->name('delete');
 
-            Route::get('export/csv', ['as' => 'export_csv', 'uses' => 'ProductController@generateCsv']);
-
-            Route::get('statistics', ['as' => 'statistics', 'uses' => 'AccountController@showOmnomcomStatistics']);
-            Route::post('statistics', ['as' => 'statistics', 'uses' => 'AccountController@showOmnomcomStatistics']);
-
-            Route::post('update/bulk', ['as' => 'bulkupdate', 'middleware' => ['permission:omnomcom'], 'uses' => 'ProductController@bulkUpdate']);
+                Route::get('export/csv', 'generateCsv')->name('export_csv');
+                Route::post('update/bulk', 'bulkUpdate')->name('bulkupdate');
+            });
+            Route::controller(AccountController::class)->group(function(){
+                Route::get('statistics', 'showOmnomcomStatistics')->name('statistics');
+                Route::post('statistics', 'showOmnomcomStatistics')->name('statistics');
+            });
         });
 
         /* Routes related to OmNomCom Categories. */
-        Route::group(['prefix' => 'categories', 'middleware' => ['permission:omnomcom'], 'as' => 'categories::'], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'ProductCategoryController@index']);
-            Route::get('add', ['as' => 'add', 'uses' => 'ProductCategoryController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'ProductCategoryController@store']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'ProductCategoryController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'ProductCategoryController@destroy']);
-            Route::get('{id}', ['as' => 'show', 'uses' => 'ProductCategoryController@show']);
+        Route::prefix('categories')->name('categories::')->middleware(['permission:omnomcom'])->controller(ProductCategoryController::class)->group(function(){
+                Route::get('', 'index')->name('list');
+                Route::get('add', 'create')->name('add');
+                Route::post('add', 'store')->name('add');
+                Route::post('edit/{id}', 'update')->name('edit');
+                Route::get('delete/{id}', 'destroy')->name('delete');
+                Route::get('{id}', 'show')->name('show');
         });
 
         /* Routes related to Withdrawals. */
-        Route::group(['prefix' => 'withdrawals', 'middleware' => ['permission:finadmin'], 'as' => 'withdrawal::'], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'WithdrawalController@index']);
-            Route::get('add', ['as' => 'add', 'uses' => 'WithdrawalController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'WithdrawalController@store']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'WithdrawalController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'WithdrawalController@destroy']);
-            Route::get('{id}', ['as' => 'show', 'uses' => 'WithdrawalController@show']);
-            Route::get('accounts/{id}', ['as' => 'showAccounts', 'uses' => 'WithdrawalController@showAccounts']);
+        Route::prefix('withdrawals')->name('withdrawal::')->middleware(['permission:finadmin'])->controller(WithdrawalController::class)->group(function(){
+            Route::get('', 'index')->name('list');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+            Route::get('{id}', 'show')->name('show');
 
-            Route::get('export/{id}', ['as' => 'export', 'uses' => 'WithdrawalController@export']);
-            Route::get('close/{id}', ['as' => 'close', 'uses' => 'WithdrawalController@close']);
-            Route::get('email/{id}', ['as' => 'email', 'uses' => 'WithdrawalController@email']);
+            Route::get('accounts/{id}', 'showAccounts')->name('showAccounts');
+            Route::get('export/{id}', 'export')->name('export');
+            Route::get('close/{id}', 'close')->name('close');
+            Route::get('email/{id}', 'email')->name('email');
 
-            Route::get('deletefrom/{id}/{user_id}', ['as' => 'deleteuser', 'uses' => 'WithdrawalController@deleteFrom']);
-            Route::get('markfailed/{id}/{user_id}', ['as' => 'markfailed', 'uses' => 'WithdrawalController@markFailed']);
-            Route::get('markloss/{id}/{user_id}', ['as' => 'markloss', 'uses' => 'WithdrawalController@markLoss']);
+            Route::get('deletefrom/{id}/{user_id}', 'deleteFrom')->name('deleteuser');
+            Route::get('markfailed/{id}/{user_id}', 'markFailed')->name('markfailed');
+            Route::get('markloss/{id}/{user_id}', 'markLoss')->name('markloss');
         });
 
-        Route::get('unwithdrawable', ['middleware' => ['permission:finadmin'], 'as' => 'unwithdrawable', 'uses' => 'WithdrawalController@unwithdrawable']);
+        Route::get('unwithdrawable', [WithdrawalController::class, 'unwithdrawable'])->name('unwithdrawable')->middleware(['permission:finadmin']);
 
         /* Routes related to Mollie. */
-        Route::group(['prefix' => 'mollie', 'middleware' => ['auth'], 'as' => 'mollie::'], function () {
-            Route::post('pay', ['as' => 'pay', 'uses' => 'MollieController@pay']);
-            Route::get('status/{id}', ['as' => 'status', 'uses' => 'MollieController@status']);
-            Route::get('receive/{id}', ['as' => 'receive', 'uses' => 'MollieController@receive']);
-            Route::get('list', ['as' => 'list', 'middleware' => ['permission:finadmin'], 'uses' => 'MollieController@index']);
-            Route::get('monthly/{month}', ['as' => 'monthly', 'middleware' => ['permission:finadmin'], 'uses' => 'MollieController@monthly']);
+        Route::prefix('mollie')->name('mollie::')->middleware(['auth'])->controller(MollieController::class)->group(function(){
+            Route::post('pay', 'pay')->name('pay');
+            Route::get('status/{id}', 'status')->name('status');
+            Route::get('receive/{id}', 'receive')->name('receive');
+            Route::middleware(['permission:finadmin'])->group(function(){
+                Route::get('list', 'index')->name('list');
+                Route::get('monthly/{month}', 'monthly')->name('monthly');
+            });
         });
 
-        Route::get('mywithdrawal/{id}', ['as' => 'mywithdrawal', 'middleware' => ['auth'], 'uses' => 'WithdrawalController@showForUser']);
-
-        Route::get('supplier', ['as' => 'generateorder', 'middleware' => ['permission:omnomcom'], 'uses' => 'OmNomController@generateOrder']);
+        Route::get('mywithdrawal/{id}', [WithdrawalController::class, 'showForUser'])->name('mywithdrawal')->middleware(['auth']);
+        Route::get('supplier', [OmNomController::class, 'generateOrder'])->name('generateorder')->middleware(['permission:omnomcom']);
     });
 
     /* Routes related to webhooks. */
-    Route::group(['prefix' => 'webhook', 'as' => 'webhook::'], function () {
-        Route::any('mollie/{id}', ['as' => 'mollie', 'uses' => 'MollieController@webhook']);
+    Route::prefix('webhook')->name('webhook::')->group(function () {
+        Route::any('mollie/{id}', [MollieController::class, 'webhook'])->name('mollie');
     });
-
     /* Routes related to YouTube videos. */
-    Route::group(['prefix' => 'video', 'as' => 'video::'], function () {
-        Route::group(['prefix' => 'admin', 'middleware' => ['permission:board'], 'as' => 'admin::'], function () {
-            Route::get('', ['as' => 'index', 'uses' => 'VideoController@index']);
-            Route::post('add', ['as' => 'add', 'uses' => 'VideoController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'VideoController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'VideoController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'VideoController@destroy']);
-        });
-        Route::get('{id}', ['as' => 'view', 'uses' => 'VideoController@view']);
-        Route::get('', ['as' => 'index', 'uses' => 'VideoController@publicIndex']);
-    });
+    Route::prefix('video')->name('video::')->controller(VideoController::class)->group(function () {
 
-    /* Routes related to announcements. */
-    Route::group(['prefix' => 'announcement', 'as' => 'announcement::'], function () {
-        Route::group(['prefix' => 'admin', 'middleware' => ['permission:sysadmin'], 'as' => ''], function () {
-            Route::get('', ['as' => 'index', 'uses' => 'AnnouncementController@index']);
-            Route::get('add', ['as' => 'add', 'uses' => 'AnnouncementController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'AnnouncementController@store']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'AnnouncementController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'AnnouncementController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'AnnouncementController@destroy']);
-            Route::get('clear', ['as' => 'clear', 'uses' => 'AnnouncementController@clear']);
+        Route::get('{id}', 'view')->name('view');
+        Route::get('', 'index')->name('index');
+
+        Route::prefix('admin')->middleware(['permission:board'])->name('admin::')->group(function () {
+            Route::get('', 'index')->name('index');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
         });
-        Route::get('dismiss/{id}', ['as' => 'dismiss', 'uses' => 'AnnouncementController@dismiss']);
+    });
+    /* Routes related to announcements. */
+    Route::prefix('announcement')->name('announcement::')->controller(AnnouncementController::class)->group(function () {
+        Route::get('dismiss/{id}', 'dismiss')->name('dismiss');
+
+        Route::prefix('admin')->middleware(['permission:sysadmin'])->group(function () {
+            Route::get('', 'index')->name('index');
+            Route::get('add', 'create')->name('add');
+            Route::post('add', 'store')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+            Route::get('clear', 'clear')->name('clear');
+        });
     });
 
     /* Routes related to photos. */
-    Route::group(['prefix' => 'photos', 'as' => 'photo::'], function () {
-        Route::get('', ['as' => 'albums', 'uses' => 'PhotoController@index']);
-        Route::get('slideshow', ['as' => 'slideshow', 'uses' => 'PhotoController@slideshow']);
+    Route::prefix('photos')->name('photo::')->group(function(){
+        Route::controller(PhotoController::class)->group(function() {
+            Route::get('', 'index')->name('albums');
+            Route::get('slideshow', 'slideshow')->name('slideshow');
 
-        Route::group(['prefix' => '{id}', 'as' => 'album::'], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'PhotoController@show']);
+            Route::prefix('{id}')->name('album::')->group(function () {
+                Route::get('', 'show')->name('list');
+            });
+
+            Route::get('like/{id}', 'likePhoto')->name('likes')->middleware('auth');
+            Route::get('dislike/{id}', 'dislikePhoto')->name('dislikes')->middleware('auth');
+            Route::get('photo/{id}', 'photo')->name('view');
         });
-        Route::get('/like/{id}', ['as' => 'likes', 'middleware' => ['auth'], 'uses' => 'PhotoController@likePhoto']);
-        Route::get('/dislike/{id}', ['as' => 'dislikes', 'middleware' => ['auth'], 'uses' => 'PhotoController@dislikePhoto']);
-        Route::get('/photo/{id}', ['as' => 'view', 'uses' => 'PhotoController@photo']);
 
-        /* Routes related to the photo admin. */
-        Route::group(['prefix' => 'admin', 'middleware' => ['permission:protography'], 'as' => 'admin::'], function () {
-            Route::get('index', ['as' => 'index', 'uses' => 'PhotoAdminController@index']);
-            Route::post('index', ['as' => 'index', 'uses' => 'PhotoAdminController@search']);
-            Route::post('add', ['as' => 'add', 'uses' => 'PhotoAdminController@create']);
-            Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'PhotoAdminController@edit']);
-            Route::post('edit/{id}', ['as' => 'edit', 'middleware' => ['permission:publishalbums'], 'uses' => 'PhotoAdminController@update']);
-            Route::post('edit/{id}/action', ['as' => 'action', 'uses' => 'PhotoAdminController@action']);
-            Route::post('edit/{id}/upload', ['as' => 'upload', 'uses' => 'PhotoAdminController@upload']);
-            Route::get('edit/{id}/delete', ['as' => 'delete', 'middleware' => ['permission:publishalbums'], 'uses' => 'PhotoAdminController@delete']);
-            Route::get('publish/{id}', ['as' => 'publish', 'middleware' => ['permission:publishalbums'], 'uses' => 'PhotoAdminController@publish']);
-            Route::get('unpublish/{id}', ['as' => 'unpublish', 'middleware' => ['permission:publishalbums'], 'uses' => 'PhotoAdminController@unpublish']);
+        Route::prefix('admin')->name('admin::')->middleware(['permission:protography'])->controller(PhotoAdminController::class)->group(function(){
+            Route::get('index', 'index')->name('index');
+            Route::post('index', 'search')->name('index');
+            Route::post('add', 'create')->name('add');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}/action', 'action')->name('action');
+            Route::post('edit/{id}/upload', 'upload')->name('upload');
+            Route::middleware(['permission:publishalbums'])->group(function(){
+                Route::post('edit/{id}', 'update')->name('edit');
+                Route::get('edit/{id}/delete', 'delete')->name('delete');
+                Route::get('publish/{id}', 'publish')->name('publish');
+                Route::get('unpublish/{id}', 'unpublish')->name('unpublish');
+            });
         });
     });
 
-    Route::group(['prefix' => 'image', 'as' => 'image::'], function () {
-        Route::get('{id}/{hash}', ['as' => 'get', 'uses' => 'FileController@getImage']);
-        Route::get('{id}/{hash}/{name}', ['uses' => 'FileController@getImage']);
+    /* Routes related to Images. */
+    Route::prefix('image')->name('image::')->controller(FileController::class)->group(function () {
+        Route::get('{id}/{hash}', 'getImage')->name('get');
+        Route::get('{id}/{hash}/{name}', 'getImage')->name('get');
     });
 
     /* Routes related to Spotify. */
-    Route::group(['prefix' => 'spotify', 'middleware' => ['auth', 'permission:board'], 'as' => 'spotify::'], function () {
-        Route::get('oauth', ['as' => 'oauth', 'uses' => 'SpotifyController@oauthTool']);
+    Route::prefix('spotify')->name('spotify::')->middleware(['auth', 'permission:board'])->controller(SpotifyController::class)->group(function () {
+        Route::get('oauth', 'oauthTool')->name('oauth');
     });
 
     /* Routes related to roles and permissions. */
-    Route::group(['prefix' => 'authorization', 'middleware' => ['auth', 'permission:sysadmin'], 'as' => 'authorization::'], function () {
-        Route::get('', ['as' => 'overview', 'uses' => 'AuthorizationController@index']);
-        Route::post('{id}/grant', ['as' => 'grant', 'uses' => 'AuthorizationController@grant']);
-        Route::get('{id}/revoke/{user}', ['as' => 'revoke', 'uses' => 'AuthorizationController@revoke']);
+    Route::prefix('authorization')->name('authorization::')->middleware(['auth', 'permission:sysadmin'])->controller(AuthorizationController::class)->group(function () {
+        Route::get('', 'index')->name('overview');
+        Route::post('{id}/grant', 'grant')->name('grant');
+        Route::get('{id}/revoke/{user}', 'revoke')->name('revoke');
     });
 
     /* Routes related to the password manager. */
-    Route::group(['prefix' => 'passwordstore', 'middleware' => ['auth'], 'as' => 'passwordstore::'], function () {
-        Route::get('', ['as' => 'index', 'uses' => 'PasswordController@index']);
-        Route::get('auth', ['as' => 'auth', 'uses' => 'PasswordController@getAuth']);
-        Route::post('auth', ['as' => 'auth', 'uses' => 'PasswordController@postAuth']);
-        Route::get('add', ['as' => 'add', 'uses' => 'PasswordController@create']);
-        Route::post('add', ['as' => 'add', 'uses' => 'PasswordController@store']);
-        Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'PasswordController@edit']);
-        Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'PasswordController@update']);
-        Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'PasswordController@destroy']);
+    Route::prefix('passwordstore')->name('passwordstore::')->middleware(['auth'])->controller(PasswordController::class)->group(function () {
+        Route::get('', 'index')->name('index');
+        Route::get('auth', 'getAuth')->name('auth');
+        Route::post('auth', 'postAuth')->name('auth');
+        Route::get('add', 'create')->name('add');
+        Route::post('add', 'store')->name('add');
+        Route::get('edit/{id}', 'edit')->name('edit');
+        Route::post('edit/{id}', 'update')->name('edit');
+        Route::get('delete/{id}', 'destroy')->name('delete');
     });
 
     /* Routes related to e-mail aliases. */
-    Route::group(['prefix' => 'alias', 'middleware' => ['auth', 'permission:sysadmin'], 'as' => 'alias::'], function () {
-        Route::get('', ['as' => 'index', 'uses' => 'AliasController@index']);
-        Route::get('add', ['as' => 'add', 'uses' => 'AliasController@create']);
-        Route::post('add', ['as' => 'add', 'uses' => 'AliasController@store']);
-        Route::get('delete/{id_or_alias}', ['as' => 'delete', 'uses' => 'AliasController@destroy']);
-        Route::post('update', ['as' => 'update', 'uses' => 'AliasController@update']);
+    Route::prefix('alias')->name('alias::')->middleware(['auth', 'permission:sysadmin'])->controller(AliasController::class)->group(function () {
+        Route::get('', 'index')->name('index');
+        Route::get('add', 'create')->name('add');
+        Route::post('add', 'store')->name('add');
+        Route::get('delete/{id_or_alias}', 'destroy')->name('delete');
+        Route::post('update', 'update')->name('update');
     });
 
     /* The route for the SmartXp Screen. */
-    Route::get('smartxp', ['as' => 'smartxp', 'uses' => 'SmartXpScreenController@show']);
-    Route::get('caniworkinthesmartxp', ['uses' => 'SmartXpScreenController@canWork']);
+    Route::controller(SmartXPScreenController::class)->group(function(){
+        Route::get('smartxp','show')->name('smartxp');
+        Route::get('caniworkinthesmartxp', 'canWork');
+    });
 
     /* The routes for Protube. */
-    Route::group(['prefix' => 'protube', 'as' => 'protube::'], function () {
-        Route::get('screen', ['as' => 'screen', 'uses' => 'ProtubeController@screen']);
-        Route::get('admin', ['as' => 'admin', 'middleware' => ['auth'], 'uses' => 'ProtubeController@admin']);
-        Route::get('offline', ['as' => 'offline', 'uses' => 'ProtubeController@offline']);
-        Route::get('dashboard', ['as' => 'dashboard', 'middleware' => ['auth'], 'uses' => 'ProtubeController@dashboard']);
-        Route::get('togglehistory', ['as' => 'togglehistory', 'middleware' => ['auth'], 'uses' => 'ProtubeController@toggleHistory']);
-        Route::get('clearhistory', ['as' => 'clearhistory', 'middleware' => ['auth'], 'uses' => 'ProtubeController@clearHistory']);
-        Route::get('top', ['as' => 'top', 'uses' => 'ProtubeController@topVideos']);
-        Route::get('login', ['as' => 'login', 'middleware' => ['auth'], 'uses' => 'ProtubeController@loginRedirect']);
-        Route::get('{id?}', ['as' => 'remote', 'uses' => 'ProtubeController@remote']);
+    Route::prefix('protube')->name('protube::')->group(function(){
+        Route::controller(ProtubeController::class)->group(function(){
+            Route::get('screen', 'screen')->name('screen');
+            Route::get('offline', 'offline')->name('offline');
+            Route::get('top', 'top')->name('top');
+            Route::get('{id?}', 'remote')->name('remote');
 
+            Route::middleware('auth')->group(function(){
+                Route::get('admin', 'admin')->name('admin');
+                Route::get('dashboard', 'dashboard')->name('dashboard');
+                Route::get('togglehistory', 'toggleHistory')->name('togglehistory');
+                Route::get('clearhistory', 'clearHistory')->name('clearhistory');
+                Route::get('login', 'loginRedirect')->name('login');
+            });
+        });
         /* Routes related to the Protube Radio */
-        Route::group(['prefix' => 'radio', 'middleware' => ['permission:sysadmin'], 'as' => 'radio::'], function () {
-            Route::get('index', ['as' => 'index', 'uses' => 'RadioController@index']);
-            Route::post('store', ['as' => 'store', 'uses' => 'RadioController@store']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'RadioController@destroy']);
+        Route::prefix('radio')->name('radio::')->middleware(['auth', 'permission:sysadmin'])->controller(RadioController::class)->group(function(){
+            Route::get('index', 'index')->name('index');
+            Route::post('store', 'store')->name('store');
+            Route::get('delete/{id}', 'destroy')->name('delete');
         });
 
         /* Routes related to the Protube displays */
-        Route::group(['prefix' => 'display', 'middleware' => ['permission:sysadmin'], 'as' => 'display::'], function () {
-            Route::get('index', ['as' => 'index', 'uses' => 'DisplayController@index']);
-            Route::post('store', ['as' => 'store', 'uses' => 'DisplayController@store']);
-            Route::post('update/{id}', ['as' => 'update', 'uses' => 'DisplayController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'DisplayController@destroy']);
+        Route::prefix('display')->name('display::')->middleware(['permission:sysadmin'])->controller(DisplayController::class)->group(function(){
+            Route::get('index', 'index')->name('index');
+            Route::post('store', 'store')->name('store');
+            Route::post('update/{id}', 'update')->name('update');
+            Route::get('delete/{id}', 'destroy')->name('delete');
         });
 
-        /* Routes related to teh Soundboard */
-        Route::group(['prefix' => 'soundboard', 'middleware' => ['permission:sysadmin'], 'as' => 'soundboard::'], function () {
-            Route::get('index', ['as' => 'index', 'uses' => 'SoundboardController@index']);
-            Route::post('store', ['as' => 'store', 'uses' => 'SoundboardController@store']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'SoundboardController@destroy']);
-            Route::get('togglehidden/{id}', ['as' => 'togglehidden', 'uses' => 'SoundboardController@toggleHidden']);
+        /* Routes related to the Soundboard */
+        Route::prefix('soundboard')->name('soundboard::')->middleware(['permission:sysadmin'])->controller(SoundboardController::class)->group(function(){
+            Route::get('index', 'index')->name('index');
+            Route::post('store', 'store')->name('store');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+            Route::get('togglehidden/{id}', 'toggleHidden')->name('togglehidden');
         });
     });
 
     /* Routes related to calendars. */
-    Route::group(['prefix' => 'ical', 'as' => 'ical::'], function () {
-        Route::get('calendar/{personal_key?}', ['as' => 'calendar', 'uses' => 'EventController@icalCalendar']);
+    Route::prefix('ical')->name('ical::')->controller(EventController::class)->group(function () {
+        Route::get('calendar/{personal_key?}', 'icalCalendar')->name('calendar');
     });
 
     /* Routes related to the Achievement system. */
-    Route::group(['prefix' => 'achievement', 'as' => 'achievement::'], function () {
-        Route::group(['middleware' => ['auth', 'permission:board']], function () {
-            Route::get('', ['as' => 'list', 'uses' => 'AchievementController@overview']);
-            Route::get('add', ['as' => 'add', 'uses' => 'AchievementController@create']);
-            Route::post('add', ['as' => 'add', 'uses' => 'AchievementController@store']);
-            Route::get('manage/{id}', ['as' => 'manage', 'uses' => 'AchievementController@manage']);
-            Route::post('update/{id}', ['as' => 'update', 'uses' => 'AchievementController@update']);
-            Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'AchievementController@destroy']);
-            Route::post('award/{id}', ['as' => 'award', 'uses' => 'AchievementController@award']);
-            Route::post('give', ['as' => 'give', 'uses' => 'AchievementController@give']);
-            Route::get('take/{id}/{user}', ['as' => 'take', 'uses' => 'AchievementController@take']);
-            Route::get('takeAll/{id}', ['as' => 'takeAll', 'uses' => 'AchievementController@takeAll']);
-            Route::post('{id}/icon', ['as' => 'icon', 'uses' => 'AchievementController@icon']);
+    Route::controller(AchievementController::class)->group(function(){
+        Route::prefix('achievement')->name('achievement::')->group(function () {
+            Route::middleware(['auth', 'permission:board'])->group(function(){
+                Route::get('', 'overview')->name('list');
+                Route::get('add', 'create')->name('add');
+                Route::post('add', 'store')->name('add');
+                Route::get('manage/{id}', 'manage')->name('manage');
+                Route::post('update/{id}', 'update')->name('update');
+                Route::get('delete/{id}', 'destroy')->name('delete');
+                Route::post('award/{id}', 'award')->name('award');
+                Route::post('give', 'give')->name('give');
+                Route::get('take/{id}/{user}', 'take')->name('take');
+                Route::get('takeAll/{id}', 'takeAll')->name('takeAll');
+                Route::post('{id}/icon', 'icon')->name('icon');
+            });
+            Route::get('gallery', 'gallery')->name('gallery');
         });
-        Route::get('gallery', ['as' => 'gallery', 'uses' => 'AchievementController@gallery']);
+        Route::get('achieve/{achievement}', 'achieve')->name('achieve')->middleware(['auth']);
     });
-    Route::get('achieve/{achievement}', ['as' => 'achieve', 'middleware' => ['auth'], 'uses' => 'AchievementController@achieve']);
-
     /* Routes related to the Welcome Message system. */
-    Route::group(['prefix' => 'welcomeMessages', 'middleware' => ['auth', 'permission:board'], 'as' => 'welcomeMessages::'], function () {
-        Route::get('', ['as' => 'list', 'uses' => 'WelcomeController@overview']);
-        Route::post('add', ['as' => 'add', 'uses' => 'WelcomeController@store']);
-        Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'WelcomeController@destroy']);
+    Route::prefix('welcomeMessages')->name('welcomeMessages::')->middleware(['auth', 'permission:board'])->controller(WelcomeController::class)->group(function () {
+        Route::get('', 'overview')->name('list');
+        Route::post('add', 'store')->name('add');
+        Route::get('delete/{id}', 'destroy')->name('delete');
     });
 
     /* Routes related to Protube TempAdmin */
-    Route::group(['prefix' => 'tempadmin', 'as' => 'tempadmin::', 'middleware' => ['auth', 'permission:board']], function () {
-        Route::get('make/{id}', ['as' => 'make', 'uses' => 'TempAdminController@make']);
-        Route::get('end/{id}', ['as' => 'end', 'uses' => 'TempAdminController@end']);
-        Route::get('endId/{id}', ['as' => 'endId', 'uses' => 'TempAdminController@endId']);
-        Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'TempAdminController@edit']);
-        Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'TempAdminController@update']);
-        Route::get('add', ['as' => 'add', 'uses' => 'TempAdminController@create']);
-        Route::post('add', ['as' => 'add', 'uses' => 'TempAdminController@store']);
-        Route::get('', ['as' => 'index', 'uses' => 'TempAdminController@index']);
+    Route::prefix('tempadmin')->name('tempadmin::')->middleware(['auth', 'permission:board'])->controller(TempAdminController::class)->group(function () {
+        Route::get('', 'index')->name('index');
+        Route::get('make/{id}', 'make')->name('make');
+        Route::get('end/{id}', 'end')->name('end');
+        Route::get('endId/{id}', 'endId')->name('endId');
+        Route::get('edit/{id}', 'edit')->name('edit');
+        Route::post('edit/{id}', 'update')->name('edit');
+        Route::get('add', 'create')->name('add');
+        Route::post('add', 'store')->name('add');
     });
 
     /* Routes related to QR Authentication. */
-    Route::group(['prefix' => 'qr', 'as' => 'qr::'], function () {
-        Route::get('code/{code}', ['as' => 'code', 'uses' => 'QrAuthController@showCode']);
-        Route::post('generate', ['as' => 'generate', 'uses' => 'QrAuthController@generateRequest']);
-        Route::get('isApproved', ['as' => 'approved', 'uses' => 'QrAuthController@isApproved']);
-
-        Route::group(['middleware' => ['auth']], function () {
-            Route::get('{code}', ['as' => 'dialog', 'uses' => 'QrAuthController@showDialog']);
-            Route::get('{code}/approve', ['as' => 'approve', 'uses' => 'QrAuthController@approve']);
+    Route::prefix('qr')->name('qr::')->controller(QrAuthController::class)->group(function () {
+        Route::get('code/{code}', 'showCode')->name('code');
+        Route::post('generate', 'generateRequest')->name('generate');
+        Route::get('isApproved', 'isApproved')->name('approved');
+        Route::middleware(['auth'])->group(function () {
+            Route::get('{code}', 'showDialog')->name('dialog');
+            Route::get('{code}/approve', 'approve')->name('approve');
         });
     });
 
     /* Routes related to the Short URL Service */
-    Route::group(['prefix' => 'short_url', 'as' => 'short_url::', 'middleware' => ['auth', 'permission:board']], function () {
-        Route::get('', ['as' => 'index', 'uses' => 'ShortUrlController@index']);
-        Route::get('edit/{id}', ['as' => 'edit', 'uses' => 'ShortUrlController@edit']);
-        Route::post('edit/{id}', ['as' => 'edit', 'uses' => 'ShortUrlController@update']);
-        Route::get('delete/{id}', ['as' => 'delete', 'uses' => 'ShortUrlController@destroy']);
+    Route::name('short_url::')->controller(ShortUrlController::class)->group(function () {
+        Route::prefix('short_url')->middleware(['auth', 'permission:board'])->group(function (){
+            Route::get('', 'index')->name('index');
+            Route::get('edit/{id}', 'edit')->name('edit');
+            Route::post('edit/{id}', 'update')->name('edit');
+            Route::get('delete/{id}', 'destroy')->name('delete');
+        });
+        Route::get('go/{short?}', 'go')->name('go');
     });
-    Route::get('go/{short?}', ['as' => 'short_url::go', 'uses' => 'ShortUrlController@go']);
 
     /* Routes related to the DMX Management. */
-    Route::group(['prefix' => 'dmx', 'as' => 'dmx::', 'middleware' => ['auth', 'permission:board|alfred']], function () {
-        Route::get('/', ['as' => 'index', 'uses' => 'DmxController@index']);
-        Route::get('/add', ['as' => 'add', 'uses' => 'DmxController@create']);
-        Route::post('/add', ['as' => 'add', 'uses' => 'DmxController@store']);
-        Route::get('/edit/{id}', ['as' => 'edit', 'uses' => 'DmxController@edit']);
-        Route::post('/edit/{id}', ['as' => 'edit', 'uses' => 'DmxController@update']);
-        Route::get('/delete/{id}', ['as' => 'delete', 'uses' => 'DmxController@delete']);
+    Route::prefix('dmx')->name('dmx::')->middleware(['auth', 'permission:board|alfred'])->controller(DmxController::class)->group(function () {
+        Route::get('/', 'index')->name('index');
+        Route::get('/add', 'create')->name('add');
+        Route::post('/add', 'store')->name('add');
+        Route::get('/edit/{id}', 'edit')->name('edit');
+        Route::post('/edit/{id}', 'update')->name('edit');
+        Route::get('/delete/{id}', 'destroy')->name('delete');
 
-        Route::group(['prefix' => 'override', 'as' => 'override::'], function () {
-            Route::get('/', ['as' => 'index', 'uses' => 'DmxController@overrideIndex']);
-            Route::get('/add', ['as' => 'add', 'uses' => 'DmxController@overrideCreate']);
-            Route::post('/add', ['as' => 'add', 'uses' => 'DmxController@overrideStore']);
-            Route::get('/edit/{id}', ['as' => 'edit', 'uses' => 'DmxController@overrideEdit']);
-            Route::post('/edit/{id}', ['as' => 'edit', 'uses' => 'DmxController@overrideUpdate']);
-            Route::get('/delete/{id}', ['as' => 'delete', 'uses' => 'DmxController@overrideDelete']);
+        Route::prefix('override')->name('override::')->group(function () {
+            Route::get('/', 'overrideIndex')->name('index');
+            Route::get('/add', 'overrideCreate')->name('add');
+            Route::post('/add', 'overrideStore')->name('add');
+            Route::get('/edit/{id}', 'overrideEdit')->name('edit');
+            Route::post('/edit/{id}', 'overrideUpdate')->name('edit');
+            Route::get('/delete/{id}', 'overrideDestroy')->name('delete');
         });
     });
 
     /* Routes related to the Query system. */
-    Route::group(['prefix' => 'queries', 'as' => 'queries::', 'middleware' => ['auth', 'permission:board']], function () {
-        Route::get('/', ['as' => 'index', 'uses' => 'QueryController@index']);
-        Route::get('/activity_overview', ['as' => 'activity_overview', 'uses' => 'QueryController@activityOverview']);
-        Route::get('/membership_totals', ['as' => 'membership_totals', 'uses' => 'QueryController@membershipTotals']);
+    Route::prefix('queries')->name('queries::')->middleware(['auth', 'permission:board'])->controller(QueryController::class)->group(function () {
+        Route::get('/', 'index')->name('index');
+        Route::get('/activity_overview', 'activityOverview')->name('activity_overview');
+        Route::get('/membership_totals', 'membershipTotals')->name('membership_totals');
     });
 
     /* Routes related to the Minisites */
-    Route::group(['prefix' => 'minisites', 'as' => 'minisites::'], function () {
-        Route::group(['prefix' => 'isalfredthere', 'as' => 'isalfredthere::'], function () {
-            Route::get('/', ['as' => 'index', 'uses' => 'IsAlfredThereController@showMiniSite']);
-            Route::get('/admin', ['as' => 'admin', 'uses' => 'IsAlfredThereController@getAdminInterface', 'middleware' => ['auth', 'permission:sysadmin|alfred']]);
-            Route::post('/admin', ['as' => 'admin', 'uses' => 'IsAlfredThereController@postAdminInterface', 'middleware' => ['auth', 'permission:sysadmin|alfred']]);
+    Route::prefix('minisites')->name('minisites::')->group(function () {
+        Route::prefix('isalfredthere')->name('isalfredthere::')->controller(IsAlfredThereController::class)->group(function () {
+            Route::get('/', 'showshowMiniSite')->name('index');
+            Route::get('/admin', 'getAdminInterface')->name('admin')->middleware(['auth', 'permission:sysadmin|alfred']);
+            Route::post('/admin', 'postAdminInterface')->name('admin')->middleware(['auth', 'permission:sysadmin|alfred']);
         });
     });
 });


### PR DESCRIPTION
Moved the syntax from web.php over to the new php callable syntax and made more appropriate use of grouping.
I suggest taking a work evening to test this thoroughly.

For some reason 'sail artisan route:list' can not find the ProtubeController and I do not see why as the filenames seem to be correct and the import and namespace are there and my editor recognizes it. So if someone sees my mistake please let me know.
Also reminded me of the fact that we need to remove all of the unused Protube features as more than half the routes are old and unused.