### PR TITLE
Fix the ticket not being deleted when a non member does not pay correctly

### DIFF
--- a/app/Models/MollieTransaction.php
+++ b/app/Models/MollieTransaction.php
@@ -132,8 +132,8 @@ class MollieTransaction extends Model
                  */
                 if (
                     $orderline->product->ticket &&
-                    $orderline->product->ticket->is_prepaid &&
-                    ! $orderline->ticketPurchase->payment_complete
+                    ! $orderline->ticketPurchase->payment_complete &&
+                    ($orderline->product->ticket->is_prepaid || !$orderline->user->is_member)
                 ) {
                     if ($orderline->ticketPurchase) {
                         $orderline->ticketPurchase->delete();

--- a/app/Models/MollieTransaction.php
+++ b/app/Models/MollieTransaction.php
@@ -133,7 +133,7 @@ class MollieTransaction extends Model
                 if (
                     $orderline->product->ticket &&
                     ! $orderline->ticketPurchase->payment_complete &&
-                    ($orderline->product->ticket->is_prepaid || !$orderline->user->is_member)
+                    ($orderline->product->ticket->is_prepaid || ! $orderline->user->is_member)
                 ) {
                     if ($orderline->ticketPurchase) {
                         $orderline->ticketPurchase->delete();


### PR DESCRIPTION
When the mollie webhook comes back with a failed payment when the ticket was not set to prepaid the ticket would not get deleted for non users. Now fixed.