### PR TITLE
Feature: laravel rector

### DIFF
--- a/.github/workflows/fix_php.yml
+++ b/.github/workflows/fix_php.yml
@@ -5,12 +5,25 @@ jobs:
     runs-on: ubuntu-latest
     name: 🛠 Fix PHP formatting
     steps:
+      - name: 🔍 Read .env
+        run: grep -E 'PHP_VERSION|NODE_VERSION' .env.prod >> $GITHUB_ENV
+
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          coverage: none
+          
+      - uses: "ramsey/composer-install@v2"
+      - run: vendor/bin/rector --ansi
+
       - name: "laravel-pint"
         uses: aglipanci/laravel-pint-action@2.2.0
-      - name : "Commit changes"
+
+      - name: "Commit changes"
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: PHP Linting (Pint)

--- a/.github/workflows/fix_php.yml
+++ b/.github/workflows/fix_php.yml
@@ -5,18 +5,18 @@ jobs:
     runs-on: ubuntu-latest
     name: 🛠 Fix PHP formatting
     steps:
-      - name: 🔍 Read .env
-        run: grep -E 'PHP_VERSION|NODE_VERSION' .env.prod >> $GITHUB_ENV
-
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+          
+      - name: 🔍 Read .env
+        run: grep -E 'PHP_VERSION' .env.prod >> $GITHUB_ENV
 
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ env.PHP_VERSION }}
           coverage: none
-          
+
       - uses: "ramsey/composer-install@v2"
       - run: vendor/bin/rector --ansi
 

