### PR TITLE
Fix weird styling of event signup details

### DIFF
--- a/app/Csp/Policies/ProtoPolicy.php
+++ b/app/Csp/Policies/ProtoPolicy.php
@@ -2,12 +2,13 @@
 
 namespace App\Csp\Policies;
 
-use function Sentry\captureException;
 use Spatie\Csp\Directive;
 use Spatie\Csp\Exceptions\InvalidDirective;
 use Spatie\Csp\Exceptions\InvalidValueSet;
 use Spatie\Csp\Keyword;
 use Spatie\Csp\Policies\Policy;
+
+use function Sentry\captureException;
 
 class ProtoPolicy extends Policy
 {

--- a/resources/views/event/edit_includes/activity.blade.php
+++ b/resources/views/event/edit_includes/activity.blade.php
@@ -81,17 +81,6 @@
                                    required>
                         </div>
 
-                        <div class="col-md-12 mb-3">
-                            <label for="redirect_url">Redirect URL</label>
-                            <i class="fas fa-question-circle me-2" data-bs-toggle="tooltip" data-bs-placement="top"
-                               data-html="true"
-                               title="The URL you get redirect to after signing up!."></i>
-                            <input type="url" class="form-control" id="redirect_url" name="redirect_url"
-                                   placeholder='https://forms.gle/...'
-                                   value="{{ $event->activity?->redirect_url ?? ''}}"
-                            />
-                        </div>
-
                     </div>
 
                     <div class="col-md-6">
@@ -107,11 +96,26 @@
                                value="{{ old('participants', $event->activity?->participants) }}">
                     </div>
 
-                    @include('components.forms.checkbox', [
+                    <div class="col-md-6">
+                        <div class="col-md-12 mb-3">
+                            <label for="redirect_url">Redirect URL</label>
+                            <i class="fas fa-question-circle me-2" data-bs-toggle="tooltip" data-bs-placement="top"
+                               data-html="true"
+                               title="The URL you get redirect to after signing up!."></i>
+                            <input type="url" class="form-control" id="redirect_url" name="redirect_url"
+                                   placeholder='https://forms.gle/...'
+                                   value="{{ $event->activity?->redirect_url ?? ''}}"
+                            />
+                        </div>
+                    </div>
+
+                    <div class="col-md-6">
+                        @include('components.forms.checkbox', [
                         'name' => 'hide_participants',
                         'checked' => isset($request) && $request->exists('hide_participants') || $event->activity?->hide_participants,
-                        'label' => '<i class="fas fa-question-circle me-2" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="This will hide who participates in this event for members!"></i>'
-                    ])
+                        'label' => 'Hide participants  <i class="fas fa-question-circle me-2" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="This will hide who participates in this event for members!"></i>'
+                        ])
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
The hide participants checkbox does not have a description currently and is placed weirdly. 
![image](https://github.com/saproto/saproto/assets/72889753/0f0912f5-6036-49ff-b8d0-805aaaaf966b)
