### PR TITLE
Feature/Added inactive committees

### DIFF
--- a/app/Http/Controllers/CommitteeController.php
+++ b/app/Http/Controllers/CommitteeController.php
@@ -9,7 +9,6 @@ use App\Models\HelperReminder;
 use App\Models\StorageEntry;
 use App\Models\User;
 use Auth;
-use Carbon;
 use Exception;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\RedirectResponse;
@@ -137,20 +136,26 @@ class CommitteeController extends Controller
      */
     public function update($id, Request $request)
     {
+        // Retrieve the committee
         $committee = Committee::find($id);
 
+        // Check if the committee is protected
         if ($committee->slug == config('proto.rootcommittee') && $request->slug != $committee->slug) {
             Session::flash('flash_message', "This committee is protected. You cannot change it's e-mail alias.");
 
             return Redirect::back();
         }
 
+        // Update the committee with the request data
         $committee->fill($request->all());
+
+        // The is_active value is either unset or 'on' so only set it to false if selected.
+        $committee->is_active = !$request->has('is_active');
 
         $committee->save();
 
+        // Redirect back with a message
         Session::flash('flash_message', 'Changes have been saved.');
-
         return Redirect::route('committee::edit', ['new' => false, 'id' => $id]);
     }
 

--- a/app/Http/Controllers/CommitteeController.php
+++ b/app/Http/Controllers/CommitteeController.php
@@ -150,12 +150,13 @@ class CommitteeController extends Controller
         $committee->fill($request->all());
 
         // The is_active value is either unset or 'on' so only set it to false if selected.
-        $committee->is_active = !$request->has('is_active');
+        $committee->is_active = ! $request->has('is_active');
 
         $committee->save();
 
         // Redirect back with a message
         Session::flash('flash_message', 'Changes have been saved.');
+
         return Redirect::route('committee::edit', ['new' => false, 'id' => $id]);
     }
 

--- a/app/Models/Committee.php
+++ b/app/Models/Committee.php
@@ -26,6 +26,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int|null $image_id
  * @property int $allow_anonymous_email
  * @property int $is_society
+ * @property int $is_active
+ *
  * @property-read string $email_address
  * @property-read StorageEntry|null $image
  * @property-read Collection|HelperReminder[] $helperReminderSubscriptions

--- a/app/Models/Committee.php
+++ b/app/Models/Committee.php
@@ -27,7 +27,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int $allow_anonymous_email
  * @property int $is_society
  * @property int $is_active
- *
  * @property-read string $email_address
  * @property-read StorageEntry|null $image
  * @property-read Collection|HelperReminder[] $helperReminderSubscriptions

--- a/database/migrations/2023_11_23_120900_add_is_active_to_committees.php
+++ b/database/migrations/2023_11_23_120900_add_is_active_to_committees.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Committee;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Create new is_active column to show if society is active or not
+        Schema::table('committees', function (Blueprint $table) {
+            $table->boolean('is_active')->default(true);
+        });
+
+        // Set all hidden committees to inactive
+        Committee::where('public', 0)->update(['is_active' => false]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Remove the is_active column
+        Schema::table('committees', function (Blueprint $table) {
+            $table->dropColumn('is_active');
+        });
+    }
+};

--- a/resources/views/committee/include/form-committee.blade.php
+++ b/resources/views/committee/include/form-committee.blade.php
@@ -59,7 +59,7 @@
                 </div>
             </div>
 
