### PR TITLE
Optimization: lazy load background images

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -427,12 +427,11 @@ class AuthController extends Controller
                 Session::flash('flash_message', 'The password you would like to set is unsafe because it has been exposed in one or more data breaches. Please choose a different password and <a href="https://wiki.proto.utwente.nl/ict/pwned-passwords" target="_blank">click here to learn more</a>.');
 
                 return view('auth.passchange');
-            } else {
-                $user->setPassword($pass_new1);
-                Session::flash('flash_message', 'Your password has been changed.');
-
-                return Redirect::route('user::dashboard');
             }
+            $user->setPassword($pass_new1);
+            Session::flash('flash_message', 'Your password has been changed.');
+
+            return Redirect::route('user::dashboard');
         }
 
         Session::flash('flash_message', 'Old password incorrect.');

--- a/app/Http/Controllers/QueryController.php
+++ b/app/Http/Controllers/QueryController.php
@@ -149,19 +149,19 @@ class QueryController extends Controller
             ];
 
             return Response::make(view('queries.export_active_members', ['export' => $export_active]), 200, $headers);
-        } else {
-            return view('queries.membership_totals', [
-                'total' => $count_total,
-                'primary' => $count_primary,
-                'secondary' => $count_secondary,
-                'ut' => $count_ut,
-                'active' => $count_active,
-                'lifelong' => $count_lifelong,
-                'honorary' => $count_honorary,
-                'donor' => $count_donor,
-                'pending' => $count_pending,
-            ]);
         }
+
+        return view('queries.membership_totals', [
+            'total' => $count_total,
+            'primary' => $count_primary,
+            'secondary' => $count_secondary,
+            'ut' => $count_ut,
+            'active' => $count_active,
+            'lifelong' => $count_lifelong,
+            'honorary' => $count_honorary,
+            'donor' => $count_donor,
+            'pending' => $count_pending,
+        ]);
     }
 
     public function activityStatistics(Request $request)

--- a/app/Models/Email.php
+++ b/app/Models/Email.php
@@ -114,9 +114,8 @@ class Email extends Model
             }
 
             return 'event';
-        } else {
-            throw new Exception('Email has no destination');
         }
+        throw new Exception('Email has no destination');
     }
 
     /** @return SupportCollection|User[] */
@@ -155,9 +154,9 @@ class Email extends Model
             }
 
             return User::whereIn('id', $user_ids)->orderBy('name', 'asc')->get();
-        } else {
-            return collect([]);
         }
+
+        return collect([]);
     }
 
     /** @return bool */

--- a/app/Models/MollieTransaction.php
+++ b/app/Models/MollieTransaction.php
@@ -84,9 +84,9 @@ class MollieTransaction extends Model
         }
         if ($status == 'paid' || $status == 'paidout') {
             return 'paid';
-        } else {
-            return 'unknown';
         }
+
+        return 'unknown';
     }
 
     /** @return string */

--- a/app/Models/StorageEntry.php
+++ b/app/Models/StorageEntry.php
@@ -178,11 +178,9 @@ class StorageEntry extends Model
         }
         if ($size < pow(1024, 3)) {
             return round($size / pow(1024, 2), 1).' megabytes';
-        } else {
-            return round($size / pow(1024, 3), 1).' gigabytes';
         }
 
-        return $size;
+        return round($size / pow(1024, 3), 1).' gigabytes';
     }
 
     /** @return string */

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -94,9 +94,9 @@ class Video extends Model
         }
         if ($interval->i > 0) {
             return sprintf('%s:%s ', $interval->i, str_pad(strval($interval->s), 2, '0', STR_PAD_LEFT));
-        } else {
-            return sprintf('%s seconds', $interval->s);
         }
+
+        return sprintf('%s seconds', $interval->s);
     }
 
     /** @return string|false */

--- a/resources/assets/js/application.js
+++ b/resources/assets/js/application.js
@@ -248,6 +248,36 @@ import shiftSelect from "./shift-select";
 
 document.querySelectorAll('.shift-select').forEach(el => el.hasAttribute('data-name') ? shiftSelect(el, el.getAttribute('data-name')) : null)
 
