### PR TITLE
Fix: Remove unnecessary check that counts events per year

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -101,7 +101,7 @@ class Event extends Model
     }
 
     /**
-     * @param  string  $public_id
+     * @param string $public_id
      * @return Model
      */
     public static function fromPublicId($public_id)
@@ -133,8 +133,8 @@ class Event extends Model
         }
 
         //show non-secret events only when published
-        if (! $this->secret) {
-            if (! $this->publication || $this->isPublished()) {
+        if (!$this->secret) {
+            if (!$this->publication || $this->isPublished()) {
                 return true;
             }
         }
@@ -191,7 +191,7 @@ class Event extends Model
     }
 
     /**
-     * @param  User  $user
+     * @param User $user
      * @return bool Whether the user is organising the activity.
      */
     public function isOrganising($user)
@@ -221,24 +221,24 @@ class Event extends Model
     }
 
     /**
-     * @param  string  $long_format  Format when timespan is larger than 24 hours.
-     * @param  string  $short_format  Format when timespan is smaller than 24 hours.
-     * @param  string  $combiner  Character to separate start and end time.
+     * @param string $long_format Format when timespan is larger than 24 hours.
+     * @param string $short_format Format when timespan is smaller than 24 hours.
+     * @param string $combiner Character to separate start and end time.
      * @return string Timespan text in given format
      */
     public function generateTimespanText($long_format, $short_format, $combiner)
     {
-        return date($long_format, $this->start).' '.$combiner.' '.(
+        return date($long_format, $this->start) . ' ' . $combiner . ' ' . (
             (($this->end - $this->start) < 3600 * 24)
                 ?
                 date($short_format, $this->end)
                 :
                 date($long_format, $this->end)
-        );
+            );
     }
 
     /**
-     * @param  User  $user
+     * @param User $user
      * @return bool Whether the user is an admin of the event.
      */
     public function isEventAdmin($user)
@@ -247,7 +247,7 @@ class Event extends Model
     }
 
     /**
-     * @param  User  $user
+     * @param User $user
      * @return bool Whether the user is an ERO at the event
      */
     public function isEventEro($user)
@@ -258,7 +258,7 @@ class Event extends Model
         if (date('U') > $this->end) {
             return false;
         }
-        if (! $this->activity) {
+        if (!$this->activity) {
             return false;
         }
         $eroHelping = HelpingCommittee::query()
@@ -266,16 +266,16 @@ class Event extends Model
             ->where('committee_id', config('proto.committee')['ero'])->first();
         if ($eroHelping) {
             return ActivityParticipation::query()
-                ->where('activity_id', $this->activity->id)
-                ->where('committees_activities_id', $eroHelping->id)
-                ->where('user_id', $user->id)->count() > 0;
+                    ->where('activity_id', $this->activity->id)
+                    ->where('committees_activities_id', $eroHelping->id)
+                    ->where('user_id', $user->id)->count() > 0;
         } else {
             return false;
         }
     }
 
     /**
-     * @param  User  $user
+     * @param User $user
      * @return bool Whether the user has bought a ticket for the event.
      */
     public function hasBoughtTickets($user)
@@ -292,7 +292,7 @@ class Event extends Model
         }
         if ($this->activity) {
             $users = $users->merge($this->activity->allUsers->sort(function ($a, $b) {
-                return (int) isset($a->pivot->committees_activities_id); // prefer helper participation registration
+                return (int)isset($a->pivot->committees_activities_id); // prefer helper participation registration
             })->unique());
         }
 