--- a/app/Console/Commands/DirectAdminSync.php
+++ b/app/Console/Commands/DirectAdminSync.php
@@ -330,7 +330,7 @@ class DirectAdminSync extends Command
      */
     private function executeQueries($da, $queries)
     {
-        foreach ($queries as $i => $query) {
+        foreach ($queries as $query) {
             //$this->info('Query '.$i.'/'.count($queries).': '.$query['cmd'].implode($query['options'])); //Temporarily disabled to reduce Sentry spam
             $da->query($query['cmd'], $query['options']);
 

--- a/app/Console/Commands/SpotifyUpdate.php
+++ b/app/Console/Commands/SpotifyUpdate.php
@@ -103,7 +103,7 @@ class SpotifyUpdate extends Command
 
         $this->info("Matching to Spotify music.\n---");
 
-        foreach ($videos_to_search as $t => $video) {
+        foreach ($videos_to_search as $video) {
             if (! $video->spotify_id) {
                 $sameVideo = PlayedVideo::where('video_id', $video->video_id)->whereNotNull('spotify_id')->first();
 

--- a/app/Console/Commands/TestIBANs.php
+++ b/app/Console/Commands/TestIBANs.php
@@ -38,8 +38,6 @@ class TestIBANs extends Command
     {
         $this->info('Starting clean-up.');
 
-        $count = 0;
-
         foreach (Bank::all() as $bank) {
             if (! verify_iban($bank->iban)) {
                 $this->info('INVALID -- '.$bank->iban.' of '.$bank->user->name.'(#'.$bank->user->id.')');

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -516,7 +516,7 @@ class AuthController extends Controller
             $remoteFullName = $remoteData['givenname'].' '.$remoteData['surname'];
             $remoteCallingName = $remoteData['givenname'];
         } elseif ($remoteData['surname'] || $remoteData['givenname']) {
-            $remoteFullName = $remoteData['surname'] ? $remoteData['surname'] : $remoteData['givenname'];
+            $remoteFullName = $remoteData['surname'] ?: $remoteData['givenname'];
             $remoteCallingName = $remoteFullName;
         }
         $remoteData['name'] = $remoteFullName;

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -37,7 +37,7 @@ class CalendarController extends Controller
                 $name_exp[0] = '';
             }
             $name = '';
-            foreach ($name_exp as $key => $val) {
+            foreach ($name_exp as $val) {
                 $name .= $val.' ';
             }
 

--- a/app/Http/Controllers/CommitteeController.php
+++ b/app/Http/Controllers/CommitteeController.php
@@ -190,8 +190,8 @@ class CommitteeController extends Controller
      */
     public function addMembership(Request $request)
     {
-        $user = User::findOrFail($request->user_id);
-        $committee = Committee::findOrFail($request->committee_id);
+        User::findOrFail($request->user_id);
+        Committee::findOrFail($request->committee_id);
 
         $membership = new CommitteeMembership();
         $membership->role = $request->role;
@@ -322,8 +322,6 @@ class CommitteeController extends Controller
 
             return Redirect::back();
         }
-
-        $email = $committee->email_address;
         $name = $committee->name;
 
         $message_content = strip_tags($request->get('message'));

--- a/app/Http/Controllers/DinnerformOrderlineController.php
+++ b/app/Http/Controllers/DinnerformOrderlineController.php
@@ -32,7 +32,7 @@ class DinnerformOrderlineController extends Controller
         $amount = $request->input('price');
         $helper = $request->has('helper') || $dinnerform->isHelping();
 
-        $dinnerOrderline = DinnerformOrderline::create([
+        DinnerformOrderline::create([
             'description' => $order,
             'price' => $amount,
             'user_id' => Auth::user()->id,

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -80,7 +80,7 @@ class ExportController extends Controller
                 }
 
                 // Exclude 'activity' relation
-                foreach ($data as $key => $val) {
+                foreach ($data as $val) {
                     unset($val->activity);
                 }
 

--- a/app/Http/Controllers/PasswordController.php
+++ b/app/Http/Controllers/PasswordController.php
@@ -46,7 +46,7 @@ class PasswordController extends Controller
     public function index(Request $request)
     {
         if (! $this->extraVerification($request)) {
-            return $this->forwardToAuth($request);
+            return $this->forwardToAuth();
         }
 
         return view('passwordstore.index', ['passwords' => PasswordEntry::orderBy('permission_id', 'asc')->orderBy('description', 'asc')->get()]);
@@ -58,7 +58,7 @@ class PasswordController extends Controller
     public function create(Request $request)
     {
         if (! $this->extraVerification($request)) {
-            return $this->forwardToAuth($request);
+            return $this->forwardToAuth();
         }
 
         return view('passwordstore.edit', ['password' => null, 'type' => $request->get('type')]);
@@ -70,7 +70,7 @@ class PasswordController extends Controller
     public function store(Request $request)
     {
         if (! $this->extraVerification($request)) {
-            return $this->forwardToAuth($request);
+            return $this->forwardToAuth();
         }
 
         $permission = Permission::findOrFail($request->get('permission_id'));
@@ -121,7 +121,7 @@ class PasswordController extends Controller
     public function edit(Request $request, $id)
     {
         if (! $this->extraVerification($request)) {
-            return $this->forwardToAuth($request);
+            return $this->forwardToAuth();
         }
 
         /** @var PasswordEntry $password */
@@ -142,7 +142,7 @@ class PasswordController extends Controller
     public function update(Request $request, $id)
     {
         if (! $this->extraVerification($request)) {
-            return $this->forwardToAuth($request);
+            return $this->forwardToAuth();
         }
 
         /** @var PasswordEntry $password */
@@ -208,7 +208,7 @@ class PasswordController extends Controller
     public function destroy(Request $request, $id)
     {
         if (! $this->extraVerification($request)) {
-            return $this->forwardToAuth($request);
+            return $this->forwardToAuth();
         }
 
         $password = PasswordEntry::findOrFail($id);
@@ -245,7 +245,7 @@ class PasswordController extends Controller
     /**
      * @return RedirectResponse
      */
-    private function forwardToAuth(Request $request)
+    private function forwardToAuth()
     {
         Session::flash('flash_message', 'You need to enter your password again, in order to access this feature.');
 

--- a/app/Http/Controllers/QueryController.php
+++ b/app/Http/Controllers/QueryController.php
@@ -125,7 +125,7 @@ class QueryController extends Controller
                             'primary' => $is_primary_student ? 'true' : 'false',
                             'name' => $member->user->name,
                             'email' => $has_ut_mail ? $member->user->email : null,
-                            'ut_number' => $member->user->utwente_username ? $member->user->utwente_username : null,
+                            'ut_number' => $member->user->utwente_username ?: null,
                         ];
                     }
                 }

--- a/app/Http/Controllers/SmartXpScreenController.php
+++ b/app/Http/Controllers/SmartXpScreenController.php
@@ -89,7 +89,7 @@ class SmartXpScreenController extends Controller
                 $name_exp[0] = '';
             }
             $name = '';
-            foreach ($name_exp as $key => $val) {
+            foreach ($name_exp as $val) {
                 $name .= $val.' ';
             }
             preg_match('/Type: (.*)/', $entry->description, $type);

--- a/app/Http/Controllers/VideoController.php
+++ b/app/Http/Controllers/VideoController.php
@@ -62,7 +62,7 @@ class VideoController extends Controller
             return Redirect::back();
         }
 
-        $video = Video::create([
+        Video::create([
             'title' => $youtube_video->snippet->title,
             'youtube_id' => $youtube_video->id,
             'youtube_title' => $youtube_video->snippet->title,

--- a/app/Http/Controllers/WallstreetController.php
+++ b/app/Http/Controllers/WallstreetController.php
@@ -174,7 +174,8 @@ class WallstreetController extends Controller
     public function getLoss(WallstreetDrink $drink)
     {
         $productIDs = $drink->products->pluck('id');
-        $orderlines = OrderLine::query()
+
+        return OrderLine::query()
             ->selectRaw('(original_unit_price*units)-total_price AS loss')
             ->whereHas('product', function ($q) use ($productIDs) {
                 $q->whereIn('id', $productIDs);
@@ -183,8 +184,6 @@ class WallstreetController extends Controller
             ->where('created_at', '>', Carbon::parse($drink->start_time))
             ->get()
             ->sum('loss');
-
-        return $orderlines;
     }
 
     public function getAllPrices($drinkID)

--- a/app/Mail/AnonymousEmail.php
+++ b/app/Mail/AnonymousEmail.php
@@ -14,20 +14,14 @@ class AnonymousEmail extends Mailable
 
     public $committee;
 
-    public $message_content;
-
-    public $hash;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct(Committee $committee, $message_content, $message_hash)
+    public function __construct(Committee $committee, public $message_content, public $hash)
     {
         $this->committee = $committee;
-        $this->message_content = $message_content;
-        $this->hash = $message_hash;
     }
 
     /**

--- a/app/Mail/BirthdayEmailForBoard.php
+++ b/app/Mail/BirthdayEmailForBoard.php
@@ -11,16 +11,13 @@ class BirthdayEmailForBoard extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public $users;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct($users)
+    public function __construct(public $users)
     {
-        $this->users = $users;
     }
 
     /**

--- a/app/Mail/FeeEmail.php
+++ b/app/Mail/FeeEmail.php
@@ -12,26 +12,14 @@ class FeeEmail extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public $user;
-
-    public $fee;
-
-    public $fee_amount;
-
-    public $remitted_reason;
-
     /**
      * @param  User  $user
      * @param  string  $fee
      * @param  float  $fee_amount
      * @param  null|string  $remitted_reason
      */
-    public function __construct($user, $fee, $fee_amount, $remitted_reason)
+    public function __construct(public $user, public $fee, public $fee_amount, public $remitted_reason)
     {
-        $this->user = $user;
-        $this->fee = $fee;
-        $this->fee_amount = $fee_amount;
-        $this->remitted_reason = $remitted_reason;
     }
 
     /** @return FeeEmail */

--- a/app/Mail/FeeEmailForBoard.php
+++ b/app/Mail/FeeEmailForBoard.php
@@ -11,16 +11,13 @@ class FeeEmailForBoard extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public $charged_fees;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct($charged_fees)
+    public function __construct(public $charged_fees)
     {
-        $this->charged_fees = $charged_fees;
     }
 
     /**

--- a/app/Mail/FeedbackReplyEmail.php
+++ b/app/Mail/FeedbackReplyEmail.php
@@ -13,23 +13,11 @@ class FeedbackReplyEmail extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public Feedback $feedback;
-
-    public User $user;
-
-    public string $reply;
-
-    public bool $accepted;
-
     /**
      * Create a new message instance.
      */
-    public function __construct(Feedback $feedback, User $user, $reply, bool $accepted)
+    public function __construct(public Feedback $feedback, public User $user, public string $reply, public bool $accepted)
     {
-        $this->feedback = $feedback;
-        $this->user = $user;
-        $this->reply = $reply;
-        $this->accepted = $accepted;
     }
 
     /**

--- a/app/Mail/ManualEmail.php
+++ b/app/Mail/ManualEmail.php
@@ -11,40 +11,13 @@ class ManualEmail extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public $sender_address;
-
-    public $sender_name;
-
-    public $subject;
-
-    public $body;
-
-    public $submitted_attachments;
-
-    public $destination;
-
-    public $user_id;
-
-    public $events;
-
-    public $email_id;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct($sender_address, $sender_name, $subject, $body, $attachments, $destination, $user_id, $events, $email_id)
+    public function __construct(public $sender_address, public $sender_name, public $subject, public $body, public $submitted_attachments, public $destination, public $user_id, public $events, public $email_id)
     {
-        $this->sender_address = $sender_address;
-        $this->sender_name = $sender_name;
-        $this->subject = $subject;
-        $this->body = $body;
-        $this->submitted_attachments = $attachments;
-        $this->destination = $destination;
-        $this->user_id = $user_id;
-        $this->events = $events;
-        $this->email_id = $email_id;
     }
 
     /**

--- a/app/Mail/MembershipEndedForBoard.php
+++ b/app/Mail/MembershipEndedForBoard.php
@@ -11,16 +11,13 @@ class MembershipEndedForBoard extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public $deleted_memberships;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct($deleted_memberships)
+    public function __construct(public $deleted_memberships)
     {
-        $this->deleted_memberships = $deleted_memberships;
     }
 
     /**

--- a/app/Mail/PasswordResetEmail.php
+++ b/app/Mail/PasswordResetEmail.php
@@ -14,17 +14,14 @@ class PasswordResetEmail extends Mailable
 
     public $name;
 
-    public $token;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct(User $user, $token)
+    public function __construct(User $user, public $token)
     {
         $this->name = $user->calling_name;
-        $this->token = $token;
     }
 
     /**

--- a/app/Mail/ProductBulkUpdateNotification.php
+++ b/app/Mail/ProductBulkUpdateNotification.php
@@ -12,8 +12,6 @@ class ProductBulkUpdateNotification extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public $log;
-
     public $user;
 
     /**
@@ -21,9 +19,8 @@ class ProductBulkUpdateNotification extends Mailable
      *
      * @return void
      */
-    public function __construct(User $user, $log)
+    public function __construct(User $user, public $log)
     {
-        $this->log = $log;
         $this->user = $user;
     }
 

--- a/app/Mail/RegistrationConfirmation.php
+++ b/app/Mail/RegistrationConfirmation.php
@@ -11,16 +11,13 @@ class RegistrationConfirmation extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public $user;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct($user)
+    public function __construct(public $user)
     {
-        $this->user = $user;
     }
 
     /**

--- a/app/Mail/ReviewFeedbackMail.php
+++ b/app/Mail/ReviewFeedbackMail.php
@@ -12,19 +12,13 @@ class ReviewFeedbackMail extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public FeedbackCategory $category;
-
-    public $feedback;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct(FeedbackCategory $category, $feedback)
+    public function __construct(public FeedbackCategory $category, public $feedback)
     {
-        $this->feedback = $feedback;
-        $this->category = $category;
     }
 
     /**

--- a/app/Mail/UserMailChange.php
+++ b/app/Mail/UserMailChange.php
@@ -14,20 +14,14 @@ class UserMailChange extends Mailable
 
     public $user;
 
-    public $changer;
-
-    public $email;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct(User $user, $changer, $email)
+    public function __construct(User $user, public $changer, public $email)
     {
         $this->user = $user;
-        $this->changer = $changer;
-        $this->email = $email;
     }
 
     /**

--- a/app/Mail/UtwenteCleanup.php
+++ b/app/Mail/UtwenteCleanup.php
@@ -11,16 +11,13 @@ class UtwenteCleanup extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public $unlinked;
-
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct($unlinked)
+    public function __construct(public $unlinked)
     {
-        $this->unlinked = $unlinked;
     }
 
     /**

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -40,7 +40,7 @@ class Account extends Model
     /** @return hasMany */
     public function products()
     {
-        return $this->hasMany('App\Models\Product');
+        return $this->hasMany(\App\Models\Product::class);
     }
 
     /**

--- a/app/Models/Achievement.php
+++ b/app/Models/Achievement.php
@@ -53,12 +53,12 @@ class Achievement extends Model
     /** @return BelongsToMany */
     public function users()
     {
-        return $this->belongsToMany('App\Models\User', 'achievements_users');
+        return $this->belongsToMany(\App\Models\User::class, 'achievements_users');
     }
 
     public function achievementOwnership(): HasMany
     {
-        return $this->hasMany('App\Models\AchievementOwnership');
+        return $this->hasMany(\App\Models\AchievementOwnership::class);
     }
 
     /** @return int */

--- a/app/Models/AchievementOwnership.php
+++ b/app/Models/AchievementOwnership.php
@@ -50,11 +50,11 @@ class AchievementOwnership extends Model
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo('App\Models\User');
+        return $this->belongsTo(\App\Models\User::class);
     }
 
     public function achievement(): BelongsTo
     {
-        return $this->belongsTo('App\Models\Achievement');
+        return $this->belongsTo(\App\Models\Achievement::class);
     }
 }

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -74,19 +74,19 @@ class Activity extends Validatable
     /** @return BelongsTo */
     public function event()
     {
-        return $this->belongsTo('App\Models\Event');
+        return $this->belongsTo(\App\Models\Event::class);
     }
 
     /** @return BelongsTo */
     public function closedAccount()
     {
-        return $this->belongsTo('App\Models\Account', 'closed_account');
+        return $this->belongsTo(\App\Models\Account::class, 'closed_account');
     }
 
     /** @return BelongsToMany */
     public function users()
     {
-        return $this->belongsToMany('App\Models\User', 'activities_users')
+        return $this->belongsToMany(\App\Models\User::class, 'activities_users')
             ->withPivot('id', 'committees_activities_id', 'is_present')
             ->whereNull('activities_users.deleted_at')
             ->whereNull('committees_activities_id')
@@ -97,7 +97,7 @@ class Activity extends Validatable
     /** @return BelongsToMany */
     public function presentUsers()
     {
-        return $this->belongsToMany('App\Models\User', 'activities_users')
+        return $this->belongsToMany(\App\Models\User::class, 'activities_users')
             ->withPivot('id', 'committees_activities_id', 'is_present')
             ->whereNull('activities_users.deleted_at')
             ->whereNull('committees_activities_id')
@@ -109,7 +109,7 @@ class Activity extends Validatable
     /** @return BelongsToMany */
     public function allUsers()
     {
-        return $this->belongsToMany('App\Models\User', 'activities_users')
+        return $this->belongsToMany(\App\Models\User::class, 'activities_users')
             ->withPivot('id', 'committees_activities_id', 'is_present')
             ->whereNull('activities_users.deleted_at')
             ->where('backup', false)
@@ -119,19 +119,19 @@ class Activity extends Validatable
     /** @return BelongsToMany */
     public function backupUsers()
     {
-        return $this->belongsToMany('App\Models\User', 'activities_users')->whereNull('activities_users.deleted_at')->whereNull('committees_activities_id')->where('backup', true)->withPivot('id')->withTimestamps();
+        return $this->belongsToMany(\App\Models\User::class, 'activities_users')->whereNull('activities_users.deleted_at')->whereNull('committees_activities_id')->where('backup', true)->withPivot('id')->withTimestamps();
     }
 
     /** @return BelongsToMany */
     public function helpingCommittees()
     {
-        return $this->belongsToMany('App\Models\Committee', 'committees_activities')->withPivot(['amount', 'id'])->withTimestamps();
+        return $this->belongsToMany(\App\Models\Committee::class, 'committees_activities')->withPivot(['amount', 'id'])->withTimestamps();
     }
 
     /** @return HasMany */
     public function helpingCommitteeInstances()
     {
-        return $this->hasMany('App\Models\HelpingCommittee', 'activity_id');
+        return $this->hasMany(\App\Models\HelpingCommittee::class, 'activity_id');
     }
 
     /**

--- a/app/Models/ActivityParticipation.php
+++ b/app/Models/ActivityParticipation.php
@@ -62,18 +62,18 @@ class ActivityParticipation extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User')->withTrashed();
+        return $this->belongsTo(\App\Models\User::class)->withTrashed();
     }
 
     /** @return BelongsTo */
     public function activity()
     {
-        return $this->belongsTo('App\Models\Activity');
+        return $this->belongsTo(\App\Models\Activity::class);
     }
 
     /** @return BelongsTo */
     public function help()
     {
-        return $this->belongsTo('App\Models\HelpingCommittee', 'committees_activities_id');
+        return $this->belongsTo(\App\Models\HelpingCommittee::class, 'committees_activities_id');
     }
 }

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -59,6 +59,6 @@ class Address extends Validatable
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User');
+        return $this->belongsTo(\App\Models\User::class);
     }
 }

--- a/app/Models/Alias.php
+++ b/app/Models/Alias.php
@@ -40,6 +40,6 @@ class Alias extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User');
+        return $this->belongsTo(\App\Models\User::class);
     }
 }

--- a/app/Models/Bank.php
+++ b/app/Models/Bank.php
@@ -47,6 +47,6 @@ class Bank extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User')->withTrashed();
+        return $this->belongsTo(\App\Models\User::class)->withTrashed();
     }
 }

--- a/app/Models/Committee.php
+++ b/app/Models/Committee.php
@@ -71,7 +71,7 @@ class Committee extends Model
     /** @return BelongsToMany */
     public function users()
     {
-        return $this->belongsToMany('App\Models\User', 'committees_users')
+        return $this->belongsToMany(\App\Models\User::class, 'committees_users')
             ->where(function ($query) {
                 $query
                     ->whereNull('committees_users.deleted_at')
@@ -86,13 +86,13 @@ class Committee extends Model
     /** @return BelongsTo */
     public function image()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'image_id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'image_id');
     }
 
     /** @return HasMany */
     public function organizedEvents()
     {
-        return $this->hasMany('App\Models\Event', 'committee_id');
+        return $this->hasMany(\App\Models\Event::class, 'committee_id');
     }
 
     /** @return string */
@@ -132,7 +132,7 @@ class Committee extends Model
     public function helpedEvents($includeSecret = false)
     {
         /** @var Activity[] $activities */
-        $activities = $this->belongsToMany('App\Models\Activity', 'committees_activities')->orderBy('created_at', 'desc')->get();
+        $activities = $this->belongsToMany(\App\Models\Activity::class, 'committees_activities')->orderBy('created_at', 'desc')->get();
 
         $events = [];
         foreach ($activities as $activity) {
@@ -149,7 +149,7 @@ class Committee extends Model
     public function pastHelpedEvents()
     {
         /** @var Activity[] $activities */
-        $activities = $this->belongsToMany('App\Models\Activity', 'committees_activities')->orderBy('created_at', 'desc')->get();
+        $activities = $this->belongsToMany(\App\Models\Activity::class, 'committees_activities')->orderBy('created_at', 'desc')->get();
 
         $events = [];
         foreach ($activities as $activity) {

--- a/app/Models/CommitteeMembership.php
+++ b/app/Models/CommitteeMembership.php
@@ -62,12 +62,12 @@ class CommitteeMembership extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User')->withTrashed();
+        return $this->belongsTo(\App\Models\User::class)->withTrashed();
     }
 
     /** @return BelongsTo */
     public function committee()
     {
-        return $this->belongsTo('App\Models\Committee');
+        return $this->belongsTo(\App\Models\Committee::class);
     }
 }

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -59,12 +59,12 @@ class Company extends Model
     /** @return BelongsTo */
     public function image()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'image_id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'image_id');
     }
 
     /** @return HasMany */
     public function joboffers()
     {
-        return $this->hasMany('App\Models\Joboffer', 'company_id');
+        return $this->hasMany(\App\Models\Joboffer::class, 'company_id');
     }
 }

--- a/app/Models/Dinnerform.php
+++ b/app/Models/Dinnerform.php
@@ -61,18 +61,18 @@ class Dinnerform extends Model
     /** @return BelongsTo */
     public function event()
     {
-        return $this->belongsTo('App\Models\Event');
+        return $this->belongsTo(\App\Models\Event::class);
     }
 
     public function orderedBy(): BelongsTo
     {
-        return $this->belongsTo('App\Models\User', 'ordered_by_user_id');
+        return $this->belongsTo(\App\Models\User::class, 'ordered_by_user_id');
     }
 
     /** @return HasMany */
     public function orderlines()
     {
-        return $this->hasMany('App\Models\DinnerformOrderline');
+        return $this->hasMany(\App\Models\DinnerformOrderline::class);
     }
 
     /** @return float The regular discount as a percentage out of 100. */

--- a/app/Models/DinnerformOrderline.php
+++ b/app/Models/DinnerformOrderline.php
@@ -34,13 +34,13 @@ class DinnerformOrderline extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User')->withTrashed();
+        return $this->belongsTo(\App\Models\User::class)->withTrashed();
     }
 
     /** @return BelongsTo */
     public function dinnerform()
     {
-        return $this->belongsTo('App\Models\Dinnerform');
+        return $this->belongsTo(\App\Models\Dinnerform::class);
     }
 
     /** @return float Price of orderline reduced by possible discounts. */

--- a/app/Models/Email.php
+++ b/app/Models/Email.php
@@ -71,19 +71,19 @@ class Email extends Model
     /** @return BelongsToMany */
     public function lists()
     {
-        return $this->belongsToMany('App\Models\EmailList', 'emails_lists', 'email_id', 'list_id');
+        return $this->belongsToMany(\App\Models\EmailList::class, 'emails_lists', 'email_id', 'list_id');
     }
 
     /** @return BelongsToMany */
     public function events()
     {
-        return $this->belongsToMany('App\Models\Event', 'emails_events', 'email_id', 'event_id');
+        return $this->belongsToMany(\App\Models\Event::class, 'emails_events', 'email_id', 'event_id');
     }
 
     /** @return BelongsToMany */
     public function attachments()
     {
-        return $this->belongsToMany('App\Models\StorageEntry', 'emails_files', 'email_id', 'file_id');
+        return $this->belongsToMany(\App\Models\StorageEntry::class, 'emails_files', 'email_id', 'file_id');
     }
 
     /**

--- a/app/Models/EmailList.php
+++ b/app/Models/EmailList.php
@@ -40,7 +40,7 @@ class EmailList extends Model
     /** @return BelongsToMany */
     public function users()
     {
-        return $this->belongsToMany('App\Models\User', 'users_mailinglists', 'list_id', 'user_id');
+        return $this->belongsToMany(\App\Models\User::class, 'users_mailinglists', 'list_id', 'user_id');
     }
 
     /**

--- a/app/Models/EmailListSubscription.php
+++ b/app/Models/EmailListSubscription.php
@@ -40,12 +40,12 @@ class EmailListSubscription extends Model
     /** @return HasOne */
     public function user()
     {
-        return $this->hasOne('App\Models\User');
+        return $this->hasOne(\App\Models\User::class);
     }
 
     /** @return BelongsTo */
     public function emaillist()
     {
-        return $this->belongsTo('App\Models\EmailList', 'list_id');
+        return $this->belongsTo(\App\Models\EmailList::class, 'list_id');
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -114,7 +114,7 @@ class Event extends Model
     /** @return BelongsTo */
     public function committee()
     {
-        return $this->belongsTo('App\Models\Committee');
+        return $this->belongsTo(\App\Models\Committee::class);
     }
 
     /** @return bool */
@@ -151,43 +151,43 @@ class Event extends Model
     /** @return BelongsTo */
     public function image()
     {
-        return $this->belongsTo('App\Models\StorageEntry');
+        return $this->belongsTo(\App\Models\StorageEntry::class);
     }
 
     /** @return HasOne */
     public function activity()
     {
-        return $this->hasOne('App\Models\Activity');
+        return $this->hasOne(\App\Models\Activity::class);
     }
 
     /** @return HasMany */
     public function videos()
     {
-        return $this->hasMany('App\Models\Video');
+        return $this->hasMany(\App\Models\Video::class);
     }
 
     /** @return HasMany */
     public function albums()
     {
-        return $this->hasMany('App\Models\PhotoAlbum', 'event_id');
+        return $this->hasMany(\App\Models\PhotoAlbum::class, 'event_id');
     }
 
     /** @return HasMany */
     public function tickets()
     {
-        return $this->hasMany('App\Models\Ticket', 'event_id');
+        return $this->hasMany(\App\Models\Ticket::class, 'event_id');
     }
 
     /** @return HasMany */
     public function dinnerforms()
     {
-        return $this->hasMany('App\Models\Dinnerform', 'event_id');
+        return $this->hasMany(\App\Models\Dinnerform::class, 'event_id');
     }
 
     /** @return BelongsTo */
     public function category()
     {
-        return $this->BelongsTo('App\Models\EventCategory');
+        return $this->BelongsTo(\App\Models\EventCategory::class);
     }
 
     /**

--- a/app/Models/EventCategory.php
+++ b/app/Models/EventCategory.php
@@ -37,7 +37,7 @@ class EventCategory extends Model
     /** @return HasMany */
     public function events()
     {
-        return $this->hasMany('App\Models\Event', 'category_id');
+        return $this->hasMany(\App\Models\Event::class, 'category_id');
     }
 
     public function average_cost(): float

--- a/app/Models/FailedWithdrawal.php
+++ b/app/Models/FailedWithdrawal.php
@@ -40,18 +40,18 @@ class FailedWithdrawal extends Model
     /** @return BelongsTo */
     public function correctionOrderline()
     {
-        return $this->belongsTo('App\Models\OrderLine', 'correction_orderline_id');
+        return $this->belongsTo(\App\Models\OrderLine::class, 'correction_orderline_id');
     }
 
     /** @return HasOne */
     public function withdrawal()
     {
-        return $this->hasOne('App\Models\Withdrawal', 'withdrawal_id');
+        return $this->hasOne(\App\Models\Withdrawal::class, 'withdrawal_id');
     }
 
     /** @return HasOne */
     public function user()
     {
-        return $this->hasOne('App\Models\User', 'user_id');
+        return $this->hasOne(\App\Models\User::class, 'user_id');
     }
 }

--- a/app/Models/Feedback.php
+++ b/app/Models/Feedback.php
@@ -49,17 +49,17 @@ class Feedback extends Model
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo('App\Models\User');
+        return $this->belongsTo(\App\Models\User::class);
     }
 
     public function category(): BelongsTo
     {
-        return $this->belongsTo('App\Models\FeedbackCategory', 'feedback_category_id');
+        return $this->belongsTo(\App\Models\FeedbackCategory::class, 'feedback_category_id');
     }
 
     public function votes(): HasMany
     {
-        return $this->hasMany('App\Models\FeedbackVote');
+        return $this->hasMany(\App\Models\FeedbackVote::class);
     }
 
     public function voteScore(): int

--- a/app/Models/FeedbackCategory.php
+++ b/app/Models/FeedbackCategory.php
@@ -44,11 +44,11 @@ class FeedbackCategory extends Model
 
     public function feedback(): HasMany
     {
-        return $this->hasMany('App\Models\Feedback', 'feedback_category_id');
+        return $this->hasMany(\App\Models\Feedback::class, 'feedback_category_id');
     }
 
     public function reviewer(): BelongsTo
     {
-        return $this->belongsTo('App\Models\User', 'reviewer_id');
+        return $this->belongsTo(\App\Models\User::class, 'reviewer_id');
     }
 }

--- a/app/Models/FeedbackVote.php
+++ b/app/Models/FeedbackVote.php
@@ -40,11 +40,11 @@ class FeedbackVote extends Model
 
     public function feedback(): BelongsTo
     {
-        return $this->belongsTo('App\Models\Feedback');
+        return $this->belongsTo(\App\Models\Feedback::class);
     }
 
     public function user(): HasOne
     {
-        return $this->hasOne('App\Models\User');
+        return $this->hasOne(\App\Models\User::class);
     }
 }

--- a/app/Models/FinancialAccount.php
+++ b/app/Models/FinancialAccount.php
@@ -39,6 +39,6 @@ class FinancialAccount extends Model
     /** @return HasMany */
     public function products()
     {
-        return $this->hasMany('App\Models\Product', 'account_id');
+        return $this->hasMany(\App\Models\Product::class, 'account_id');
     }
 }

--- a/app/Models/HeaderImage.php
+++ b/app/Models/HeaderImage.php
@@ -41,12 +41,12 @@ class HeaderImage extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'credit_id');
+        return $this->belongsTo(\App\Models\User::class, 'credit_id');
     }
 
     /** @return BelongsTo */
     public function image()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'image_id', 'id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'image_id', 'id');
     }
 }

--- a/app/Models/HelpingCommittee.php
+++ b/app/Models/HelpingCommittee.php
@@ -51,20 +51,20 @@ class HelpingCommittee extends Validatable
     /** @return BelongsTo */
     public function activity()
     {
-        return $this->belongsTo('App\Models\Activity');
+        return $this->belongsTo(\App\Models\Activity::class);
     }
 
     /** @return BelongsTo */
     public function committee()
     {
-        return $this->belongsTo('App\Models\Committee');
+        return $this->belongsTo(\App\Models\Committee::class);
     }
 
     /** @return BelongsToMany */
     public function users()
     {
         return $this
-            ->belongsToMany('App\Models\User', 'activities_users', 'committees_activities_id')
+            ->belongsToMany(\App\Models\User::class, 'activities_users', 'committees_activities_id')
             ->whereNull('activities_users.deleted_at')
             ->withTrashed();
     }

--- a/app/Models/Joboffer.php
+++ b/app/Models/Joboffer.php
@@ -42,6 +42,6 @@ class Joboffer extends Model
     /** @return BelongsTo */
     public function company()
     {
-        return $this->belongsTo('App\Models\Company', 'company_id');
+        return $this->belongsTo(\App\Models\Company::class, 'company_id');
     }
 }

--- a/app/Models/Leaderboard.php
+++ b/app/Models/Leaderboard.php
@@ -49,13 +49,13 @@ class Leaderboard extends Model
     /** @return BelongsTo */
     public function committee()
     {
-        return $this->belongsTo('App\Models\Committee', 'committee_id');
+        return $this->belongsTo(\App\Models\Committee::class, 'committee_id');
     }
 
     /** @return HasMany */
     public function entries()
     {
-        return $this->hasMany('App\Models\LeaderboardEntry');
+        return $this->hasMany(\App\Models\LeaderboardEntry::class);
     }
 
     public static function isAdminAny(User $user): bool

--- a/app/Models/LeaderboardEntry.php
+++ b/app/Models/LeaderboardEntry.php
@@ -41,12 +41,12 @@ class LeaderboardEntry extends Model
     /** @return BelongsTo */
     public function leaderboard()
     {
-        return $this->belongsTo('App\Models\Leaderboard', 'leaderboard_id');
+        return $this->belongsTo(\App\Models\Leaderboard::class, 'leaderboard_id');
     }
 
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'user_id');
+        return $this->belongsTo(\App\Models\User::class, 'user_id');
     }
 }

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -73,19 +73,19 @@ class Member extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User')->withTrashed();
+        return $this->belongsTo(\App\Models\User::class)->withTrashed();
     }
 
     /** @return BelongsTo */
     public function membershipForm()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'membership_form_id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'membership_form_id');
     }
 
     /** @return BelongsTo */
     public function customOmnomcomSound()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'omnomcom_sound_id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'omnomcom_sound_id');
     }
 
     /** @return int */

--- a/app/Models/MenuItem.php
+++ b/app/Models/MenuItem.php
@@ -50,13 +50,13 @@ class MenuItem extends Model
     /** @return BelongsTo */
     public function page()
     {
-        return $this->belongsTo('App\Models\Page', 'page_id', 'id');
+        return $this->belongsTo(\App\Models\Page::class, 'page_id', 'id');
     }
 
     /** @return HasMany */
     public function children()
     {
-        return $this->hasMany('App\Models\MenuItem', 'parent');
+        return $this->hasMany(\App\Models\MenuItem::class, 'parent');
     }
 
     /** @return string|null */

--- a/app/Models/MollieTransaction.php
+++ b/app/Models/MollieTransaction.php
@@ -49,13 +49,13 @@ class MollieTransaction extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User')->withTrashed();
+        return $this->belongsTo(\App\Models\User::class)->withTrashed();
     }
 
     /** @return HasMany */
     public function orderlines()
     {
-        return $this->hasMany('App\Models\OrderLine', 'payed_with_mollie');
+        return $this->hasMany(\App\Models\OrderLine::class, 'payed_with_mollie');
     }
 
     /** @return MollieTransaction */

