### PR TITLE
set the uploadlimit for our local phpmyadmin image so it does not default to 0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
         environment:
             - 'PMA_HOST=mariadb'
             - 'PMA_PORT=${SAIL_SQL_PORT}'
+            - 'UPLOAD_LIMIT=500M'
         networks:
             - sail
         depends_on:


### PR DESCRIPTION
When trying to import a database locally for debugging the phpmyadmin errors because no upload limit is set in the docker container so it defaults to 0 bytes. This is not taken from the php.ini because it is its seperate container. Now set to 500mb so we will not encounter the limit again soon.