+//Lazy load background images 
+if ('IntersectionObserver' in window) {
+    document.addEventListener("DOMContentLoaded", function () {
+        function handleIntersection(entries) {
+            entries.map((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.style.backgroundPosition = "center";
+                    entry.target.style.backgroundRepeat = "no-repeat";
+                    entry.target.style.backgroundSize = "cover";
+                    entry.target.style.backgroundImage = "url('" + entry.target.dataset.bgimage + "')";
+                    observer.unobserve(entry.target);
+                }
+            });
+        }
+
+        const headers = document.querySelectorAll('.bg-img');
+        const observer = new IntersectionObserver(
+            handleIntersection,
+            {rootMargin: "100px"}
+        );
+        headers.forEach(header => observer.observe(header));
+    });
+} else {
+    // No interaction support? Load all background images automatically
+    const headers = document.querySelectorAll('.bg-img');
+    headers.forEach(header => {
+        header.style.backgroundImage = "url('" + header.dataset.bgimage + "')";
+    });
+}
+
 // Matomo Analytics
 const _paq = [];
 _paq.push(['trackPageView']);

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -4,13 +4,14 @@
        href="{{ route('event::show', ['id' => $event->getPublicId()]) }}">
 
         <div class="card-body event text-start {{ $event->image && (!isset($hide_photo) || !$hide_photo) ? 'bg-img' : 'no-img'}}"
-             style="{{ $event->image && (!isset($hide_photo) || !$hide_photo) ? sprintf('background: center no-repeat url(%s);', $event->image->generateImagePath(800,300)) : '' }} background-size: cover;">
+             data-bgimage="{{(!isset($hide_photo) || !$hide_photo) ? $event?->image?->generateImagePath(800,300):''}}">
 
             {{-- Countdown --}}
             @if(!empty($countdown))
-                <div class="btn btn-info btn-block mb-3 ">
+                <div class=" btn btn-info btn-block mb-3">
                     <i class="fas fa-circle-notch fa-fw fa-spin me-2" aria-hidden="true"></i>
-                    <span class="proto-countdown" data-countdown-start="{{ $event->start }}" data-countdown-text-counting="Starts in {}" data-countdown-text-finished="Event is underway!">
+                    <span class="proto-countdown" data-countdown-start="{{ $event->start }}"
+                          data-countdown-text-counting="Starts in {}" data-countdown-text-finished="Event is underway!">
                         Counting down...
                     </span>
                 </div>
@@ -24,13 +25,13 @@
 
             {{-- Participating --}}
             @if(Auth::check() && $event->activity?->isParticipating(Auth::user()))
-                    @if($event->activity->isOnBackupList(Auth::user()))
-                        <i class="fas fa-check text-warning fa-fw" aria-hidden="true"
-                           data-bs-toggle="tooltip" data-bs-placement="top" title="You are on the backuplist!"></i>
-                    @else
-                        <i class="fas fa-check text-primary fa-fw" aria-hidden="true"
-                           data-bs-toggle="tooltip" data-bs-placement="top" title="You are participating!"></i>
-                    @endif
+                @if($event->activity->isOnBackupList(Auth::user()))
+                    <i class="fas fa-check text-warning fa-fw" aria-hidden="true"
+                       data-bs-toggle="tooltip" data-bs-placement="top" title="You are on the backuplist!"></i>
+                @else
+                    <i class="fas fa-check text-primary fa-fw" aria-hidden="true"
+                       data-bs-toggle="tooltip" data-bs-placement="top" title="You are participating!"></i>
+                @endif
                 @if($event->activity->isHelping(Auth::user()))
                     <i class="fas fa-life-ring fa-fw text-danger" aria-hidden="true"
                        data-bs-toggle="tooltip" data-bs-placement="top" title="You are helping!"></i>
@@ -107,20 +108,20 @@
             @endif
 
             {{-- Signup Icon --}}
-                <div class= "d-flex justify-content-between">
-                    @if($event->usersCount()>0)
-                        <span>
+            <div class="d-flex justify-content-between">
+                @if($event->usersCount()>0)
+                    <span>
                             <i class="fas fa-user-alt fa-fw" aria-hidden="true"></i>
                             {{$event->usersCount()}}
                         </span>
-                    @endif
+                @endif
 
-                    @if($event->activity && $event->activity->canSubscribe())
-                        <span>
+                @if($event->activity && $event->activity->canSubscribe())
+                    <span>
                             <i class="fas fa-lock-open"></i>
                         </span>
-                    @endif
-                </div>
+                @endif
+            </div>
 
         </div>
 


### PR DESCRIPTION
Lazy load images as described in: https://www.conroyp.com/articles/improve-load-time-performance-lazily-loading-background-images

This will prevent us from loading all images at once, for instance in the calendar overview. For now, only implemented for the event_block. This means those images only get loaded when the IntersectionObserver notices the image is within 100 pixels of coming into view.