--- a/app/Models/NarrowcastingItem.php
+++ b/app/Models/NarrowcastingItem.php
@@ -46,6 +46,6 @@ class NarrowcastingItem extends Model
     /** @return BelongsTo */
     public function image()
     {
-        return $this->belongsTo('App\Models\StorageEntry');
+        return $this->belongsTo(\App\Models\StorageEntry::class);
     }
 }

--- a/app/Models/Newsitem.php
+++ b/app/Models/Newsitem.php
@@ -61,7 +61,7 @@ class Newsitem extends Model
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo('App\Models\User', 'user_id');
+        return $this->belongsTo(\App\Models\User::class, 'user_id');
     }
 
     public function events(): BelongsToMany
@@ -71,7 +71,7 @@ class Newsitem extends Model
 
     public function featuredImage(): BelongsTo
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'featured_image_id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'featured_image_id');
     }
 
     public function isPublished(): bool

--- a/app/Models/OrderLine.php
+++ b/app/Models/OrderLine.php
@@ -68,37 +68,37 @@ class OrderLine extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User')->withTrashed();
+        return $this->belongsTo(\App\Models\User::class)->withTrashed();
     }
 
     /** @return BelongsTo */
     public function product()
     {
-        return $this->belongsTo('App\Models\Product');
+        return $this->belongsTo(\App\Models\Product::class);
     }
 
     /** @return BelongsTo */
     public function cashier()
     {
-        return $this->belongsTo('App\Models\User')->withTrashed();
+        return $this->belongsTo(\App\Models\User::class)->withTrashed();
     }
 
     /** @return BelongsTo */
     public function withdrawal()
     {
-        return $this->belongsTo('App\Models\Withdrawal', 'payed_with_withdrawal');
+        return $this->belongsTo(\App\Models\Withdrawal::class, 'payed_with_withdrawal');
     }
 
     /** @return BelongsTo */
     public function molliePayment()
     {
-        return $this->belongsTo('App\Models\MollieTransaction', 'payed_with_mollie');
+        return $this->belongsTo(\App\Models\MollieTransaction::class, 'payed_with_mollie');
     }
 
     /** @return HasOne */
     public function ticketPurchase()
     {
-        return $this->hasOne('App\Models\TicketPurchase', 'orderline_id');
+        return $this->hasOne(\App\Models\TicketPurchase::class, 'orderline_id');
     }
 
     /** @return bool */

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -62,13 +62,13 @@ class Page extends Model
     /** @return BelongsTo */
     public function featuredImage()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'featured_image_id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'featured_image_id');
     }
 
     /** @return BelongsToMany */
     public function files()
     {
-        return $this->belongsToMany('App\Models\StorageEntry', 'pages_files', 'page_id', 'file_id');
+        return $this->belongsToMany(\App\Models\StorageEntry::class, 'pages_files', 'page_id', 'file_id');
     }
 
     /** @return string */

