### PR TITLE
Fix/improve committee page visibilty

### DIFF
--- a/resources/assets/sass/partials/_components.scss
+++ b/resources/assets/sass/partials/_components.scss
@@ -150,14 +150,21 @@ $card-collapse-bg: #fff !default;
 }
 
 // Events
-$event-gradient: linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.8)) !default;
-$event-hover-gradient: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)) !default;
+$event-gradient: linear-gradient(rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.7)) !default;
+$event-hover-gradient: linear-gradient(rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.6)) !default;
 $event-bg: #eee !default;
 $event-hover-bg: #aaa !default;
 
 .event {
-  * { position: relative; z-index: 2; }
   p { margin: 0; }
+  &.no-img {
+    background: $event-bg;
+    &:hover { background: $event-hover-bg; }
+  }
+}
+
+.dark-card{
+  * { position: relative; z-index: 2; }
   &::after {
     position: absolute;
     top: 0;
@@ -168,12 +175,8 @@ $event-hover-bg: #aaa !default;
     content: '';
     z-index: 1;
   }
-  &:hover.event::after {
+  &:hover::after {
     background-image: $event-hover-gradient;
-  }
-  &.no-img {
-    background: $event-bg;
-    &:hover { background: $event-hover-bg; }
   }
 }
 
@@ -253,11 +256,15 @@ $event-hover-bg: #aaa !default;
 }
 
 // Card Background Photos
-$photo_pop-color: #fff !default;
+$photo_pop-color: #000 !default;
 $photo-color: #222 !default;
 $photo-hover-color: #222 !default;
 $photo-gradient: linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.7)) !default;
 $photo-hover-gradient: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.6)) !default;
+
+.card{
+  overflow: hidden;
+}
 
 .photo_pop {
   color: $photo_pop-color;

--- a/resources/assets/sass/partials/_components.scss
+++ b/resources/assets/sass/partials/_components.scss
@@ -150,8 +150,8 @@ $card-collapse-bg: #fff !default;
 }
 
 // Events
-$event-gradient: linear-gradient(rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.7)) !default;
-$event-hover-gradient: linear-gradient(rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.6)) !default;
+$event-gradient: linear-gradient(rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.6)) !default;
+$event-hover-gradient: linear-gradient(rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.5)) !default;
 $event-bg: #eee !default;
 $event-hover-bg: #aaa !default;
 

--- a/resources/assets/sass/rainbowbarf.scss
+++ b/resources/assets/sass/rainbowbarf.scss
@@ -36,6 +36,21 @@ body, .card, .navbar {
   margin: 0;
   overflow: hidden;
 }
+.dark-card{
+  &::after {
+    background: linear-gradient(124deg, #ff2400, #e81d1d, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3
+    , #dd00f3);
+    opacity: 25%;
+    background-size: 1800% 1800%;
+    animation: rainbow 18s ease infinite;
+  }
+  &:hover::after {
+    background: linear-gradient(124deg, #ff2400, #e81d1d, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3
+    , #dd00f3);
+    background-size: 1800% 1800%;
+    opacity: 15%;
+  }
+}
 
 @keyframes rotate {
   100% {

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -3,7 +3,7 @@
     <a class="card mb-3 leftborder leftborder-info text-decoration-none"
        href="{{ route('event::show', ['id' => $event->getPublicId()]) }}">
 
-        <div class="card-body event text-start {{ $event->image && (!isset($hide_photo) || !$hide_photo) ? 'bg-img' : 'no-img'}}"
+        <div class="card-body dark-card event text-start {{ $event->image && (!isset($hide_photo) || !$hide_photo) ? 'bg-img' : 'no-img'}}"
              style="{{ $event->image && (!isset($hide_photo) || !$hide_photo) ? sprintf('background: center no-repeat url(%s);', $event->image->generateImagePath(800,300)) : '' }} background-size: cover;">
 
             {{-- Countdown --}}

--- a/resources/views/website/layouts/macros/card-bg-image.blade.php
+++ b/resources/views/website/layouts/macros/card-bg-image.blade.php
@@ -1,6 +1,6 @@
 <div id="{{ $id ?? null  }}" class="card mb-3 text-decoration-none {{ isset($classes) ? implode(' ', $classes) : null }}
 {{ isset($leftborder) ? sprintf('leftborder leftborder-%s', $leftborder) : null }}">
-    <a href="{{ $url ?? '#' }}" class="card-body d-flex justify-content-start text-decoration-none {{ (isset($photo_pop)&&$photo_pop) ? 'photo_pop' : 'photo' }}"
+    <a href="{{ $url ?? '#' }}" class="card-body dark-card d-flex justify-content-start text-decoration-none {{ (isset($photo_pop)&&$photo_pop) ? 'photo_pop' : 'photo' }}"
        style="background: center no-repeat {{ isset($img) ? "url($img)" : "#333" }}; background-size: cover; height: {{ $height ?? 100 }}px;">
         <p class="card-text ellipsis">
             {!! $html !!}


### PR DESCRIPTION
## Improved committee, photo and societies pages

Splitted the overlay on the events to a new css class, `.dark-card`. This class is then used on the committee, societies and photo overview pages, as well as the events in on the home page.
Also updated the default white overlay to have a lower opacity so the page isn't completly white.
The rainbowbarf has a custom beatifull animated overlay.

![afbeelding](https://user-images.githubusercontent.com/94541505/224007067-f7fe6f37-e636-43b9-abdb-160cc2f5684f.png)
