### PR TITLE
Show the error message when the environment is local

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -60,7 +60,7 @@ class Handler extends ExceptionHandler
     /**
      * Render an exception into an HTTP response.
      *
-     * @param  Request  $request
+     * @param Request $request
      * @return SymfonyResponse
      *
      * @throws Throwable
@@ -77,7 +77,7 @@ class Handler extends ExceptionHandler
     /**
      * Convert an authentication exception into an unauthenticated response.
      *
-     * @param  Request  $request
+     * @param Request $request
      * @return JsonResponse|RedirectResponse
      */
     protected function unauthenticated($request, AuthenticationException $exception)
@@ -96,8 +96,9 @@ class Handler extends ExceptionHandler
      */
     protected function renderHttpException(HttpExceptionInterface $e)
     {
-        if (! view()->exists("errors.{$e->getStatusCode()}")) {
-            return response()->view('errors.default', ['exception' => $e, 'hide_message' => (! Auth::check() || Auth::user()?->canNot('finadmin'))], 500, $e->getHeaders());
+        if (!view()->exists("errors.{$e->getStatusCode()}")) {
+            $maySeeError = App()->env('local') | Auth::check() && Auth::user()->can('finadmin');
+            return response()->view('errors.default', ['exception' => $e, 'hide_message' => !$maySeeError], 500, $e->getHeaders());
         }
 
         return parent::renderHttpException($e);


### PR DESCRIPTION
When developing on local the message when impersonating a normal user also was hidden. Will now be shown