### PR TITLE
Properly add the photo_pop effect to the committee overview

### DIFF
--- a/resources/assets/sass/partials/_components.scss
+++ b/resources/assets/sass/partials/_components.scss
@@ -150,21 +150,14 @@ $card-collapse-bg: #fff !default;
 }
 
 // Events
-$event-gradient: linear-gradient(rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.6)) !default;
-$event-hover-gradient: linear-gradient(rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.5)) !default;
+$event-gradient: linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.8)) !default;
+$event-hover-gradient: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)) !default;
 $event-bg: #eee !default;
 $event-hover-bg: #aaa !default;
 
 .event {
-  p { margin: 0; }
-  &.no-img {
-    background: $event-bg;
-    &:hover { background: $event-hover-bg; }
-  }
-}
-
-.dark-card{
   * { position: relative; z-index: 2; }
+  p { margin: 0; }
   &::after {
     position: absolute;
     top: 0;
@@ -175,8 +168,12 @@ $event-hover-bg: #aaa !default;
     content: '';
     z-index: 1;
   }
-  &:hover::after {
+  &:hover.event::after {
     background-image: $event-hover-gradient;
+  }
+  &.no-img {
+    background: $event-bg;
+    &:hover { background: $event-hover-bg; }
   }
 }
 
@@ -256,15 +253,11 @@ $event-hover-bg: #aaa !default;
 }
 
 // Card Background Photos
-$photo_pop-color: #000 !default;
+$photo_pop-color: #fff !default;
 $photo-color: #222 !default;
 $photo-hover-color: #222 !default;
 $photo-gradient: linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.7)) !default;
 $photo-hover-gradient: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.6)) !default;
-
-.card{
-  overflow: hidden;
-}
 
 .photo_pop {
   color: $photo_pop-color;

--- a/resources/assets/sass/rainbowbarf.scss
+++ b/resources/assets/sass/rainbowbarf.scss
@@ -36,21 +36,6 @@ body, .card, .navbar {
   margin: 0;
   overflow: hidden;
 }
-.dark-card{
-  &::after {
-    background: linear-gradient(124deg, #ff2400, #e81d1d, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3
-    , #dd00f3);
-    opacity: 25%;
-    background-size: 1800% 1800%;
-    animation: rainbow 18s ease infinite;
-  }
-  &:hover::after {
-    background: linear-gradient(124deg, #ff2400, #e81d1d, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3
-    , #dd00f3);
-    background-size: 1800% 1800%;
-    opacity: 15%;
-  }
-}
 
 @keyframes rotate {
   100% {

--- a/resources/views/committee/list.blade.php
+++ b/resources/views/committee/list.blade.php
@@ -16,7 +16,7 @@
 
                     <div class="col-lg-2 col-lg-3 col-md-4 col-sm-6">
 
-                        @include('committee.include.committee_block', ['committee' => $committee])
+                        @include('committee.include.committee_block', ['committee' => $committee, 'photo_pop'=>false])
 
                     </div>
 

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -3,7 +3,7 @@
     <a class="card mb-3 leftborder leftborder-info text-decoration-none"
        href="{{ route('event::show', ['id' => $event->getPublicId()]) }}">
 
-        <div class="card-body dark-card event text-start {{ $event->image && (!isset($hide_photo) || !$hide_photo) ? 'bg-img' : 'no-img'}}"
+        <div class="card-body event text-start {{ $event->image && (!isset($hide_photo) || !$hide_photo) ? 'bg-img' : 'no-img'}}"
              style="{{ $event->image && (!isset($hide_photo) || !$hide_photo) ? sprintf('background: center no-repeat url(%s);', $event->image->generateImagePath(800,300)) : '' }} background-size: cover;">
 
             {{-- Countdown --}}

--- a/resources/views/website/layouts/macros/card-bg-image.blade.php
+++ b/resources/views/website/layouts/macros/card-bg-image.blade.php
@@ -1,6 +1,6 @@
 <div id="{{ $id ?? null  }}" class="card mb-3 text-decoration-none {{ isset($classes) ? implode(' ', $classes) : null }}
 {{ isset($leftborder) ? sprintf('leftborder leftborder-%s', $leftborder) : null }}">
-    <a href="{{ $url ?? '#' }}" class="card-body dark-card d-flex justify-content-start text-decoration-none {{ (isset($photo_pop)&&$photo_pop) ? 'photo_pop' : 'photo' }}"
+    <a href="{{ $url ?? '#' }}" class="card-body d-flex justify-content-start text-decoration-none {{ (isset($photo_pop)&&$photo_pop) ? 'photo_pop' : 'photo' }}"
        style="background: center no-repeat {{ isset($img) ? "url($img)" : "#333" }}; background-size: cover; height: {{ $height ?? 100 }}px;">
         <p class="card-text ellipsis">
             {!! $html !!}


### PR DESCRIPTION
Revert "Fix/improve committee page visibility (#1895)"

This reverts commit a1af0c012b3ccbebe8072c0ce13f73ea25c417f0.

After looking at it myself again the only thing needed was to add the photo_pop class to the old situation, so the photo overview etc does not have the effect anymore.