### PR TITLE
Fix the migration for the unique users count

### DIFF
--- a/database/migrations/2024_03_12_115002_add_users_count_to_events.php
+++ b/database/migrations/2024_03_12_115002_add_users_count_to_events.php
@@ -5,13 +5,14 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        
+
         if (Schema::hasColumn('events', 'unique_users_count')) {
             Schema::table('events', function (Blueprint $table) {
                 $table->dropColumn('unique_users_count');

--- a/database/migrations/2024_03_12_115002_add_users_count_to_events.php
+++ b/database/migrations/2024_03_12_115002_add_users_count_to_events.php
@@ -5,13 +5,19 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
     public function up(): void
     {
+        
+        if (Schema::hasColumn('events', 'unique_users_count')) {
+            Schema::table('events', function (Blueprint $table) {
+                $table->dropColumn('unique_users_count');
+            });
+        }
+
         Schema::table('events', function (Blueprint $table) {
             //add a new column that counts the amount of users who signed up called users_count for the event_block number
             $table->unsignedInteger('unique_users_count')->after('publication')->default(0);


### PR DESCRIPTION
somehow the column already exists on the live server so added a check that removes it first when exists and then updates it. Adding the check is safer than doing sql queries on live.