### PR TITLE
Add the option to show the users who have bought tickets on an event

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -48,6 +48,7 @@ class TicketController extends Controller
         $ticket->is_prepaid = $request->has('is_prepaid');
         $ticket->available_from = strtotime($request->input('available_from'));
         $ticket->available_to = strtotime($request->input('available_to'));
+        $ticket->show_participants = $request->has('show_participants');
         $ticket->save();
 
         Session::flash('flash_message', 'The ticket has been created!');
@@ -90,6 +91,7 @@ class TicketController extends Controller
         $ticket->is_prepaid = $request->has('is_prepaid');
         $ticket->available_from = strtotime($request->input('available_from'));
         $ticket->available_to = strtotime($request->input('available_to'));
+        $ticket->show_participants = $request->has('show_participants');
         $ticket->save();
 
         Session::flash('flash_message', 'The ticket has been updated!');

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -307,6 +307,21 @@ class Event extends Model
         });
     }
 
+    public function allUsersCount()
+    {
+        $allUserIds=collect([]);
+        foreach ($this->tickets as $ticket) {
+            if($ticket->show_participants) {
+                $allUserIds = $allUserIds->merge($ticket->getUsers()->pluck('id'));
+            }
+        }
+
+        if ($this->activity) {
+            $allUserIds = $allUserIds->merge($this->activity->allUsers->pluck('id'));
+        }
+        return $allUserIds->unique()->count();
+    }
+
     /** @return string[] */
     public function getAllEmails()
     {

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Collection;
  * @property int $available_to
  * @property bool $members_only
  * @property bool $is_prepaid
+ * @property bool $show_participants
  * @property-read Event $event
  * @property-read Product $product
  * @property-read Collection|TicketPurchase[] $purchases

--- a/database/migrations/2023_04_23_231630_add_show_participants_to_ticket.php
+++ b/database/migrations/2023_04_23_231630_add_show_participants_to_ticket.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddShowParticipantsToTicket extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->boolean('show_participants')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->dropColumn('show_participants');
+        });
+    }
+}

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -107,21 +107,20 @@
             @endif
 
             {{-- Signup Icon --}}
-            @if($event->activity)
                 <div class= "d-flex justify-content-between">
-                    @if($event->activity->users->count()>0)
+                    @if($event->allUsersCount()>0)
                         <span>
                             <i class="fas fa-user-alt fa-fw" aria-hidden="true"></i>
-                            {{$event->activity->users->count()}}
+                            {{$event->allUsersCount()}}
                         </span>
                     @endif
-                    @if($event->activity->canSubscribe())
+
+                    @if($event->activity && $event->activity->canSubscribe())
                         <span>
                             <i class="fas fa-lock-open"></i>
                         </span>
                     @endif
                 </div>
-            @endif
 
         </div>
 

--- a/resources/views/event/display_includes/render_participant_list.blade.php
+++ b/resources/views/event/display_includes/render_participant_list.blade.php
@@ -1,6 +1,6 @@
 @foreach($participants as $user)
 
-    <?php $pid = (get_class($user) == 'Proto\Models\User' ? $user->pivot->id : $user->id) ?>
+    <?php $pid = (get_class($user) == 'Proto\Models\User' && $event ? $user->pivot->id : $user->id) ?>
     <?php $u = (get_class($user) == 'Proto\Models\User' ? $user : $user->user) ?>
 
     <div class="btn-group btn-group-sm mb-1">
@@ -10,7 +10,7 @@
             style="width: 21px; height: 21px; margin-top: -3px;">
             {{ $u->name }}
         </a>
-        @if(Auth::user()->can('board') && !$event->activity->closed)
+        @if(Auth::user()->can('board') && $event && !$event->activity->closed)
             <a href="{{ route('event::deleteparticipation', ['participation_id' => $pid]) }}"
                class="btn btn-outline-warning">
                 <i class="fas fa-times" aria-hidden="true"></i>

--- a/resources/views/event/display_includes/tickets.blade.php
+++ b/resources/views/event/display_includes/tickets.blade.php
@@ -149,6 +149,9 @@
                                     </select>
                                 @endif
 
+                                @if($ticket->show_participants)
+                                    <i>Note: with this ticket your name be visible on the event page</i>
+                                @endif
                             </div>
                         </div>
 
@@ -193,6 +196,22 @@
 
     </form>
 
+    @foreach($event->tickets as $ticket)
+        @if($ticket->show_participants)
+            <div class="card mb-3">
+                <div class="card-header">
+                    Participants who bought <b>{{$ticket->product->name}}</b> tickets
+                </div>
+                <div class="card-body">
+                    @include('event.display_includes.render_participant_list', [
+                                'participants' => $ticket->getUsers(),
+                                'event' => null
+                            ])
+                </div>
+            </div>
+        @endif
+    @endforeach
+
     @push('javascript')
         <script type="text/javascript" nonce="{{ csp_nonce() }}">
             const directPayButton = document.getElementById('directpay')
@@ -217,4 +236,5 @@
             }))
         </script>
     @endpush
+
 @endif

--- a/resources/views/tickets/edit.blade.php
+++ b/resources/views/tickets/edit.blade.php
@@ -62,6 +62,14 @@
                             </label>
                         </div>
 
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox"
+                                       name="show_participants" {{ ($ticket && $ticket->show_participants ? 'checked' : '') }}>
+                                Show the participant's who bought this ticket on the event.
+                            </label>
+                        </div>
+
                     </div>
 
                     <div class="card-footer">


### PR DESCRIPTION
This helps with the confusion when for instance with a symposium you want to create hype but users get confused by only getting a ticket or only signing up. The idea is that you then will not make an event for that anymore. Fixes #1900 and #1820 as you can add two free tickets.