### PR TITLE
Use the FISHCAM_URL instead of the removed API route in Smartxp Screen

### DIFF
--- a/resources/views/smartxp/screen.blade.php
+++ b/resources/views/smartxp/screen.blade.php
@@ -159,7 +159,7 @@
         }
 
         #protube.inactive {
-            background-image: url('{{ route('api::fishcam') }}') !important;
+            background-image: url({{env("FISHCAM_URL")}}) !important;
         }
 
         #protube-title {


### PR DESCRIPTION
Fixes the screens in SmartXP. 

They broke because the fishcam API is no longer there.

This PR fixes it. 

Breaking PR: #1932 