### PR TITLE
revert the image() relation of companies back to the correct db field

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -59,7 +59,7 @@ class Company extends Model
     /** @return BelongsTo */
     public function image()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'photo_id');
+        return $this->belongsTo('App\Models\StorageEntry', 'image_id');
     }
 
     /** @return HasMany */


### PR DESCRIPTION
With the fixing of updating and creating companies (#1972), my local DB was accidentally seeded on the photo-update branch.
I fixed the updates but accidentally broke the belongsTo relation by setting it to the new Photo field instead of the image field. This breaks the company images and therefore the logo bar. Now reverted.