@@ -338,24 +338,12 @@ class Event extends Model
     /** @return object */
     public function getFormattedDateAttribute()
     {
-        return (object) [
+        return (object)[
             'simple' => date('M d, Y', $this->start),
             'year' => date('Y', $this->start),
             'month' => date('M Y', $this->start),
             'time' => date('H:i', $this->start),
         ];
-    }
-
-    public static function countEventsPerYear(int $year)
-    {
-        $yearStart = strtotime('January 1, '.$year);
-        $yearEnd = strtotime('January 1, '.($year + 1));
-        $events = self::where('start', '>', $yearStart)->where('end', '<', $yearEnd);
-        if (! Auth::user()?->can('board')) {
-            $events = $events->where('secret', 0);
-        }
-
-        return $events->count();
     }
 
     public static function boot()

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Auth;
 use Carbon;
 use Eloquent;
 use Hashids;
@@ -101,7 +100,7 @@ class Event extends Model
     }
 
     /**
-     * @param string $public_id
+     * @param  string  $public_id
      * @return Model
      */
     public static function fromPublicId($public_id)
@@ -133,8 +132,8 @@ class Event extends Model
         }
 
         //show non-secret events only when published
-        if (!$this->secret) {
-            if (!$this->publication || $this->isPublished()) {
+        if (! $this->secret) {
+            if (! $this->publication || $this->isPublished()) {
                 return true;
             }
         }
@@ -191,7 +190,7 @@ class Event extends Model
     }
 
     /**
-     * @param User $user
+     * @param  User  $user
      * @return bool Whether the user is organising the activity.
      */
     public function isOrganising($user)
@@ -221,24 +220,24 @@ class Event extends Model
     }
 
     /**
-     * @param string $long_format Format when timespan is larger than 24 hours.
-     * @param string $short_format Format when timespan is smaller than 24 hours.
-     * @param string $combiner Character to separate start and end time.
+     * @param  string  $long_format  Format when timespan is larger than 24 hours.
+     * @param  string  $short_format  Format when timespan is smaller than 24 hours.
+     * @param  string  $combiner  Character to separate start and end time.
      * @return string Timespan text in given format
      */
     public function generateTimespanText($long_format, $short_format, $combiner)
     {
-        return date($long_format, $this->start) . ' ' . $combiner . ' ' . (
+        return date($long_format, $this->start).' '.$combiner.' '.(
             (($this->end - $this->start) < 3600 * 24)
                 ?
                 date($short_format, $this->end)
                 :
                 date($long_format, $this->end)
-            );
+        );
     }
 
     /**
-     * @param User $user
+     * @param  User  $user
      * @return bool Whether the user is an admin of the event.
      */
     public function isEventAdmin($user)
@@ -247,7 +246,7 @@ class Event extends Model
     }
 
     /**
-     * @param User $user
+     * @param  User  $user
      * @return bool Whether the user is an ERO at the event
      */
     public function isEventEro($user)
@@ -258,7 +257,7 @@ class Event extends Model
         if (date('U') > $this->end) {
             return false;
         }
-        if (!$this->activity) {
+        if (! $this->activity) {
             return false;
         }
         $eroHelping = HelpingCommittee::query()
@@ -266,16 +265,16 @@ class Event extends Model
             ->where('committee_id', config('proto.committee')['ero'])->first();
         if ($eroHelping) {
             return ActivityParticipation::query()
-                    ->where('activity_id', $this->activity->id)
-                    ->where('committees_activities_id', $eroHelping->id)
-                    ->where('user_id', $user->id)->count() > 0;
+                ->where('activity_id', $this->activity->id)
+                ->where('committees_activities_id', $eroHelping->id)
+                ->where('user_id', $user->id)->count() > 0;
         } else {
             return false;
         }
     }
 
     /**
-     * @param User $user
+     * @param  User  $user
      * @return bool Whether the user has bought a ticket for the event.
      */
     public function hasBoughtTickets($user)
@@ -292,7 +291,7 @@ class Event extends Model
         }
         if ($this->activity) {
             $users = $users->merge($this->activity->allUsers->sort(function ($a, $b) {
-                return (int)isset($a->pivot->committees_activities_id); // prefer helper participation registration
+                return (int) isset($a->pivot->committees_activities_id); // prefer helper participation registration
             })->unique());
         }
 
