### PR TITLE
Fix/db seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # IDE files
 /.idea
+.phpactor.json
 
 # Helper files
 .phpstorm.meta.php

--- a/database/factories/ActivityParticipationFactory.php
+++ b/database/factories/ActivityParticipationFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Activity;
 use App\Models\ActivityParticipation;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -33,7 +34,11 @@ class ActivityParticipationFactory extends Factory
     public function createAt(array $attributes)
     {
         $activity = Activity::find($attributes['activity_id']);
-        $date = fake()->dateTimeBetween($activity->registration_start, $activity->event->start);
+
+        $start = Carbon::parse($activity->registration_start);
+        $end = Carbon::parse($activity->event->start);
+
+        $date = fake()->dateTimeBetween($start, $end);
 
         return $date->format('Y-m-d H:i:s');
     }
@@ -46,7 +51,11 @@ class ActivityParticipationFactory extends Factory
     public function deletedAt(array $attributes)
     {
         $activity = Activity::find($attributes['activity_id']);
-        $date = fake()->dateTimeBetween($attributes['created_at'], $activity->event->start);
+
+        $start = Carbon::parse($attributes['created_at']);
+        $end = Carbon::parse($activity->event->start);
+
+        $date = fake()->dateTimeBetween($start, $end);
 
         return $date->format('Y-m-d H:i:s');
     }


### PR DESCRIPTION
My local db wouldn't seed. 
It kept giving an error when it tried to find a date between 12-dec-23 and 14-jan-24.
Parsing it with carbon before seems to have fixed it.

I also added a tinkerwell file to the gitignore as I'm gonna forget it sometime otherwise.

The error:
<img width="1111" alt="Scherm­afbeelding 2023-12-25 om 16 55 48" src="https://github.com/saproto/saproto/assets/43108191/d92f8363-22b0-4e6b-bca2-545139bb09ea">

My debug statement/log:
<img width="772" alt="Scherm­afbeelding 2023-12-25 om 17 10 07" src="https://github.com/saproto/saproto/assets/43108191/722559d0-2188-4266-81bb-38aa96ce5c31">
The culprit:
<img width="661" alt="Scherm­afbeelding 2023-12-25 om 17 10 15" src="https://github.com/saproto/saproto/assets/43108191/5127e121-434d-4737-a633-a8a4b71151a7">
Testing the bug in tinkerwell
<img width="937" alt="Scherm­afbeelding 2023-12-25 om 17 10 22" src="https://github.com/saproto/saproto/assets/43108191/8ada4c35-1f1f-4a17-a6c5-43ef0b563102">
Testing parsed version in tinkerwell
<img width="680" alt="Scherm­afbeelding 2023-12-25 om 17 12 06" src="https://github.com/saproto/saproto/assets/43108191/e8b29498-a195-43c2-a0a6-ceb39ddcdb1d">
