### PR TITLE
Fixed the user count on events

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -309,7 +309,7 @@ class Event extends Model
         });
     }
 
-    public function allUsersCount()
+    public function usersCount()
     {
         $allUserIds = collect([]);
         foreach ($this->tickets as $ticket) {
@@ -319,7 +319,7 @@ class Event extends Model
         }
 
         if ($this->activity) {
-            $allUserIds = $allUserIds->merge($this->activity->allUsers->pluck('id'));
+            $allUserIds = $allUserIds->merge($this->activity->users->pluck('id'));
         }
         return $allUserIds->unique()->count();
     }

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -108,10 +108,10 @@
 
             {{-- Signup Icon --}}
                 <div class= "d-flex justify-content-between">
-                    @if($event->allUsersCount()>0)
+                    @if($event->usersCount()>0)
                         <span>
                             <i class="fas fa-user-alt fa-fw" aria-hidden="true"></i>
-                            {{$event->allUsersCount()}}
+                            {{$event->usersCount()}}
                         </span>
                     @endif
 

--- a/resources/views/tickets/edit.blade.php
+++ b/resources/views/tickets/edit.blade.php
@@ -62,13 +62,11 @@
                             'label' => 'This ticket should be prepaid.'
                         ])
 
-                        <div class="checkbox">
-                            <label>
-                                <input type="checkbox"
-                                       name="show_participants" {{ ($ticket && $ticket->show_participants ? 'checked' : '') }}>
-                                Show the participant's who bought this ticket on the event.
-                            </label>
-                        </div>
+                        @include('components.forms.checkbox', [
+                           'name' => 'show_participants',
+                           'checked' =>  $ticket?->show_participants,
+                           'label' => "Show the participant's who bought this ticket on the event."
+                       ])
 
                     </div>
 


### PR DESCRIPTION
The user count accidentally also included helpers (which was not apparent because sometimes helpers are signed up and sometimes not and we only count the unique ID's).
Also, use the new checkbox component for the corresponding ticket toolie.