@@ -338,7 +337,7 @@ class Event extends Model
     /** @return object */
     public function getFormattedDateAttribute()
     {
-        return (object)[
+        return (object) [
             'simple' => date('M d, Y', $this->start),
             'year' => date('Y', $this->start),
             'month' => date('M Y', $this->start),

--- a/resources/views/event/calendar_includes/archivebar.blade.php
+++ b/resources/views/event/calendar_includes/archivebar.blade.php
@@ -15,31 +15,33 @@
             @endif
 
             @foreach($years as $y)
-                @if(App\Models\Event::countEventsPerYear($y) > 0)
-                    <a href="{{ route('event::archive', ['year'=>$y, 'category' => $cur_category]) }}"
-                       class="btn btn-{{ Route::currentRouteName() == 'event::archive' && $y == $year ? 'primary' : 'light' }}
+                <a href="{{ route('event::archive', ['year'=>$y, 'category' => $cur_category]) }}"
+                   class="btn btn-{{ Route::currentRouteName() == 'event::archive' && $y == $year ? 'primary' : 'light' }}
                         {{ $loop->index == count($years)-1 ? 'rounded-end' : '' }}">
-                        {{ $y }}
-                    </a>
-                @endif
+                    {{ $y }}
+                </a>
             @endforeach
         </div>
     </div>
     <div class="col-12 col-sm-auto mb-2 text-center">
         <div class="btn-group">
-            <button type="button" class="btn btn-info px-4 px-sm-3 {{ !Auth::check() || !Auth::user()->can('board') ? 'rounded-end' : '' }}" data-bs-toggle="modal" data-bs-target="#calendar-modal">
+            <button type="button"
+                    class="btn btn-info px-4 px-sm-3 {{ !Auth::check() || !Auth::user()->can('board') ? 'rounded-end' : '' }}"
+                    data-bs-toggle="modal" data-bs-target="#calendar-modal">
                 <i class="fas fa-calendar-alt"></i><span class="d-none d-sm-inline-block ms-2">Import Calendar</span>
             </button>
 
             @can('board')
                 <a href="{{ route("event::add") }}" class="btn btn-info rounded-end">
-                    <i class="fas fa-calendar-plus me-2"></i><span class="d-none d-sm-inline-block ms-2">Create Event</span>
+                    <i class="fas fa-calendar-plus me-2"></i><span
+                            class="d-none d-sm-inline-block ms-2">Create Event</span>
                 </a>
             @endcan
 
             @php($categories = \App\Models\EventCategory::all())
             @if(count($categories) > 0)
-                <form class="form-inline ms-3" action="{{ Route::currentRouteName() == 'event::archive' ? route('event::archive', ['year' => $year]) : route('event::list')}}">
+                <form class="form-inline ms-3"
+                      action="{{ Route::currentRouteName() == 'event::archive' ? route('event::archive', ['year' => $year]) : route('event::list')}}">
                     <div id="category-search" class="input-group">
                         <div class="input-group-prepend">
                             <button type="submit" class="btn btn-info"><i class="fas fa-search"></i></button>
@@ -78,8 +80,12 @@
                     favorite calendar application and looking for an option similar to <i>Import calendar by URL</i>.
                     You can then to copy the URL below.
                 </p>
-                <input id="ical-url" class="form-control" value="{{ Auth::check() ? Auth::user()->getIcalUrl() : route("ical::calendar") }}" readonly>
-                <script nonce="{{ csp_nonce() }}"> document.getElementById('ical-url').addEventListener('click', e => { e.target.focus(); e.target.select() }) </script>
+                <input id="ical-url" class="form-control"
+                       value="{{ Auth::check() ? Auth::user()->getIcalUrl() : route("ical::calendar") }}" readonly>
+                <script nonce="{{ csp_nonce() }}"> document.getElementById('ical-url').addEventListener('click', e => {
+                        e.target.focus();
+                        e.target.select()
+                    }) </script>
 
                 <hr>
 


### PR DESCRIPTION
This was only being done to ensure the years have events, but the original years call only gets years where there are events anyway. Saves about 10ms/year we have events in.

The query where we get the years already ensures that only years are gotten which have events in them:
![image](https://github.com/saproto/saproto/assets/72889753/805fc2b9-3dd4-4aa3-b041-6f760eb27f71)