-            <div class="form-group mt-1" id="isSocietyActiveGroup">
+            <div class="form-group mt-1">
                 <div class="input-group" id="isActiveInput">
                     @include('components.forms.checkbox', [
                                 'name' => 'is_active',
@@ -128,8 +128,10 @@
 
         // Update the is active checkbox when the committee type is changed
         function updateIsSociety(isSociety) {
-            document.getElementById('isActiveInput').lastElementChild.lastElementChild.innerText = "Set " + (isSociety ? 'society' : 'committee') + " as inactive";
+            // Update the checkbox text
+            document.getElementById('isActiveInput').firstElementChild.lastElementChild.innerText = "Set " + (isSociety ? 'society' : 'committee') + " as inactive";
 
+            // Update the labels
             document.getElementById('committee_header_label').innerText = (isSociety ? 'Society' : 'Committee') + " information";
             document.getElementById('committee_name_label').innerText = (isSociety ? 'Society' : 'Committee') + " name";
             document.getElementById('committee_slug_label').innerText = (isSociety ? 'Society' : 'Committee') + " e-mail alias";

--- a/resources/views/committee/include/form-committee.blade.php
+++ b/resources/views/committee/include/form-committee.blade.php
@@ -5,22 +5,20 @@
 
     <div class="card">
 
-        <div class="card-header bg-dark text-white">
-
+        <div class="card-header bg-dark text-white" id="committee_header_label">
             Committee information
-
         </div>
 
         <div class="card-body">
 
             <div class="form-group">
-                <label for="name">Committee name</label>
+                <label for="name" id="committee_name_label">Committee name</label>
                 <input type="text" class="form-control" id="name" name="name"
                        placeholder="Awesome Committee Extraordinaire" value="{{ (!$new ? $committee->name : "" ) }}">
             </div>
 
             <div class="form-group">
-                <label for="slug">Committee e-mail alias</label>
+                <label for="slug" id="committee_slug_label">Committee e-mail alias</label>
 
                 <div class="input-group">
                     <input type="text" class="form-control" id="slug" name="slug"
@@ -49,7 +47,7 @@
                 <div class="col-md-6">
 
                     <div class="form-group">
-                        <label for="public">Committee visibility</label>
+                        <label for="public" id="committee_type_label">Committee visibility</label>
                         <select class="form-control" id="public" name="public">
                             <option value="0" @selected(!$new && !$committee->public)>Admin only
                             </option>
@@ -120,16 +118,21 @@
 @push('javascript')
     <script type="text/javascript" nonce="{{ csp_nonce() }}">
         // Update the is active checkbox when the committee type is changed
-        document.getElementById('is_society').addEventListener("change", function() {
-            updateSocietyActive(this.value === '1');
+        document.getElementById('is_society').addEventListener("change", function () {
+            updateIsSociety(this.value === '1');
         });
 
         // Update the is active checkbox when the committee type is changed
-        function updateSocietyActive(isSociety) {
+        function updateIsSociety(isSociety) {
             document.getElementById('isActiveInput').lastElementChild.lastElementChild.innerText = "Set " + (isSociety ? 'society' : 'committee') + " as inactive";
+
+            document.getElementById('committee_header_label').innerText = (isSociety ? 'Society' : 'Committee') + " information";
+            document.getElementById('committee_name_label').innerText = (isSociety ? 'Society' : 'Committee') + " name";
+            document.getElementById('committee_slug_label').innerText = (isSociety ? 'Society' : 'Committee') + " e-mail alias";
+            document.getElementById('committee_type_label').innerText = (isSociety ? 'Society' : 'Committee') + " visibility";
         }
 
         // Set the initial state of the is active checkbox
-        updateSocietyActive(Boolean({{($committee?->is_society ?? 0)}}));
+        updateIsSociety(Boolean({{($committee?->is_society ?? 0)}}));
     </script>
 @endpush

--- a/resources/views/committee/include/form-committee.blade.php
+++ b/resources/views/committee/include/form-committee.blade.php
@@ -66,7 +66,7 @@
                     @include('components.forms.checkbox', [
                                 'name' => 'is_active',
                                 'checked' => !$new && !$committee?->is_active ,
-                                'label' => "Set " . ($committee?->is_society ? 'society' : 'committee') . " as inactive"
+                                'label' => "Set " . (!$new && $committee?->is_society ? 'society' : 'committee') . " as inactive"
                             ])
                 </div>
             </div>

--- a/resources/views/committee/include/form-committee.blade.php
+++ b/resources/views/committee/include/form-committee.blade.php
@@ -28,13 +28,14 @@
                     <span class="input-group-text">@ {{ config('proto.emaildomain') }}</span>
                 </div>
 
+
             </div>
 
             <div class="row">
                 <div class="col-md-6">
 
                     <div class="form-group">
-                        <label for="public">Committee type</label>
+                        <label for="is_society">Committee type</label>
                         <select class="form-control" id="is_society" name="is_society">
                             <option value="0" @selected(!$new && !$committee->is_society)>Committee
                             </option>
@@ -60,12 +61,22 @@
                 </div>
             </div>
 
+            <div class="form-group mt-1" id="isSocietyActiveGroup">
+                <div class="input-group">
+                    @include('components.forms.checkbox', [
+                                'name' => 'is_active',
+                                'checked' => !$new && !$committee?->is_active ,
+                                'label' => 'Set society as inactive'
+                            ])
+                </div>
+            </div>
+
             <div class="row">
 
                 <div class="col-md-12">
 
                     <div class="form-group">
-                        <label for="public">Enable anonymous e-mail</label>
+                        <label for="allow_anonymous_email">Enable anonymous e-mail</label>
                         <select class="form-control" id="allow_anonymous_email" name="allow_anonymous_email">
                             <option value="0" @selected(!$new && $committee->allow_anonymous_email)>No
                             </option>
@@ -106,3 +117,19 @@
     </div>
 
 </form>
+@push('javascript')
+    <script type="text/javascript" nonce="{{ csp_nonce() }}">
+        // Update the society active checkbox when the committee type is changed
+        document.getElementById('is_society').addEventListener("change", function() {
+            updateSocietyActive(this.value === '1')
+        });
+
+        // Hide/show the option to set a society as inactive
+        function updateSocietyActive(isSociety) {
+            document.getElementById('isSocietyActiveGroup').style.display = isSociety ? "flex" : "none"
+        }
+
+        // Set the initial state if the society inactive checkbox should be shown
+        updateSocietyActive(Boolean({{($committee?->is_society ?? 0)}}));
+    </script>
+@endpush

--- a/resources/views/committee/include/form-committee.blade.php
+++ b/resources/views/committee/include/form-committee.blade.php
@@ -62,11 +62,11 @@
             </div>
 
             <div class="form-group mt-1" id="isSocietyActiveGroup">
-                <div class="input-group">
+                <div class="input-group" id="isActiveInput">
                     @include('components.forms.checkbox', [
                                 'name' => 'is_active',
                                 'checked' => !$new && !$committee?->is_active ,
-                                'label' => 'Set society as inactive'
+                                'label' => "Set " . ($committee?->is_society ? 'society' : 'committee') . " as inactive"
                             ])
                 </div>
             </div>
@@ -119,17 +119,17 @@
 </form>
 @push('javascript')
     <script type="text/javascript" nonce="{{ csp_nonce() }}">
-        // Update the society active checkbox when the committee type is changed
+        // Update the is active checkbox when the committee type is changed
         document.getElementById('is_society').addEventListener("change", function() {
-            updateSocietyActive(this.value === '1')
+            updateSocietyActive(this.value === '1');
         });
 
-        // Hide/show the option to set a society as inactive
+        // Update the is active checkbox when the committee type is changed
         function updateSocietyActive(isSociety) {
-            document.getElementById('isSocietyActiveGroup').style.display = isSociety ? "flex" : "none"
+            document.getElementById('isActiveInput').lastElementChild.lastElementChild.innerText = "Set " + (isSociety ? 'society' : 'committee') + " as inactive";
         }
 
-        // Set the initial state if the society inactive checkbox should be shown
+        // Set the initial state of the is active checkbox
         updateSocietyActive(Boolean({{($committee?->is_society ?? 0)}}));
     </script>
 @endpush

--- a/resources/views/committee/include/form-committee.blade.php
+++ b/resources/views/committee/include/form-committee.blade.php
@@ -66,6 +66,10 @@
                                 'checked' => !$new && !$committee?->is_active ,
                                 'label' => "Set " . (!$new && $committee?->is_society ? 'society' : 'committee') . " as inactive"
                             ])
+                    {{-- Tooltip to show aditional information --}}
+                    <i class="fas fa-info-circle align-self-center ms-1" data-bs-toggle="tooltip"
+                       data-bs-placement="right"
+                       title="Setting it to inactive will not hide the committee/society, it will only display it separately"></i>
                 </div>
             </div>
 

--- a/resources/views/committee/list.blade.php
+++ b/resources/views/committee/list.blade.php
@@ -6,13 +6,16 @@
 
 @section('container')
 
+    {{--  Active societies or committees  --}}
     <div class="card mb-3">
-
+        <div class="card-header bg-dark text-white">
+            Active {{$data->first()->is_society ? 'societies' : 'committees'}}
+        </div>
         <div class="card-body">
 
             <div class="row" id="committee__list">
 
-                @foreach($data as $key => $committee)
+                @foreach($data->filter(function($item) {return $item->is_active;}) as $key => $committee)
 
                     <div class="col-lg-2 col-lg-3 col-md-4 col-sm-6">
 
@@ -25,7 +28,30 @@
             </div>
 
         </div>
-
     </div>
+
+    {{--  Inactive societies or committees  --}}
+    @if($data->filter(function($item) {return !$item->is_active;})->count() > 0)
+        <div class="card mb-3">
+            <div class="card-header bg-dark text-white">
+                Inactive {{$data->first()->is_society ? 'societies' : 'committees'}}
+            </div>
+            <div class="card-body">
+                <div class="row" id="committee__list_inactive">
+
+                    @foreach($data->filter(function($item) {return !$item->is_active;}) as $key => $committee)
+
+                        <div class="col-lg-2 col-lg-3 col-md-4 col-sm-6">
+
+                            @include('committee.include.committee_block', ['committee' => $committee, 'photo_pop'=>false])
+
+                        </div>
+
+                    @endforeach
+
+                </div>
+            </div>
+        </div>
+    @endif
 
 @endsection


### PR DESCRIPTION
# Added Inactive committees and societies
These inactive committees/societies are shown separately on the overview page.

## Edit/new committee page
![afbeelding](https://github.com/saproto/saproto/assets/94541505/db1f9032-536f-4846-8fdd-7949006e88d9)


## Societies overview page
![afbeelding](https://github.com/saproto/saproto/assets/94541505/92b816b5-237a-4644-a10b-a49a2a8fb59f)
For the committees page it's the same, but the societies is changed to committees.