### PR TITLE
Dev/protube database

### DIFF
--- a/create-protube-db.sh
+++ b/create-protube-db.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
+    CREATE DATABASE IF NOT EXISTS protube;
+    GRANT ALL PRIVILEGES ON \`protube%\`.* TO '$MYSQL_USER'@'%';
+EOSQL

--- a/database/seeders/OtherDataSeeder.php
+++ b/database/seeders/OtherDataSeeder.php
@@ -131,20 +131,20 @@ class OtherDataSeeder extends Seeder
         $n = 40;
         $output->task("creating $n newsitems", fn () => Newsitem::factory()->count($n)->create());
         
-        $output->task("Creating ProTube OAUTH client", function () use ($output) { 
+        $output->task("Creating ProTube OAUTH client", function () { 
             Artisan::call("passport:client", [
                 "--name" => "ProTube",
                 "--no-interaction" => true,
                 "--redirect_uri" => "http://localhost:3000/auth/login/callback"
             ]);
-
-            $client = DB::table("oauth_clients")
-                ->where("name", "ProTube")
-                ->latest()
-                ->first();
-            
-              $output->info("<options=bold>ProTube OAUTH Id:</> <fg=green>$client->id</>
-                       <options=bold>secret:</> <fg=green>$client->secret</>");
         });
+
+        $client = DB::table("oauth_clients")
+            ->where("name", "ProTube")
+            ->latest()
+            ->first();
+    
+        $output->info("<options=bold>ProTube OAUTH Id:</> <fg=green>$client->id</>
+               <options=bold>secret:</> <fg=green>$client->secret</>");
     }
 }

--- a/database/seeders/OtherDataSeeder.php
+++ b/database/seeders/OtherDataSeeder.php
@@ -15,6 +15,8 @@ use App\Models\Newsitem;
 use App\Models\OrderLine;
 use App\Models\Page;
 use App\Models\User;
+use Artisan;
+use DB;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
 
@@ -128,5 +130,21 @@ class OtherDataSeeder extends Seeder
         // Create newsitems and weekly newsitems
         $n = 40;
         $output->task("creating $n newsitems", fn () => Newsitem::factory()->count($n)->create());
+        
+        $output->task("Creating ProTube OAUTH client", function () use ($output) { 
+            Artisan::call("passport:client", [
+                "--name" => "ProTube",
+                "--no-interaction" => true,
+                "--redirect_uri" => "http://localhost:3000/auth/login/callback"
+            ]);
+
+            $client = DB::table("oauth_clients")
+                ->where("name", "ProTube")
+                ->latest()
+                ->first();
+            
+              $output->info("<options=bold>ProTube OAUTH Id:</> <fg=green>$client->id</>
+                       <options=bold>secret:</> <fg=green>$client->secret</>");
+        });
     }
 }

--- a/database/seeders/OtherDataSeeder.php
+++ b/database/seeders/OtherDataSeeder.php
@@ -130,20 +130,20 @@ class OtherDataSeeder extends Seeder
         // Create newsitems and weekly newsitems
         $n = 40;
         $output->task("creating $n newsitems", fn () => Newsitem::factory()->count($n)->create());
-        
-        $output->task("Creating ProTube OAUTH client", function () { 
-            Artisan::call("passport:client", [
-                "--name" => "ProTube",
-                "--no-interaction" => true,
-                "--redirect_uri" => "http://localhost:3000/auth/login/callback"
+
+        $output->task('Creating ProTube OAUTH client', function () {
+            Artisan::call('passport:client', [
+                '--name' => 'ProTube',
+                '--no-interaction' => true,
+                '--redirect_uri' => 'http://localhost:3000/auth/login/callback',
             ]);
         });
 
-        $client = DB::table("oauth_clients")
-            ->where("name", "ProTube")
+        $client = DB::table('oauth_clients')
+            ->where('name', 'ProTube')
             ->latest()
             ->first();
-    
+
         $output->info("<options=bold>ProTube OAUTH Id:</> <fg=green>$client->id</>
                <options=bold>secret:</> <fg=green>$client->secret</>");
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
     laravel.test:
+        hostname: 'saproto_sail'
         container_name: '${SAIL_CONTAINER_NAME}-app'
         build:
             context: ./vendor/laravel/sail/runtimes/8.2
@@ -39,6 +40,7 @@ services:
         volumes:
             - 'sail-mariadb:/var/lib/mysql'
             - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+            - './create-protube-db.sh:/docker-entrypoint-initdb.d/10-create-protube-database.sh'
         networks:
             - sail
         healthcheck:


### PR DESCRIPTION
This adds some dev features, of which some will be for protube v2 but they won't hurt the current stuff.
The docker compose is modded so that it now also adds a protube database (the new protube will use the same mysql instance, but a different database so you can use the same phpmyadmin for both #yay).

Another thing it now also does is creating the protube oath client by default when seeding.

Doesn't directly need to be merged, but sometime in the future.