--- a/app/Models/PasswordEntry.php
+++ b/app/Models/PasswordEntry.php
@@ -49,7 +49,7 @@ class PasswordEntry extends Model
     /** @return BelongsTo */
     public function permission()
     {
-        return $this->belongsTo('Spatie\Permission\Models\Permission', 'permission_id');
+        return $this->belongsTo(\Spatie\Permission\Models\Permission::class, 'permission_id');
     }
 
     /** @return bool */

--- a/app/Models/PasswordReset.php
+++ b/app/Models/PasswordReset.php
@@ -35,6 +35,6 @@ class PasswordReset extends Model
     /** @return HasOne */
     public function user()
     {
-        return $this->hasOne('App\Models\User', 'email', 'email');
+        return $this->hasOne(\App\Models\User::class, 'email', 'email');
     }
 }

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -48,19 +48,19 @@ class Photo extends Model
     /** @return BelongsTo */
     public function album()
     {
-        return $this->belongsTo('App\Models\PhotoAlbum', 'album_id');
+        return $this->belongsTo(\App\Models\PhotoAlbum::class, 'album_id');
     }
 
     /** @return HasMany */
     public function likes()
     {
-        return $this->hasMany('App\Models\PhotoLikes');
+        return $this->hasMany(\App\Models\PhotoLikes::class);
     }
 
     /** @return hasOne */
     public function file()
     {
-        return $this->hasOne('App\Models\StorageEntry', 'id', 'file_id');
+        return $this->hasOne(\App\Models\StorageEntry::class, 'id', 'file_id');
     }
 
     /**

--- a/app/Models/PhotoAlbum.php
+++ b/app/Models/PhotoAlbum.php
@@ -53,19 +53,19 @@ class PhotoAlbum extends Model
     /** @return BelongsTo */
     public function event()
     {
-        return $this->belongsTo('App\Models\Event', 'event_id');
+        return $this->belongsTo(\App\Models\Event::class, 'event_id');
     }
 
     /** @return HasOne */
     private function thumbPhoto()
     {
-        return $this->hasOne('App\Models\Photo', 'id', 'thumb_id');
+        return $this->hasOne(\App\Models\Photo::class, 'id', 'thumb_id');
     }
 
     /** @return HasMany */
     public function items()
     {
-        return $this->hasMany('App\Models\Photo', 'album_id');
+        return $this->hasMany(\App\Models\Photo::class, 'album_id');
     }
 
     /** @return string|null */

