### PR TITLE
Move the orderline wizard to a new page

### DIFF
--- a/app/Http/Controllers/OrderLineController.php
+++ b/app/Http/Controllers/OrderLineController.php
@@ -110,14 +110,15 @@ class OrderLineController extends Controller
         ]);
     }
 
-    public function orderlineWizard(){
-         $members = User::whereHas('member', function ($query) {
+    public function orderlineWizard()
+    {
+        $members = User::whereHas('member', function ($query) {
             $query->where('is_pending', false);
         })->orderBy('name')->get();
 
-         $products=Product::where('is_visible', true)->orderBy('name')->get();
+        $products = Product::where('is_visible', true)->orderBy('name')->get();
 
-       return view('omnomcom.orders.admin_includes.orderline-wizard', [
+        return view('omnomcom.orders.admin_includes.orderline-wizard', [
             'members' => $members,
             'products' => $products,
         ]);
@@ -139,9 +140,9 @@ class OrderLineController extends Controller
         }
 
         $orderlines = $orderlines->with('user', 'product')
-                                 ->orderBy('created_at', 'desc')
-                                 ->paginate(20)
-                                 ->appends(['date' => $date]);
+            ->orderBy('created_at', 'desc')
+            ->paginate(20)
+            ->appends(['date' => $date]);
 
         return view('omnomcom.orders.adminhistory', [
             'date' => $date,

--- a/app/Http/Controllers/OrderLineController.php
+++ b/app/Http/Controllers/OrderLineController.php
@@ -101,12 +101,25 @@ class OrderLineController extends Controller
         } else {
             $orderlines = OrderLine::whereDate('created_at', Carbon::today());
         }
-        $orderlines = $orderlines->orderBy('created_at', 'desc')->paginate(20);
+        $orderlines = $orderlines->with('user', 'product')->orderBy('created_at', 'desc')->paginate(20);
 
         return view('omnomcom.orders.adminhistory', [
             'date' => Carbon::today()->format('d-m-Y'),
             'orderlines' => $orderlines,
             'user' => null,
+        ]);
+    }
+
+    public function orderlineWizard(){
+         $members = User::whereHas('member', function ($query) {
+            $query->where('is_pending', false);
+        })->orderBy('name')->get();
+
+         $products=Product::where('is_visible', true)->orderBy('name')->get();
+
+       return view('omnomcom.orders.admin_includes.orderline-wizard', [
+            'members' => $members,
+            'products' => $products,
         ]);
     }
 
@@ -125,7 +138,10 @@ class OrderLineController extends Controller
             $orderlines = OrderLine::whereDate('created_at', Carbon::parse($date));
         }
 
-        $orderlines = $orderlines->orderBy('created_at', 'desc')->paginate(20)->appends(['date' => $date]);
+        $orderlines = $orderlines->with('user', 'product')
+                                 ->orderBy('created_at', 'desc')
+                                 ->paginate(20)
+                                 ->appends(['date' => $date]);
 
         return view('omnomcom.orders.adminhistory', [
             'date' => $date,
@@ -149,7 +165,10 @@ class OrderLineController extends Controller
             $orderlines = OrderLine::where('user_id', $user);
         }
 
-        $orderlines = $orderlines->orderBy('created_at', 'desc')->paginate(20)->appends(['user' => $user]);
+        $orderlines = $orderlines->with('user', 'product')
+            ->orderBy('created_at', 'desc')
+            ->paginate(20)
+            ->appends(['user' => $user]);
 
         return view('omnomcom.orders.adminhistory', [
             'date' => null,

--- a/resources/views/omnomcom/orders/admin_includes/orderline-addone.blade.php
+++ b/resources/views/omnomcom/orders/admin_includes/orderline-addone.blade.php
@@ -1,4 +1,4 @@
-<a class="btn btn-success btn-block mb-3" data-bs-toggle="modal" data-bs-target="#orderline-modal" href="#">
+<a class="btn btn-success btn-block mb-3" href="{{route('omnomcom::orders::orderline-wizard')}}">
     Add orderline wizard. <span class="ms-3">🧙</span>
 </a>
 

--- a/resources/views/omnomcom/orders/admin_includes/orderline-wizard.blade.php
+++ b/resources/views/omnomcom/orders/admin_includes/orderline-wizard.blade.php
@@ -1,25 +1,33 @@
-<div id="orderline-modal" class="modal fade vh-100" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-lg">
+@extends('website.layouts.redesign.generic')
+
+@section('page-title')
+Orderline wizard
+@endsection
+
+@section('container')
+    <div class="row">
+    <div class="column">
 
         <form method="post" action="{{ route('omnomcom::orders::addbulk') }}">
 
             {!! csrf_field() !!}
 
-            <div class="modal-content" style="height:calc(100vh - 80px)">
+            <div class="card mb-3">
 
-                <div class="modal-header">
-                    <h5 class="modal-title">Add orderlines</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <div class="card-header d-inline-flex justify-content-between">
+                    <h5>Add orderlines</h5 >
+                    <a href="{{ route('omnomcom::orders::adminlist') }}" class="btn btn-default">
+                        Back to Orderline Overview
+                    </a>
                 </div>
 
-                <div id="orderline-rows" class="modal-body overflow-auto">
+                <div id="orderline-rows" class="card-body">
 
                     <div class="row orderline-row">
 
                         <div class="col-lg-3">
 
                             <select name="user[]" class="form-control orderline-user">
-                                {{ $members = App\Models\User::has('member')->orderBy('name')->get()->reject(function(App\Models\User $user, int $index) { return $user->member->is_pending == true; }) }}
                                 @foreach($members as $member)
                                     <option value="{{ $member->id }}">{{ $member->name }} (#{{ $member->id }})</option>
                                 @endforeach
@@ -30,7 +38,7 @@
                         <div class="col-lg-3">
 
                             <select name="product[]" class="form-control orderline-product">
-                                @foreach(App\Models\Product::where('is_visible', true)->orderBy('name', 'asc')->get() as $product)
+                                @foreach($products as $product)
                                     <option value="{{ $product->id }}" data-price="{{ $product->price }}">{{ $product->name }}
                                         (&euro;{{ $product->price }}, #{{ $product->id }})
                                     </option>
@@ -91,11 +99,6 @@
                         </button>
                     </div>
                     <div class="col-1">
-                        <button class="btn btn-outline-default btn-block" data-bs-dismiss="modal">
-                            <i class="fas fa-times-circle"></i>
-                        </button>
-                    </div>
-                    <div class="col-1">
                         <button type="submit" class="btn btn-success btn-block">
                             <i class="fas fa-shopping-cart"></i>
                         </button>
@@ -106,9 +109,9 @@
             </div>
 
         </form>
-
     </div>
-</div>
+    </div>
+@endsection
 
 @push('javascript')
 

--- a/resources/views/omnomcom/orders/adminhistory.blade.php
+++ b/resources/views/omnomcom/orders/adminhistory.blade.php
@@ -27,6 +27,4 @@
 
     </div>
 
-    @include('omnomcom.orders.admin_includes.orderline-modal')
-
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -548,7 +548,6 @@ Route::group(['middleware' => ['forcedomain']], function () {
             Route::post('add/single', ['as' => 'add', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@store']);
             Route::get('delete/{id}', ['as' => 'delete', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@destroy']);
 
-
             Route::get('history/{date?}', ['as' => 'list', 'uses' => 'OrderLineController@index']);
             Route::get('', ['as' => 'adminlist', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@adminindex']);
             Route::get('orderline-wizard', ['as' => 'orderline-wizard', 'uses' => 'OrderLineController@orderlineWizard']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -548,8 +548,10 @@ Route::group(['middleware' => ['forcedomain']], function () {
             Route::post('add/single', ['as' => 'add', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@store']);
             Route::get('delete/{id}', ['as' => 'delete', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@destroy']);
 
+
             Route::get('history/{date?}', ['as' => 'list', 'uses' => 'OrderLineController@index']);
             Route::get('', ['as' => 'adminlist', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@adminindex']);
+            Route::get('orderline-wizard', ['as' => 'orderline-wizard', 'uses' => 'OrderLineController@orderlineWizard']);
 
             Route::group(['prefix' => 'filter', 'middleware' => ['permission:omnomcom'], 'as' => 'filter::'], function () {
                 Route::get('name/{name?}', ['as' => 'name', 'middleware' => ['permission:omnomcom'], 'uses' => 'OrderLineController@filterByUser']);


### PR DESCRIPTION
Moved the orderline wizard to a seperate page.
This means we do not load all the users and products just for the orderline overview.
Also added some querybuilder optimizations to the orderline overview.
Greatly reduces loading time of both (from over 2000ms for the orderline page to both only being 200-300ms)