### PR TITLE
Fix the search being null when less than 3 characters

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -10,7 +10,7 @@ use App\Models\PhotoAlbum;
 use App\Models\Product;
 use App\Models\User;
 use Auth;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -34,10 +34,13 @@ class SearchController extends Controller
                 User::class,
                 $term,
                 Auth::user()->can('board') ? ['id', 'name', 'calling_name', 'utwente_username', 'email'] : ['id', 'name', 'calling_name', 'email']
-            )->get();
-            foreach ($presearch_users as $user) {
-                if ($user->is_member) {
-                    $users[] = $user;
+            )?->get();
+
+            if ($presearch_users) {
+                foreach ($presearch_users as $user) {
+                    if ($user->is_member) {
+                        $users[] = $user;
+                    }
                 }
             }
         }
@@ -47,10 +50,12 @@ class SearchController extends Controller
             Page::class,
             $term,
             ['slug', 'title', 'content']
-        )->get();
-        foreach ($presearch_pages as $page) {
-            if (! $page->is_member_only || Auth::user()?->is_member) {
-                $pages[] = $page;
+        )?->get();
+        if ($presearch_pages) {
+            foreach ($presearch_pages as $page) {
+                if (!$page->is_member_only || Auth::user()?->is_member) {
+                    $pages[] = $page;
+                }
             }
         }
 
@@ -59,10 +64,12 @@ class SearchController extends Controller
             Committee::class,
             $term,
             ['id', 'name', 'slug']
-        )->get();
-        foreach ($presearch_committees as $committee) {
-            if ($committee->public || Auth::user()?->can('board')) {
-                $committees[] = $committee;
+        )?->get();
+        if ($presearch_committees) {
+            foreach ($presearch_committees as $committee) {
+                if ($committee->public || Auth::user()?->can('board')) {
+                    $committees[] = $committee;
+                }
             }
         }
 
@@ -70,25 +77,29 @@ class SearchController extends Controller
             Event::class,
             $term,
             ['id', 'title']
-        )->pluck('id');
+        )?->pluck('id');
 
         $events = collect();
-        //load the events with all the correct data to show in the event block
-        Event::getEventBlockQuery()->whereIn('id', $presearch_event_ids)->get()->each(function ($event) use ($events) {
-            if ($event->mayViewEvent(Auth::user())) {
-                $events->push($event);
-            }
-        });
+        if ($presearch_event_ids) {
+            //load the events with all the correct data to show in the event block
+            Event::getEventBlockQuery()->whereIn('id', $presearch_event_ids)->get()->each(function ($event) use ($events) {
+                if ($event->mayViewEvent(Auth::user())) {
+                    $events->push($event);
+                }
+            });
+        }
 
         $photoAlbums = [];
         $presearch_photo_albums = $this->getGenericSearchQuery(
             PhotoAlbum::class,
             $term,
             ['id', 'name']
-        )->get();
-        foreach ($presearch_photo_albums as $album) {
-            if (! $album->secret || Auth::user()?->can('protography')) {
-                $photoAlbums[] = $album;
+        )?->get();
+        if ($presearch_photo_albums) {
+            foreach ($presearch_photo_albums as $album) {
+                if (!$album->secret || Auth::user()?->can('protography')) {
+                    $photoAlbums[] = $album;
+                }
             }
         }
 
@@ -132,7 +143,7 @@ class SearchController extends Controller
 
         return view('search.ldapsearch', [
             'term' => $query,
-            'data' => (array) $data,
+            'data' => (array)$data,
         ]);
     }
 