--- a/app/Models/PhotoLikes.php
+++ b/app/Models/PhotoLikes.php
@@ -38,6 +38,6 @@ class PhotoLikes extends Model
     /** @return BelongsTo */
     public function photo()
     {
-        return $this->belongsTo('App\Models\Photo', 'photo_id');
+        return $this->belongsTo(\App\Models\Photo::class, 'photo_id');
     }
 }

--- a/app/Models/PhotoManager.php
+++ b/app/Models/PhotoManager.php
@@ -94,7 +94,7 @@ class PhotoManager extends Model
         $album = $album->first();
         $data->album_title = $album->name;
         $data->album_date = $album->date_taken;
-        $data->event = ($album->event ? $album->event : null);
+        $data->event = ($album->event ?: null);
         $data->private = $album->private;
         $data->published = $album->published;
         $data->thumb = $album->thumb();

--- a/app/Models/PlayedVideo.php
+++ b/app/Models/PlayedVideo.php
@@ -44,7 +44,7 @@ class PlayedVideo extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User');
+        return $this->belongsTo(\App\Models\User::class);
     }
 
     /**

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -73,13 +73,13 @@ class Product extends Model
     /** @return BelongsTo */
     public function account()
     {
-        return $this->belongsTo('App\Models\FinancialAccount');
+        return $this->belongsTo(\App\Models\FinancialAccount::class);
     }
 
     /** @return BelongsTo */
     public function image()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'image_id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'image_id');
     }
 
     /** @raturn String */
