### PR TITLE
Set admin account password to be fixed instead of randomly generated

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -29,7 +29,7 @@ class DatabaseSeeder extends Seeder
 
         $output->task('setting roles and permissions', fn () => Artisan::call('proto:syncroles'));
 
-        $adminPassword = str_random();
+        $adminPassword = 'proto';
 
         $importSeeder = new ImportLiveDataSeeder();
         $importSeeder->run($adminPassword, $output);


### PR DESCRIPTION
I don't know why this password is randomly generated every time. Seems unnecessary to me. If you want to suggest a better default password than 'proto' be my guest.