@@ -149,8 +160,8 @@ class SearchController extends Controller
     {
         $search_attributes = ['id', 'name', 'calling_name', 'utwente_username', 'email'];
         $result = [];
-        foreach ($this->getGenericSearchQuery(User::class, $request->get('q'), $search_attributes)->get() as $user) {
-            $result[] = (object) [
+        foreach ($this->getGenericSearchQuery(User::class, $request->get('q'), $search_attributes)?->get() ?? [] as $user) {
+            $result[] = (object)[
                 'id' => $user->id,
                 'name' => $user->name,
                 'is_member' => $user->is_member,
@@ -167,7 +178,7 @@ class SearchController extends Controller
     {
         $search_attributes = ['id', 'title'];
 
-        return $this->getGenericSearchQuery(Event::class, $request->get('q'), $search_attributes)->get();
+        return $this->getGenericSearchQuery(Event::class, $request->get('q'), $search_attributes)?->get();
     }
 
     /**
@@ -177,7 +188,7 @@ class SearchController extends Controller
     {
         $search_attributes = ['id', 'name', 'slug'];
 
-        return $this->getGenericSearchQuery(Committee::class, $request->get('q'), $search_attributes)->get();
+        return $this->getGenericSearchQuery(Committee::class, $request->get('q'), $search_attributes)?->get();
     }
 
     /**
@@ -187,7 +198,7 @@ class SearchController extends Controller
     {
         $search_attributes = ['id', 'name'];
 
-        return $this->getGenericSearchQuery(Product::class, $request->get('q'), $search_attributes)->get();
+        return $this->getGenericSearchQuery(Product::class, $request->get('q'), $search_attributes)?->get();
     }
 
     /**
@@ -197,16 +208,10 @@ class SearchController extends Controller
     {
         $search_attributes = ['id', 'name'];
 
-        return $this->getGenericSearchQuery(Achievement::class, $request->get('q'), $search_attributes)->get();
+        return $this->getGenericSearchQuery(Achievement::class, $request->get('q'), $search_attributes)?->get();
     }
 
-    /**
-     * @param  class-string|Model  $model
-     * @param  string  $query
-     * @param  string[]  $attributes
-     * @return Collection<Model>|array
-     */
-    private function getGenericSearchQuery($model, $query, $attributes)
+    private function getGenericSearchQuery(Model|string $model, string $query, array $attributes): Builder|null
     {
         $terms = explode(' ', str_replace('*', '%', $query));
         $query = $model::query();
@@ -219,8 +224,8 @@ class SearchController extends Controller
             $check_at_least_one_valid_term = true;
         }
 
-        if (! $check_at_least_one_valid_term) {
-            return [];
+        if (!$check_at_least_one_valid_term) {
+            return null;
         }
 
         foreach ($attributes as $attr) {

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -53,7 +53,7 @@ class SearchController extends Controller
         )?->get();
         if ($presearch_pages) {
             foreach ($presearch_pages as $page) {
-                if (!$page->is_member_only || Auth::user()?->is_member) {
+                if (! $page->is_member_only || Auth::user()?->is_member) {
                     $pages[] = $page;
                 }
             }
@@ -97,7 +97,7 @@ class SearchController extends Controller
         )?->get();
         if ($presearch_photo_albums) {
             foreach ($presearch_photo_albums as $album) {
-                if (!$album->secret || Auth::user()?->can('protography')) {
+                if (! $album->secret || Auth::user()?->can('protography')) {
                     $photoAlbums[] = $album;
                 }
             }
@@ -143,7 +143,7 @@ class SearchController extends Controller
 
         return view('search.ldapsearch', [
             'term' => $query,
-            'data' => (array)$data,
+            'data' => (array) $data,
         ]);
     }
 
@@ -161,7 +161,7 @@ class SearchController extends Controller
         $search_attributes = ['id', 'name', 'calling_name', 'utwente_username', 'email'];
         $result = [];
         foreach ($this->getGenericSearchQuery(User::class, $request->get('q'), $search_attributes)?->get() ?? [] as $user) {
-            $result[] = (object)[
+            $result[] = (object) [
                 'id' => $user->id,
                 'name' => $user->name,
                 'is_member' => $user->is_member,
@@ -211,7 +211,7 @@ class SearchController extends Controller
         return $this->getGenericSearchQuery(Achievement::class, $request->get('q'), $search_attributes)?->get();
     }
 
-    private function getGenericSearchQuery(Model|string $model, string $query, array $attributes): Builder|null
+    private function getGenericSearchQuery(Model|string $model, string $query, array $attributes): ?Builder
     {
         $terms = explode(' ', str_replace('*', '%', $query));
         $query = $model::query();
@@ -224,7 +224,7 @@ class SearchController extends Controller
             $check_at_least_one_valid_term = true;
         }
 
-        if (!$check_at_least_one_valid_term) {
+        if (! $check_at_least_one_valid_term) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://sa-proto.sentry.io/issues/5320218966/.
The query could be an empty array when there are less than 3 characters, now it returns empty and handles this case