@@ -98,19 +98,19 @@ class Product extends Model
     /** @return BelongsToMany */
     public function categories()
     {
-        return $this->belongsToMany('App\Models\ProductCategory', 'products_categories', 'product_id', 'category_id');
+        return $this->belongsToMany(\App\Models\ProductCategory::class, 'products_categories', 'product_id', 'category_id');
     }
 
     /** @return HasOne */
     public function ticket()
     {
-        return $this->hasOne('App\Models\Ticket', 'product_id');
+        return $this->hasOne(\App\Models\Ticket::class, 'product_id');
     }
 
     /** @return HasMany */
     public function orderlines()
     {
-        return $this->hasMany('App\Models\OrderLine');
+        return $this->hasMany(\App\Models\OrderLine::class);
     }
 
     /** @return bool */
@@ -131,7 +131,7 @@ class Product extends Model
 
     public function wallstreetPrices()
     {
-        return $this->hasMany('App\Models\WallstreetPrice');
+        return $this->hasMany(\App\Models\WallstreetPrice::class);
     }
 
     /**

--- a/app/Models/ProductCategory.php
+++ b/app/Models/ProductCategory.php
@@ -49,12 +49,12 @@ class ProductCategory extends Model
     /** @return \Illuminate\Database\Eloquent\Relations\BelongsToMany */
     public function products()
     {
-        return $this->belongsToMany('App\Models\Product', 'products_categories', 'category_id', 'product_id');
+        return $this->belongsToMany(\App\Models\Product::class, 'products_categories', 'category_id', 'product_id');
     }
 
     public function sortedProducts()
     {
-        $products = $this->belongsToMany('App\Models\Product', 'products_categories', 'category_id', 'product_id')->get();
+        $products = $this->belongsToMany(\App\Models\Product::class, 'products_categories', 'category_id', 'product_id')->get();
 
         return $products->sortBy('name');
     }

