### PR TITLE
Fixed misplaced closing div on my history page (#BlameYsbrand)

### DIFF
--- a/resources/views/omnomcom/orders/includes/payment-details.blade.php
+++ b/resources/views/omnomcom/orders/includes/payment-details.blade.php
@@ -76,8 +76,8 @@
                     </div>
                 </div>
             </div>
-    </div>
     @endif
+    </div>
 
     @if($next_withdrawal > 0)
 


### PR DESCRIPTION
# Misplaced </div> on my history page
There was a misplaced </div> in an if-statement on the myhistory page.
This caused the overview to break when there wasn't an outstanding amount.

## Bug
![afbeelding](https://github.com/saproto/saproto/assets/94541505/6f5e5030-ebb1-438b-a97e-e3c717d1c214)

## Fix
![afbeelding](https://github.com/saproto/saproto/assets/94541505/b619c91d-e91e-4e01-a33a-b23fd86f4ef2)


\#BlameYsbrand