--- a/app/Models/ProductCategoryEntry.php
+++ b/app/Models/ProductCategoryEntry.php
@@ -45,12 +45,12 @@ class ProductCategoryEntry extends Model
     /** @return BelongsTo */
     public function product()
     {
-        return $this->belongsTo('App\Models\Product');
+        return $this->belongsTo(\App\Models\Product::class);
     }
 
     /** @return BelongsTo */
     public function ProductCategory()
     {
-        return $this->belongsTo('App\Models\ProductCategory');
+        return $this->belongsTo(\App\Models\ProductCategory::class);
     }
 }

--- a/app/Models/RfidCard.php
+++ b/app/Models/RfidCard.php
@@ -40,6 +40,6 @@ class RfidCard extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User');
+        return $this->belongsTo(\App\Models\User::class);
     }
 }

--- a/app/Models/SoundboardSound.php
+++ b/app/Models/SoundboardSound.php
@@ -40,6 +40,6 @@ class SoundboardSound extends Model
     /** @return BelongsTo */
     public function file()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'file_id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'file_id');
     }
 }

--- a/app/Models/StockMutation.php
+++ b/app/Models/StockMutation.php
@@ -42,12 +42,12 @@ class StockMutation extends Model
 
     public function product(): BelongsTo
     {
-        return $this->belongsTo("App\Models\Product");
+        return $this->belongsTo(\App\Models\Product::class);
     }
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo("App\Models\User");
+        return $this->belongsTo(\App\Models\User::class);
     }
 
     public function date(): string

--- a/app/Models/Tempadmin.php
+++ b/app/Models/Tempadmin.php
@@ -43,12 +43,12 @@ class Tempadmin extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User');
+        return $this->belongsTo(\App\Models\User::class);
     }
 
     /** @return BelongsTo */
     public function creator()
     {
-        return $this->belongsTo('App\Models\User', 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by');
     }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -48,19 +48,19 @@ class Ticket extends Model
     /** @return BelongsTo */
     public function product()
     {
-        return $this->belongsTo('App\Models\Product');
+        return $this->belongsTo(\App\Models\Product::class);
     }
 
     /** @return BelongsTo */
     public function event()
     {
-        return $this->belongsTo('App\Models\Event');
+        return $this->belongsTo(\App\Models\Event::class);
     }
 
     /** @return HasMany */
     public function purchases()
     {
-        return $this->hasMany('App\Models\TicketPurchase');
+        return $this->hasMany(\App\Models\TicketPurchase::class);
     }
 
     /** @return Collection */

--- a/app/Models/TicketPurchase.php
+++ b/app/Models/TicketPurchase.php
@@ -49,19 +49,19 @@ class TicketPurchase extends Model
     /** @return BelongsTo */
     public function ticket()
     {
-        return $this->belongsTo('App\Models\Ticket', 'ticket_id');
+        return $this->belongsTo(\App\Models\Ticket::class, 'ticket_id');
     }
 
     /** @return BelongsTo */
     public function orderline()
     {
-        return $this->belongsTo('App\Models\OrderLine', 'orderline_id');
+        return $this->belongsTo(\App\Models\OrderLine::class, 'orderline_id');
     }
 
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'user_id')->withTrashed();
+        return $this->belongsTo(\App\Models\User::class, 'user_id')->withTrashed();
     }
 
     /** @return bool*/

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -38,7 +38,7 @@ class Token extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'user_id');
+        return $this->belongsTo(\App\Models\User::class, 'user_id');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -203,13 +203,13 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     /** @return BelongsTo */
     public function photo()
     {
-        return $this->belongsTo('App\Models\StorageEntry', 'image_id');
+        return $this->belongsTo(\App\Models\StorageEntry::class, 'image_id');
     }
 
     /** @return BelongsToMany */
     private function getGroups()
     {
-        return $this->belongsToMany('App\Models\Committee', 'committees_users')
+        return $this->belongsToMany(\App\Models\Committee::class, 'committees_users')
             ->where(function ($query) {
                 $query->whereNull('committees_users.deleted_at')
                     ->orWhere('committees_users.deleted_at', '>', Carbon::now());
@@ -223,13 +223,13 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     /** @return BelongsToMany */
     public function lists()
     {
-        return $this->belongsToMany('App\Models\EmailList', 'users_mailinglists', 'user_id', 'list_id');
+        return $this->belongsToMany(\App\Models\EmailList::class, 'users_mailinglists', 'user_id', 'list_id');
     }
 
     /** @return BelongsToMany */
     public function achievements()
     {
-        return $this->belongsToMany('App\Models\Achievement', 'achievements_users')->withPivot(['id', 'description'])->withTimestamps()->orderBy('pivot_created_at', 'desc');
+        return $this->belongsToMany(\App\Models\Achievement::class, 'achievements_users')->withPivot(['id', 'description'])->withTimestamps()->orderBy('pivot_created_at', 'desc');
     }
 
     /** @return BelongsToMany */
@@ -247,61 +247,61 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     /** @return HasOne */
     public function member()
     {
-        return $this->hasOne('App\Models\Member');
+        return $this->hasOne(\App\Models\Member::class);
     }
 
     /** @return HasOne */
     public function bank()
     {
-        return $this->hasOne('App\Models\Bank');
+        return $this->hasOne(\App\Models\Bank::class);
     }
 
     /** @return HasOne */
     public function address()
     {
-        return $this->hasOne('App\Models\Address');
+        return $this->hasOne(\App\Models\Address::class);
     }
 
     /** @return HasMany */
     public function orderlines()
     {
-        return $this->hasMany('App\Models\OrderLine');
+        return $this->hasMany(\App\Models\OrderLine::class);
     }
 
     /** @return HasMany */
     public function tempadmin()
     {
-        return $this->hasMany('App\Models\Tempadmin');
+        return $this->hasMany(\App\Models\Tempadmin::class);
     }
 
     /** @return HasMany */
     public function feedback()
     {
-        return $this->hasMany('App\Models\Feedback');
+        return $this->hasMany(\App\Models\Feedback::class);
     }
 
     /** @return HasMany */
     public function rfid()
     {
-        return $this->hasMany('App\Models\RfidCard');
+        return $this->hasMany(\App\Models\RfidCard::class);
     }
 
     /** @return HasMany */
     public function tokens()
     {
-        return $this->hasMany('App\Models\Token');
+        return $this->hasMany(\App\Models\Token::class);
     }
 
     /** @return HasMany */
     public function playedVideos()
     {
-        return $this->hasMany('App\Models\PlayedVideo');
+        return $this->hasMany(\App\Models\PlayedVideo::class);
     }
 
     /** @return HasMany */
     public function mollieTransactions()
     {
-        return $this->hasMany('App\Models\MollieTransaction');
+        return $this->hasMany(\App\Models\MollieTransaction::class);
     }
 
     /**

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -51,7 +51,7 @@ class Video extends Model
     /** @return BelongsTo */
     public function event()
     {
-        return $this->belongsTo('App\Models\Event', 'event_id');
+        return $this->belongsTo(\App\Models\Event::class, 'event_id');
     }
 
     /** @return string */

--- a/app/Models/WelcomeMessage.php
+++ b/app/Models/WelcomeMessage.php
@@ -43,6 +43,6 @@ class WelcomeMessage extends Model
     /** @return BelongsTo */
     public function user()
     {
-        return $this->belongsTo('App\Models\User');
+        return $this->belongsTo(\App\Models\User::class);
     }
 }

--- a/app/Models/Withdrawal.php
+++ b/app/Models/Withdrawal.php
@@ -40,7 +40,7 @@ class Withdrawal extends Model
     /** @return HasMany */
     public function orderlines()
     {
-        return $this->hasMany('App\Models\OrderLine', 'payed_with_withdrawal');
+        return $this->hasMany(\App\Models\OrderLine::class, 'payed_with_withdrawal');
     }
 
     /** @return array */

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -12,11 +12,11 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'Illuminate\Auth\Events\Login' => [
-            'App\Handlers\Events\AuthLoginEventHandler',
+        \Illuminate\Auth\Events\Login::class => [
+            \App\Handlers\Events\AuthLoginEventHandler::class,
         ],
-        'Aacotroneo\Saml2\Events\Saml2LoginEvent' => [
-            'App\Handlers\Events\SamlLoginEventHandler',
+        \Aacotroneo\Saml2\Events\Saml2LoginEvent::class => [
+            \App\Handlers\Events\SamlLoginEventHandler::class,
         ],
     ];
 

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,8 @@
     "symfony/css-selector": "~4.0",
     "symfony/dom-crawler": "~4.0",
     "laravel/sail": "^1.16",
-    "laravel/pint": "^1.10"
+    "laravel/pint": "^1.10",
+    "rector/rector": "^1.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb1a0a08453d24df9b898cdeb1864715",
+    "content-hash": "ecc8a2d35ef8a9ab42d37aa29e30f6d1",
     "packages": [
         {
             "name": "aacotroneo/laravel-saml2",
@@ -11287,16 +11287,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.15",
+            "version": "1.10.59",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "762c4dac4da6f8756eebb80e528c3a47855da9bd"
+                "reference": "e607609388d3a6d418a50a49f7940e8086798281"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/762c4dac4da6f8756eebb80e528c3a47855da9bd",
-                "reference": "762c4dac4da6f8756eebb80e528c3a47855da9bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e607609388d3a6d418a50a49f7940e8086798281",
+                "reference": "e607609388d3a6d418a50a49f7940e8086798281",
                 "shasum": ""
             },
             "require": {
@@ -11345,7 +11345,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-09T15:28:01+00:00"
+            "time": "2024-02-20T13:59:13+00:00"
         },
         {
             "name": "psy/psysh",
@@ -11422,6 +11422,62 @@
                 "source": "https://github.com/bobthecow/psysh/tree/v0.11.18"
             },
             "time": "2023-05-23T02:31:11+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "258b775511e62a7188f8ce114d44acaf244d9a7d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/258b775511e62a7188f8ce114d44acaf244d9a7d",
+                "reference": "258b775511e62a7188f8ce114d44acaf244d9a7d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.10.57"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-02-16T07:53:23+00:00"
         },
         {
             "name": "symfony/dom-crawler",

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -54,8 +54,8 @@ return [
     */
 
     'extra' => [
-        'Eloquent' => ['Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'],
-        'Session' => ['Illuminate\Session\Store'],
+        'Eloquent' => [\Illuminate\Database\Eloquent\Builder::class, \Illuminate\Database\Query\Builder::class],
+        'Session' => [\Illuminate\Session\Store::class],
     ],
 
     'magic' => [

--- a/config/imagecache.php
+++ b/config/imagecache.php
@@ -50,9 +50,9 @@ return [
     */
 
     'templates' => [
-        'small' => 'Intervention\Image\Templates\Small',
-        'medium' => 'Intervention\Image\Templates\Medium',
-        'large' => 'Intervention\Image\Templates\Large',
+        'small' => \Intervention\Image\Templates\Small::class,
+        'medium' => \Intervention\Image\Templates\Medium::class,
+        'large' => \Intervention\Image\Templates\Large::class,
     ],
 
     /*

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/app',
+        __DIR__ . '/config',
+        __DIR__ . '/public',
+        __DIR__ . '/resources',
+        __DIR__ . '/routes',
+    ])->withPhpSets(php53: true)
+    ->withRules(
+        [
+            ClassPropertyAssignToConstructorPromotionRector::class,
+            StringClassNameToClassConstantRector::class,
+        ]
+    )
+    ->withPreparedSets(deadCode: true,
+        codeQuality: false,
+        codingStyle: false,
+        typeDeclarations: false,
+        privatization: false,
+        naming: false,
+        instanceOf: false,
+        earlyReturn: false,
+        strictBooleans: false);

--- a/rector.php
+++ b/rector.php
@@ -8,11 +8,11 @@ use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 
 return RectorConfig::configure()
     ->withPaths([
-        __DIR__ . '/app',
-        __DIR__ . '/config',
-        __DIR__ . '/public',
-        __DIR__ . '/resources',
-        __DIR__ . '/routes',
+        __DIR__.'/app',
+        __DIR__.'/config',
+        __DIR__.'/public',
+        __DIR__.'/resources',
+        __DIR__.'/routes',
     ])->withPhpSets(php53: true)
     ->withRules(
         [

--- a/resources/views/event/display_includes/render_participant_list.blade.php
+++ b/resources/views/event/display_includes/render_participant_list.blade.php
@@ -1,7 +1,7 @@
 @foreach($participants as $user)
 
-    <?php $pid = (get_class($user) == 'App\Models\User' && $event ? $user->pivot->id : $user->id) ?>
-    <?php $u = (get_class($user) == 'App\Models\User' ? $user : $user->user) ?>
+    <?php $pid = (get_class($user) == \App\Models\User::class && $event ? $user->pivot->id : $user->id) ?>
+    <?php $u = (get_class($user) == \App\Models\User::class ? $user : $user->user) ?>
 
     <div class="btn-group btn-group-sm mb-1">
         <a href="{{ route("user::profile", ['id' => $u->getPublicId()]) }}"


### PR DESCRIPTION
This adds laravel rector into our codebase and CI.
Laravel rector is a tool to automaticly update your code to the newest standards.
This is done by toggling on and off rules and phpsets. See https://github.com/driftingly/rector-laravel and https://github.com/rectorphp/rector. For now enforced the minumum php version (5.3), the deadcode ruleset and the      ClassPropertyAssignToConstructorPromotionRector and StringClassNameToClassConstantRector rules. The first rule promotes class attributes into the constructor and the second one replaces all 'App\{class}\{class}' to the static \App\{class}\class::class.

I will slowly start bumping up the rulesets and php version codestyles in subsequent pull requests.