### PR TITLE
Improvement/lazyloading and paginate the dinnerforms

### DIFF
--- a/app/Http/Controllers/DinnerformController.php
+++ b/app/Http/Controllers/DinnerformController.php
@@ -17,7 +17,7 @@ use Session;
 class DinnerformController extends Controller
 {
     /**
-     * @param  int  $id
+     * @param int $id
      * @return View|RedirectResponse
      */
     public function show($id)
@@ -28,7 +28,7 @@ class DinnerformController extends Controller
             ->where('user_id', Auth::user()->id)
             ->where('dinnerform_id', $dinnerform->id)
             ->first();
-        if (! $dinnerform->isCurrent() && ! isset($order)) {
+        if (!$dinnerform->isCurrent() && !isset($order)) {
             Session::flash('flash_message', 'This dinnerform is closed and you have not ordered anything.');
 
             return Redirect::back();
@@ -48,7 +48,7 @@ class DinnerformController extends Controller
     /** @return View */
     public function create()
     {
-        $dinnerformList = Dinnerform::all()->sortByDesc('end');
+        $dinnerformList = Dinnerform::query()->orderBy('end', 'desc')->with('orderedBy')->paginate(20);
 
         return view('dinnerform.list', ['dinnerformCurrent' => null, 'dinnerformList' => $dinnerformList]);
     }
@@ -77,13 +77,13 @@ class DinnerformController extends Controller
             'ordered_by_user_id' => $request->input('ordered_by'),
         ]);
 
-        Session::flash('flash_message', "Your dinnerform at '".$dinnerform->restaurant."' has been added.");
+        Session::flash('flash_message', "Your dinnerform at '" . $dinnerform->restaurant . "' has been added.");
 
         return Redirect::route('dinnerform::add');
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return View|RedirectResponse
      */
     public function edit($id)
@@ -94,13 +94,13 @@ class DinnerformController extends Controller
 
             return Redirect::back();
         }
-        $dinnerformList = Dinnerform::all()->sortByDesc('end');
+        $dinnerformList = Dinnerform::query()->orderBy('end', 'desc')->with('orderedBy')->paginate(20);
 
         return view('dinnerform.list', ['dinnerformCurrent' => $dinnerformCurrent, 'dinnerformList' => $dinnerformList]);
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse|View
      */
     public function update(Request $request, $id)
@@ -140,16 +140,16 @@ class DinnerformController extends Controller
         ]);
 
         if ($changed_important_details) {
-            Session::flash('flash_message', "Your dinnerform for '".$dinnerform->restaurant."' has been saved. You updated some important information. Don't forget to notify your participants with this info!");
+            Session::flash('flash_message', "Your dinnerform for '" . $dinnerform->restaurant . "' has been saved. You updated some important information. Don't forget to notify your participants with this info!");
         } else {
-            Session::flash('flash_message', "Your dinnerform for '".$dinnerform->restaurant."' has been saved.");
+            Session::flash('flash_message', "Your dinnerform for '" . $dinnerform->restaurant . "' has been saved.");
         }
 
         return $this->edit($id);
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -157,8 +157,8 @@ class DinnerformController extends Controller
     public function destroy($id)
     {
         $dinnerform = Dinnerform::findOrFail($id);
-        if (! $dinnerform->closed) {
-            Session::flash('flash_message', "The dinnerform for '".$dinnerform->restaurant."' has been deleted.");
+        if (!$dinnerform->closed) {
+            Session::flash('flash_message', "The dinnerform for '" . $dinnerform->restaurant . "' has been deleted.");
             $dinnerform->delete();
         } else {
             Session::flash('flash_message', 'The dinnerform is already closed and can not be deleted!');
@@ -170,7 +170,7 @@ class DinnerformController extends Controller
     /**
      * Close the dinnerform by changing the end time to the current time.
      *
-     * @param  int  $id
+     * @param int $id
      * @return View
      */
     public function close($id)
@@ -185,7 +185,7 @@ class DinnerformController extends Controller
 
     public function process($id)
     {
-        if (! Auth::user()->can('finadmin')) {
+        if (!Auth::user()->can('finadmin')) {
             Session::flash('flash_message', 'You are not allowed to process dinnerforms!');
 
             return Redirect::back();

--- a/app/Http/Controllers/DinnerformController.php
+++ b/app/Http/Controllers/DinnerformController.php
@@ -17,7 +17,7 @@ use Session;
 class DinnerformController extends Controller
 {
     /**
-     * @param int $id
+     * @param  int  $id
      * @return View|RedirectResponse
      */
     public function show($id)
@@ -28,7 +28,7 @@ class DinnerformController extends Controller
             ->where('user_id', Auth::user()->id)
             ->where('dinnerform_id', $dinnerform->id)
             ->first();
-        if (!$dinnerform->isCurrent() && !isset($order)) {
+        if (! $dinnerform->isCurrent() && ! isset($order)) {
             Session::flash('flash_message', 'This dinnerform is closed and you have not ordered anything.');
 
             return Redirect::back();
@@ -77,13 +77,13 @@ class DinnerformController extends Controller
             'ordered_by_user_id' => $request->input('ordered_by'),
         ]);
 
-        Session::flash('flash_message', "Your dinnerform at '" . $dinnerform->restaurant . "' has been added.");
+        Session::flash('flash_message', "Your dinnerform at '".$dinnerform->restaurant."' has been added.");
 
         return Redirect::route('dinnerform::add');
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return View|RedirectResponse
      */
     public function edit($id)
@@ -100,7 +100,7 @@ class DinnerformController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse|View
      */
     public function update(Request $request, $id)
@@ -140,16 +140,16 @@ class DinnerformController extends Controller
         ]);
 
         if ($changed_important_details) {
-            Session::flash('flash_message', "Your dinnerform for '" . $dinnerform->restaurant . "' has been saved. You updated some important information. Don't forget to notify your participants with this info!");
+            Session::flash('flash_message', "Your dinnerform for '".$dinnerform->restaurant."' has been saved. You updated some important information. Don't forget to notify your participants with this info!");
         } else {
-            Session::flash('flash_message', "Your dinnerform for '" . $dinnerform->restaurant . "' has been saved.");
+            Session::flash('flash_message', "Your dinnerform for '".$dinnerform->restaurant."' has been saved.");
         }
 
         return $this->edit($id);
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -157,8 +157,8 @@ class DinnerformController extends Controller
     public function destroy($id)
     {
         $dinnerform = Dinnerform::findOrFail($id);
-        if (!$dinnerform->closed) {
-            Session::flash('flash_message', "The dinnerform for '" . $dinnerform->restaurant . "' has been deleted.");
+        if (! $dinnerform->closed) {
+            Session::flash('flash_message', "The dinnerform for '".$dinnerform->restaurant."' has been deleted.");
             $dinnerform->delete();
         } else {
             Session::flash('flash_message', 'The dinnerform is already closed and can not be deleted!');
@@ -170,7 +170,7 @@ class DinnerformController extends Controller
     /**
      * Close the dinnerform by changing the end time to the current time.
      *
-     * @param int $id
+     * @param  int  $id
      * @return View
      */
     public function close($id)
@@ -185,7 +185,7 @@ class DinnerformController extends Controller
 
     public function process($id)
     {
-        if (!Auth::user()->can('finadmin')) {
+        if (! Auth::user()->can('finadmin')) {
             Session::flash('flash_message', 'You are not allowed to process dinnerforms!');
 
             return Redirect::back();

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -89,7 +89,7 @@ class EventController extends Controller
         $event = Event::getEventBlockQuery()->where('id', Event::getIdFromPublicId($id))
             ->with('tickets', 'tickets.product')
             ->firstOrFail();
-        
+
         $methods = [];
         if (config('omnomcom.mollie.use_fees')) {
             $methods = MollieController::getPaymentMethods();
@@ -138,13 +138,13 @@ class EventController extends Controller
         $event->category()->associate($category);
         $event->save();
 
-        Session::flash('flash_message', "Your event '" . $event->title . "' has been added.");
+        Session::flash('flash_message', "Your event '".$event->title."' has been added.");
 
         return Redirect::route('event::show', ['id' => $event->getPublicId()]);
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return View
      */
     public function edit($id)
@@ -155,7 +155,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      *
      * @throws FileNotFoundException
@@ -206,24 +206,24 @@ class EventController extends Controller
         $changed_important_details = $event->start != strtotime($request->start) || $event->end != strtotime($request->end) || $event->location != $request->location;
 
         if ($changed_important_details) {
-            Session::flash('flash_message', "Your event '" . $event->title . "' has been saved. <br><b class='text-warning'>You updated some important information. Don't forget to update your participants with this info!</b>");
+            Session::flash('flash_message', "Your event '".$event->title."' has been saved. <br><b class='text-warning'>You updated some important information. Don't forget to update your participants with this info!</b>");
         } else {
-            Session::flash('flash_message', "Your event '" . $event->title . "' has been saved.");
+            Session::flash('flash_message', "Your event '".$event->title."' has been saved.");
         }
 
         return Redirect::back();
     }
 
     /**
-     * @param int $year
+     * @param  int  $year
      * @return View
      */
     public function archive(Request $request, $year)
     {
         $years = collect(DB::select('SELECT DISTINCT Year(FROM_UNIXTIME(start)) AS start FROM events ORDER BY Year(FROM_UNIXTIME(start))'))->pluck('start');
         $events = Event::getEventBlockQuery()
-            ->where('start', '>', strtotime($year . '-01-01 00:00:01'))
-            ->where('start', '<', strtotime($year . '-12-31 23:59:59'))
+            ->where('start', '>', strtotime($year.'-01-01 00:00:01'))
+            ->where('start', '<', strtotime($year.'-12-31 23:59:59'))
             ->get();
 
         $category = EventCategory::find($request->category);
@@ -234,7 +234,7 @@ class EventController extends Controller
         }
 
         foreach ($events as $event) {
-            if (!$category || $category == $event->category) {
+            if (! $category || $category == $event->category) {
                 $months[intval(date('n', $event->start))][] = $event;
             }
         }
@@ -248,7 +248,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -259,12 +259,12 @@ class EventController extends Controller
         $event = Event::findOrFail($id);
 
         if ($event->activity !== null) {
-            Session::flash('flash_message', "You cannot delete event '" . $event->title . "' since it has a participation details.");
+            Session::flash('flash_message', "You cannot delete event '".$event->title."' since it has a participation details.");
 
             return Redirect::back();
         }
 
-        Session::flash('flash_message', "The event '" . $event->title . "' has been deleted.");
+        Session::flash('flash_message', "The event '".$event->title."' has been deleted.");
 
         $event->delete();
 
@@ -272,7 +272,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function forceLogin($id)
@@ -281,14 +281,14 @@ class EventController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse|View
      */
     public function admin($id)
     {
         $event = Event::findOrFail($id);
 
-        if (!$event->isEventAdmin(Auth::user())) {
+        if (! $event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not an event admin for this event!');
 
             return Redirect::back();
@@ -298,14 +298,14 @@ class EventController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse|View
      */
     public function scan($id)
     {
         $event = Event::findOrFail($id);
 
-        if (!$event->isEventAdmin(Auth::user())) {
+        if (! $event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not an event admin for this event!');
 
             return Redirect::back();
@@ -315,7 +315,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function finclose(Request $request, $id)
@@ -323,7 +323,7 @@ class EventController extends Controller
         /** @var Activity $activity */
         $activity = Activity::findOrFail($id);
 
-        if ($activity->event && !$activity->event->over()) {
+        if ($activity->event && ! $activity->event->over()) {
             Session::flash('flash_message', 'You cannot close an activity before it has finished.');
 
             return Redirect::back();
@@ -351,7 +351,7 @@ class EventController extends Controller
 
         $product = Product::create([
             'account_id' => $account->id,
-            'name' => 'Activity: ' . ($activity->event ? $activity->event->title : $activity->comment),
+            'name' => 'Activity: '.($activity->event ? $activity->event->title : $activity->comment),
             'price' => $activity->price,
         ]);
         $product->save();
@@ -370,7 +370,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param Event $event
+     * @param  Event  $event
      * @return RedirectResponse
      */
     public function linkAlbum(Request $request, $event)
@@ -383,13 +383,13 @@ class EventController extends Controller
         $album->event()->associate($event);
         $album->save();
 
-        Session::flash('flash_message', 'The album ' . $album->name . ' has been linked to this activity!');
+        Session::flash('flash_message', 'The album '.$album->name.' has been linked to this activity!');
 
         return Redirect::back();
     }
 
     /**
-     * @param PhotoAlbum $album
+     * @param  PhotoAlbum  $album
      * @return RedirectResponse
      */
     public function unlinkAlbum($album)
@@ -399,13 +399,13 @@ class EventController extends Controller
         $album->event()->dissociate();
         $album->save();
 
-        Session::flash('flash_message', 'The album ' . $album->name . ' has been unlinked from an activity!');
+        Session::flash('flash_message', 'The album '.$album->name.' has been unlinked from an activity!');
 
         return Redirect::back();
     }
 
     /**
-     * @param int $limit
+     * @param  int  $limit
      * @return array
      */
     public function apiUpcomingEvents($limit, Request $request)
@@ -418,26 +418,26 @@ class EventController extends Controller
 
         foreach ($events as $event) {
             if ($event->secret && ($user == null || $event->activity == null || (
-                        !$event->activity->isParticipating($user) &&
-                        !$event->activity->isHelping($user) &&
-                        !$event->activity->isOrganising($user)
-                    ))) {
+                ! $event->activity->isParticipating($user) &&
+                ! $event->activity->isHelping($user) &&
+                ! $event->activity->isOrganising($user)
+            ))) {
                 continue;
             }
 
             $participants = ($user?->is_member && $event->activity ? $event->activity->users->map(function ($item) {
-                return (object)[
+                return (object) [
                     'name' => $item->name,
                     'photo' => $item->photo_preview,
                 ];
             }) : null);
             $backupParticipants = ($user?->is_member && $event->activity ? $event->activity->backupUsers->map(function ($item) {
-                return (object)[
+                return (object) [
                     'name' => $item->name,
                     'photo' => $item->photo_preview,
                 ];
             }) : null);
-            $data[] = (object)[
+            $data[] = (object) [
                 'id' => $event->id,
                 'title' => $event->title,
                 'image' => ($event->image ? $event->image->generateImagePath(800, 300) : null),
@@ -461,7 +461,7 @@ class EventController extends Controller
                 'price' => ($event->activity ? $event->activity->price : null),
                 'no_show_fee' => ($event->activity ? $event->activity->no_show_fee : null),
                 'user_signedup' => ($user && $event->activity ? $event->activity->isParticipating($user) : null),
-                'user_signedup_backup' => (bool)($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->backup : null),
+                'user_signedup_backup' => (bool) ($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->backup : null),
                 'user_signedup_id' => ($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->id : null),
                 'can_signup' => ($user && $event->activity ? $event->activity->canSubscribe() : null),
                 'can_signup_backup' => ($user && $event->activity ? $event->activity->canSubscribeBackup() : null),
@@ -511,7 +511,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param string|null $personal_key
+     * @param  string|null  $personal_key
      * @return \Illuminate\Http\Response
      */
     public function icalCalendar($personal_key = null)
@@ -524,29 +524,29 @@ class EventController extends Controller
             $calendar_name = 'S.A. Proto Calendar';
         }
 
-        $calendar = 'BEGIN:VCALENDAR' . "\r\n" .
-            'VERSION:2.0' . "\r\n" .
-            'PRODID:-//HYTTIOAOAc//S.A. Proto Calendar//EN' . "\r\n" .
-            'CALSCALE:GREGORIAN' . "\r\n" .
-            'X-WR-CALNAME:' . $calendar_name . "\r\n" .
-            "X-WR-CALDESC:All of Proto's events, straight from the website!" . "\r\n" .
-            'BEGIN:VTIMEZONE' . "\r\n" .
-            'TZID:Central European Standard Time' . "\r\n" .
-            'BEGIN:STANDARD' . "\r\n" .
-            'DTSTART:20161002T030000' . "\r\n" .
-            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=3;BYMINUTE=0;BYMONTH=10' . "\r\n" .
-            'TZNAME:Central European Standard Time' . "\r\n" .
-            'TZOFFSETFROM:+0200' . "\r\n" .
-            'TZOFFSETTO:+0100' . "\r\n" .
-            'END:STANDARD' . "\r\n" .
-            'BEGIN:DAYLIGHT' . "\r\n" .
-            'DTSTART:20160301T020000' . "\r\n" .
-            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=2;BYMINUTE=0;BYMONTH=3' . "\r\n" .
-            'TZNAME:Central European Daylight Time' . "\r\n" .
-            'TZOFFSETFROM:+0100' . "\r\n" .
-            'TZOFFSETTO:+0200' . "\r\n" .
-            'END:DAYLIGHT' . "\r\n" .
-            'END:VTIMEZONE' . "\r\n";
+        $calendar = 'BEGIN:VCALENDAR'."\r\n".
+            'VERSION:2.0'."\r\n".
+            'PRODID:-//HYTTIOAOAc//S.A. Proto Calendar//EN'."\r\n".
+            'CALSCALE:GREGORIAN'."\r\n".
+            'X-WR-CALNAME:'.$calendar_name."\r\n".
+            "X-WR-CALDESC:All of Proto's events, straight from the website!"."\r\n".
+            'BEGIN:VTIMEZONE'."\r\n".
+            'TZID:Central European Standard Time'."\r\n".
+            'BEGIN:STANDARD'."\r\n".
+            'DTSTART:20161002T030000'."\r\n".
+            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=3;BYMINUTE=0;BYMONTH=10'."\r\n".
+            'TZNAME:Central European Standard Time'."\r\n".
+            'TZOFFSETFROM:+0200'."\r\n".
+            'TZOFFSETTO:+0100'."\r\n".
+            'END:STANDARD'."\r\n".
+            'BEGIN:DAYLIGHT'."\r\n".
+            'DTSTART:20160301T020000'."\r\n".
+            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=2;BYMINUTE=0;BYMONTH=3'."\r\n".
+            'TZNAME:Central European Daylight Time'."\r\n".
+            'TZOFFSETFROM:+0100'."\r\n".
+            'TZOFFSETTO:+0200'."\r\n".
+            'END:DAYLIGHT'."\r\n".
+            'END:VTIMEZONE'."\r\n";
 
         if ($user) {
             $reminder = $user->getCalendarAlarm();
@@ -557,11 +557,11 @@ class EventController extends Controller
         $relevant_only = $user ? $user->getCalendarRelevantSetting() : false;
 
         foreach (Event::where('start', '>', strtotime('-6 months'))->get() as $event) {
-            if (!$event->mayViewEvent(Auth::user())) {
+            if (! $event->mayViewEvent(Auth::user())) {
                 continue;
             }
 
-            if (!$event->force_calendar_sync && $relevant_only && !($event->isOrganising($user) || $event->hasBoughtTickets($user) || ($event->activity && ($event->activity->isHelping($user) || $event->activity->isParticipating($user))))) {
+            if (! $event->force_calendar_sync && $relevant_only && ! ($event->isOrganising($user) || $event->hasBoughtTickets($user) || ($event->activity && ($event->activity->isHelping($user) || $event->activity->isParticipating($user))))) {
                 continue;
             }
 
@@ -570,7 +570,7 @@ class EventController extends Controller
             } elseif ($event->activity !== null && $event->activity->participants == -1) {
                 $info_text = 'Sign-up required, but no participant limit.';
             } elseif ($event->activity !== null && $event->activity->participants > 0) {
-                $info_text = 'Sign-up required! There are roughly ' . $event->activity->freeSpots() . ' of ' . $event->activity->participants . ' places left.';
+                $info_text = 'Sign-up required! There are roughly '.$event->activity->freeSpots().' of '.$event->activity->participants.' places left.';
             } elseif ($event->tickets->count() > 0) {
                 $info_text = 'Ticket purchase required.';
             } else {
@@ -597,31 +597,31 @@ class EventController extends Controller
                 }
             }
 
-            $calendar .= 'BEGIN:VEVENT' . "\r\n" .
-                sprintf('UID:%s@proto.utwente.nl', $event->id) . "\r\n" .
-                sprintf('DTSTAMP:%s', gmdate('Ymd\THis\Z', strtotime($event->created_at))) . "\r\n" .
-                sprintf('DTSTART:%s', date('Ymd\THis', $event->start)) . "\r\n" .
-                sprintf('DTEND:%s', date('Ymd\THis', $event->end)) . "\r\n" .
-                sprintf('SUMMARY:%s', $status ? sprintf('[%s] %s', $status, $event->title) : $event->title) . "\r\n" .
-                sprintf('DESCRIPTION:%s', $info_text . ' More information: ' . route('event::show', ['id' => $event->getPublicId()])) . "\r\n" .
-                sprintf('LOCATION:%s', $event->location) . "\r\n" .
+            $calendar .= 'BEGIN:VEVENT'."\r\n".
+                sprintf('UID:%s@proto.utwente.nl', $event->id)."\r\n".
+                sprintf('DTSTAMP:%s', gmdate('Ymd\THis\Z', strtotime($event->created_at)))."\r\n".
+                sprintf('DTSTART:%s', date('Ymd\THis', $event->start))."\r\n".
+                sprintf('DTEND:%s', date('Ymd\THis', $event->end))."\r\n".
+                sprintf('SUMMARY:%s', $status ? sprintf('[%s] %s', $status, $event->title) : $event->title)."\r\n".
+                sprintf('DESCRIPTION:%s', $info_text.' More information: '.route('event::show', ['id' => $event->getPublicId()]))."\r\n".
+                sprintf('LOCATION:%s', $event->location)."\r\n".
                 sprintf(
                     'ORGANIZER;CN=%s:MAILTO:%s',
                     ($event->committee ? $event->committee->name : 'S.A. Proto'),
                     ($event->committee ? $event->committee->email_address : 'board@proto.utwente.nl')
-                ) . "\r\n" .
-                sprintf('LAST_UPDATED:%s', gmdate('Ymd\THis\Z', strtotime($event->updated_at))) . "\r\n" .
-                sprintf('SEQUENCE:%s', $event->update_sequence) . "\r\n";
+                )."\r\n".
+                sprintf('LAST_UPDATED:%s', gmdate('Ymd\THis\Z', strtotime($event->updated_at)))."\r\n".
+                sprintf('SEQUENCE:%s', $event->update_sequence)."\r\n";
 
             if ($reminder && $status) {
-                $calendar .= 'BEGIN:VALARM' . "\r\n" .
-                    sprintf('TRIGGER:-PT%dM', ceil($reminder * 60)) . "\r\n" .
-                    'ACTION:DISPLAY' . "\r\n" .
-                    sprintf('DESCRIPTION:%s at %s', sprintf('[%s] %s', $status, $event->title), date('l F j, H:i:s', $event->start)) . "\r\n" .
-                    'END:VALARM' . "\r\n";
+                $calendar .= 'BEGIN:VALARM'."\r\n".
+                    sprintf('TRIGGER:-PT%dM', ceil($reminder * 60))."\r\n".
+                    'ACTION:DISPLAY'."\r\n".
+                    sprintf('DESCRIPTION:%s at %s', sprintf('[%s] %s', $status, $event->title), date('l F j, H:i:s', $event->start))."\r\n".
+                    'END:VALARM'."\r\n";
             }
 
-            $calendar .= 'END:VEVENT' . "\r\n";
+            $calendar .= 'END:VEVENT'."\r\n";
         }
 
         $calendar .= 'END:VCALENDAR';
@@ -633,7 +633,7 @@ class EventController extends Controller
                 $replace = ['\;', '\,'];
                 $line = str_replace($search, $replace, $line);
             }
-            $calendar_wrapped .= wordwrap($line, 75, "\r\n ", true) . "\r\n";
+            $calendar_wrapped .= wordwrap($line, 75, "\r\n ", true)."\r\n";
         }
 
         return Response::make($calendar_wrapped)
@@ -661,13 +661,13 @@ class EventController extends Controller
         $category->icon = $request->input('icon');
         $category->save();
 
-        Session::flash('flash_message', 'The category ' . $category->name . ' has been created.');
+        Session::flash('flash_message', 'The category '.$category->name.' has been created.');
 
         return Redirect::back();
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function categoryUpdate(Request $request, $id)
@@ -677,13 +677,13 @@ class EventController extends Controller
         $category->icon = $request->input('icon');
         $category->save();
 
-        Session::flash('flash_message', 'The category ' . $category->name . ' has been updated.');
+        Session::flash('flash_message', 'The category '.$category->name.' has been updated.');
 
         return Redirect::back();
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -699,7 +699,7 @@ class EventController extends Controller
         }
         $category->delete();
 
-        Session::flash('flash_message', 'The category ' . $category->name . ' has been deleted.');
+        Session::flash('flash_message', 'The category '.$category->name.' has been deleted.');
 
         return Redirect::route('event::category::admin', ['category' => null]);
     }
@@ -708,7 +708,7 @@ class EventController extends Controller
     {
         $event = Event::findOrFail($request->id);
         $newEvent = $event->replicate();
-        $newEvent->title = $newEvent->title . ' [copy]';
+        $newEvent->title = $newEvent->title.' [copy]';
 
         $oldStart = Carbon::createFromTimestamp($event->start);
         $newDate = Carbon::createFromFormat('Y-m-d', $request->input('newDate'));

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -86,7 +86,10 @@ class EventController extends Controller
     /** @return View */
     public function show($id)
     {
-        $event = Event::fromPublicId($id);
+        $event = Event::getEventBlockQuery()->where('id', Event::getIdFromPublicId($id))
+            ->with('tickets', 'tickets.product')
+            ->firstOrFail();
+        
         $methods = [];
         if (config('omnomcom.mollie.use_fees')) {
             $methods = MollieController::getPaymentMethods();
@@ -135,13 +138,13 @@ class EventController extends Controller
         $event->category()->associate($category);
         $event->save();
 
-        Session::flash('flash_message', "Your event '".$event->title."' has been added.");
+        Session::flash('flash_message', "Your event '" . $event->title . "' has been added.");
 
         return Redirect::route('event::show', ['id' => $event->getPublicId()]);
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return View
      */
     public function edit($id)
@@ -152,7 +155,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      *
      * @throws FileNotFoundException
@@ -203,24 +206,24 @@ class EventController extends Controller
         $changed_important_details = $event->start != strtotime($request->start) || $event->end != strtotime($request->end) || $event->location != $request->location;
 
         if ($changed_important_details) {
-            Session::flash('flash_message', "Your event '".$event->title."' has been saved. <br><b class='text-warning'>You updated some important information. Don't forget to update your participants with this info!</b>");
+            Session::flash('flash_message', "Your event '" . $event->title . "' has been saved. <br><b class='text-warning'>You updated some important information. Don't forget to update your participants with this info!</b>");
         } else {
-            Session::flash('flash_message', "Your event '".$event->title."' has been saved.");
+            Session::flash('flash_message', "Your event '" . $event->title . "' has been saved.");
         }
 
         return Redirect::back();
     }
 
     /**
-     * @param  int  $year
+     * @param int $year
      * @return View
      */
     public function archive(Request $request, $year)
     {
         $years = collect(DB::select('SELECT DISTINCT Year(FROM_UNIXTIME(start)) AS start FROM events ORDER BY Year(FROM_UNIXTIME(start))'))->pluck('start');
         $events = Event::getEventBlockQuery()
-            ->where('start', '>', strtotime($year.'-01-01 00:00:01'))
-            ->where('start', '<', strtotime($year.'-12-31 23:59:59'))
+            ->where('start', '>', strtotime($year . '-01-01 00:00:01'))
+            ->where('start', '<', strtotime($year . '-12-31 23:59:59'))
             ->get();
 
         $category = EventCategory::find($request->category);
@@ -231,7 +234,7 @@ class EventController extends Controller
         }
 
         foreach ($events as $event) {
-            if (! $category || $category == $event->category) {
+            if (!$category || $category == $event->category) {
                 $months[intval(date('n', $event->start))][] = $event;
             }
         }
@@ -245,7 +248,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -256,12 +259,12 @@ class EventController extends Controller
         $event = Event::findOrFail($id);
 
         if ($event->activity !== null) {
-            Session::flash('flash_message', "You cannot delete event '".$event->title."' since it has a participation details.");
+            Session::flash('flash_message', "You cannot delete event '" . $event->title . "' since it has a participation details.");
 
             return Redirect::back();
         }
 
-        Session::flash('flash_message', "The event '".$event->title."' has been deleted.");
+        Session::flash('flash_message', "The event '" . $event->title . "' has been deleted.");
 
         $event->delete();
 
@@ -269,7 +272,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      */
     public function forceLogin($id)
@@ -278,14 +281,14 @@ class EventController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse|View
      */
     public function admin($id)
     {
         $event = Event::findOrFail($id);
 
-        if (! $event->isEventAdmin(Auth::user())) {
+        if (!$event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not an event admin for this event!');
 
             return Redirect::back();
@@ -295,14 +298,14 @@ class EventController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse|View
      */
     public function scan($id)
     {
         $event = Event::findOrFail($id);
 
-        if (! $event->isEventAdmin(Auth::user())) {
+        if (!$event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not an event admin for this event!');
 
             return Redirect::back();
@@ -312,7 +315,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      */
     public function finclose(Request $request, $id)
@@ -320,7 +323,7 @@ class EventController extends Controller
         /** @var Activity $activity */
         $activity = Activity::findOrFail($id);
 
-        if ($activity->event && ! $activity->event->over()) {
+        if ($activity->event && !$activity->event->over()) {
             Session::flash('flash_message', 'You cannot close an activity before it has finished.');
 
             return Redirect::back();
@@ -348,7 +351,7 @@ class EventController extends Controller
 
         $product = Product::create([
             'account_id' => $account->id,
-            'name' => 'Activity: '.($activity->event ? $activity->event->title : $activity->comment),
+            'name' => 'Activity: ' . ($activity->event ? $activity->event->title : $activity->comment),
             'price' => $activity->price,
         ]);
         $product->save();
@@ -367,7 +370,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param  Event  $event
+     * @param Event $event
      * @return RedirectResponse
      */
     public function linkAlbum(Request $request, $event)
@@ -380,13 +383,13 @@ class EventController extends Controller
         $album->event()->associate($event);
         $album->save();
 
-        Session::flash('flash_message', 'The album '.$album->name.' has been linked to this activity!');
+        Session::flash('flash_message', 'The album ' . $album->name . ' has been linked to this activity!');
 
         return Redirect::back();
     }
 
     /**
-     * @param  PhotoAlbum  $album
+     * @param PhotoAlbum $album
      * @return RedirectResponse
      */
     public function unlinkAlbum($album)
@@ -396,13 +399,13 @@ class EventController extends Controller
         $album->event()->dissociate();
         $album->save();
 
-        Session::flash('flash_message', 'The album '.$album->name.' has been unlinked from an activity!');
+        Session::flash('flash_message', 'The album ' . $album->name . ' has been unlinked from an activity!');
 
         return Redirect::back();
     }
 
     /**
-     * @param  int  $limit
+     * @param int $limit
      * @return array
      */
     public function apiUpcomingEvents($limit, Request $request)
@@ -415,26 +418,26 @@ class EventController extends Controller
 
         foreach ($events as $event) {
             if ($event->secret && ($user == null || $event->activity == null || (
-                ! $event->activity->isParticipating($user) &&
-                ! $event->activity->isHelping($user) &&
-                ! $event->activity->isOrganising($user)
-            ))) {
+                        !$event->activity->isParticipating($user) &&
+                        !$event->activity->isHelping($user) &&
+                        !$event->activity->isOrganising($user)
+                    ))) {
                 continue;
             }
 
             $participants = ($user?->is_member && $event->activity ? $event->activity->users->map(function ($item) {
-                return (object) [
+                return (object)[
                     'name' => $item->name,
                     'photo' => $item->photo_preview,
                 ];
             }) : null);
             $backupParticipants = ($user?->is_member && $event->activity ? $event->activity->backupUsers->map(function ($item) {
-                return (object) [
+                return (object)[
                     'name' => $item->name,
                     'photo' => $item->photo_preview,
                 ];
             }) : null);
-            $data[] = (object) [
+            $data[] = (object)[
                 'id' => $event->id,
                 'title' => $event->title,
                 'image' => ($event->image ? $event->image->generateImagePath(800, 300) : null),
@@ -458,7 +461,7 @@ class EventController extends Controller
                 'price' => ($event->activity ? $event->activity->price : null),
                 'no_show_fee' => ($event->activity ? $event->activity->no_show_fee : null),
                 'user_signedup' => ($user && $event->activity ? $event->activity->isParticipating($user) : null),
-                'user_signedup_backup' => (bool) ($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->backup : null),
+                'user_signedup_backup' => (bool)($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->backup : null),
                 'user_signedup_id' => ($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->id : null),
                 'can_signup' => ($user && $event->activity ? $event->activity->canSubscribe() : null),
                 'can_signup_backup' => ($user && $event->activity ? $event->activity->canSubscribeBackup() : null),
@@ -508,7 +511,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param  string|null  $personal_key
+     * @param string|null $personal_key
      * @return \Illuminate\Http\Response
      */
     public function icalCalendar($personal_key = null)
@@ -521,29 +524,29 @@ class EventController extends Controller
             $calendar_name = 'S.A. Proto Calendar';
         }
 
-        $calendar = 'BEGIN:VCALENDAR'."\r\n".
-            'VERSION:2.0'."\r\n".
-            'PRODID:-//HYTTIOAOAc//S.A. Proto Calendar//EN'."\r\n".
-            'CALSCALE:GREGORIAN'."\r\n".
-            'X-WR-CALNAME:'.$calendar_name."\r\n".
-            "X-WR-CALDESC:All of Proto's events, straight from the website!"."\r\n".
-            'BEGIN:VTIMEZONE'."\r\n".
-            'TZID:Central European Standard Time'."\r\n".
-            'BEGIN:STANDARD'."\r\n".
-            'DTSTART:20161002T030000'."\r\n".
-            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=3;BYMINUTE=0;BYMONTH=10'."\r\n".
-            'TZNAME:Central European Standard Time'."\r\n".
-            'TZOFFSETFROM:+0200'."\r\n".
-            'TZOFFSETTO:+0100'."\r\n".
-            'END:STANDARD'."\r\n".
-            'BEGIN:DAYLIGHT'."\r\n".
-            'DTSTART:20160301T020000'."\r\n".
-            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=2;BYMINUTE=0;BYMONTH=3'."\r\n".
-            'TZNAME:Central European Daylight Time'."\r\n".
-            'TZOFFSETFROM:+0100'."\r\n".
-            'TZOFFSETTO:+0200'."\r\n".
-            'END:DAYLIGHT'."\r\n".
-            'END:VTIMEZONE'."\r\n";
+        $calendar = 'BEGIN:VCALENDAR' . "\r\n" .
+            'VERSION:2.0' . "\r\n" .
+            'PRODID:-//HYTTIOAOAc//S.A. Proto Calendar//EN' . "\r\n" .
+            'CALSCALE:GREGORIAN' . "\r\n" .
+            'X-WR-CALNAME:' . $calendar_name . "\r\n" .
+            "X-WR-CALDESC:All of Proto's events, straight from the website!" . "\r\n" .
+            'BEGIN:VTIMEZONE' . "\r\n" .
+            'TZID:Central European Standard Time' . "\r\n" .
+            'BEGIN:STANDARD' . "\r\n" .
+            'DTSTART:20161002T030000' . "\r\n" .
+            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=3;BYMINUTE=0;BYMONTH=10' . "\r\n" .
+            'TZNAME:Central European Standard Time' . "\r\n" .
+            'TZOFFSETFROM:+0200' . "\r\n" .
+            'TZOFFSETTO:+0100' . "\r\n" .
+            'END:STANDARD' . "\r\n" .
+            'BEGIN:DAYLIGHT' . "\r\n" .
+            'DTSTART:20160301T020000' . "\r\n" .
+            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=2;BYMINUTE=0;BYMONTH=3' . "\r\n" .
+            'TZNAME:Central European Daylight Time' . "\r\n" .
+            'TZOFFSETFROM:+0100' . "\r\n" .
+            'TZOFFSETTO:+0200' . "\r\n" .
+            'END:DAYLIGHT' . "\r\n" .
+            'END:VTIMEZONE' . "\r\n";
 
         if ($user) {
             $reminder = $user->getCalendarAlarm();
@@ -554,11 +557,11 @@ class EventController extends Controller
         $relevant_only = $user ? $user->getCalendarRelevantSetting() : false;
 
         foreach (Event::where('start', '>', strtotime('-6 months'))->get() as $event) {
-            if (! $event->mayViewEvent(Auth::user())) {
+            if (!$event->mayViewEvent(Auth::user())) {
                 continue;
             }
 
-            if (! $event->force_calendar_sync && $relevant_only && ! ($event->isOrganising($user) || $event->hasBoughtTickets($user) || ($event->activity && ($event->activity->isHelping($user) || $event->activity->isParticipating($user))))) {
+            if (!$event->force_calendar_sync && $relevant_only && !($event->isOrganising($user) || $event->hasBoughtTickets($user) || ($event->activity && ($event->activity->isHelping($user) || $event->activity->isParticipating($user))))) {
                 continue;
             }
 
@@ -567,7 +570,7 @@ class EventController extends Controller
             } elseif ($event->activity !== null && $event->activity->participants == -1) {
                 $info_text = 'Sign-up required, but no participant limit.';
             } elseif ($event->activity !== null && $event->activity->participants > 0) {
-                $info_text = 'Sign-up required! There are roughly '.$event->activity->freeSpots().' of '.$event->activity->participants.' places left.';
+                $info_text = 'Sign-up required! There are roughly ' . $event->activity->freeSpots() . ' of ' . $event->activity->participants . ' places left.';
             } elseif ($event->tickets->count() > 0) {
                 $info_text = 'Ticket purchase required.';
             } else {
@@ -594,31 +597,31 @@ class EventController extends Controller
                 }
             }
 
-            $calendar .= 'BEGIN:VEVENT'."\r\n".
-                sprintf('UID:%s@proto.utwente.nl', $event->id)."\r\n".
-                sprintf('DTSTAMP:%s', gmdate('Ymd\THis\Z', strtotime($event->created_at)))."\r\n".
-                sprintf('DTSTART:%s', date('Ymd\THis', $event->start))."\r\n".
-                sprintf('DTEND:%s', date('Ymd\THis', $event->end))."\r\n".
-                sprintf('SUMMARY:%s', $status ? sprintf('[%s] %s', $status, $event->title) : $event->title)."\r\n".
-                sprintf('DESCRIPTION:%s', $info_text.' More information: '.route('event::show', ['id' => $event->getPublicId()]))."\r\n".
-                sprintf('LOCATION:%s', $event->location)."\r\n".
+            $calendar .= 'BEGIN:VEVENT' . "\r\n" .
+                sprintf('UID:%s@proto.utwente.nl', $event->id) . "\r\n" .
+                sprintf('DTSTAMP:%s', gmdate('Ymd\THis\Z', strtotime($event->created_at))) . "\r\n" .
+                sprintf('DTSTART:%s', date('Ymd\THis', $event->start)) . "\r\n" .
+                sprintf('DTEND:%s', date('Ymd\THis', $event->end)) . "\r\n" .
+                sprintf('SUMMARY:%s', $status ? sprintf('[%s] %s', $status, $event->title) : $event->title) . "\r\n" .
+                sprintf('DESCRIPTION:%s', $info_text . ' More information: ' . route('event::show', ['id' => $event->getPublicId()])) . "\r\n" .
+                sprintf('LOCATION:%s', $event->location) . "\r\n" .
                 sprintf(
                     'ORGANIZER;CN=%s:MAILTO:%s',
                     ($event->committee ? $event->committee->name : 'S.A. Proto'),
                     ($event->committee ? $event->committee->email_address : 'board@proto.utwente.nl')
-                )."\r\n".
-                sprintf('LAST_UPDATED:%s', gmdate('Ymd\THis\Z', strtotime($event->updated_at)))."\r\n".
-                sprintf('SEQUENCE:%s', $event->update_sequence)."\r\n";
+                ) . "\r\n" .
+                sprintf('LAST_UPDATED:%s', gmdate('Ymd\THis\Z', strtotime($event->updated_at))) . "\r\n" .
+                sprintf('SEQUENCE:%s', $event->update_sequence) . "\r\n";
 
             if ($reminder && $status) {
-                $calendar .= 'BEGIN:VALARM'."\r\n".
-                    sprintf('TRIGGER:-PT%dM', ceil($reminder * 60))."\r\n".
-                    'ACTION:DISPLAY'."\r\n".
-                    sprintf('DESCRIPTION:%s at %s', sprintf('[%s] %s', $status, $event->title), date('l F j, H:i:s', $event->start))."\r\n".
-                    'END:VALARM'."\r\n";
+                $calendar .= 'BEGIN:VALARM' . "\r\n" .
+                    sprintf('TRIGGER:-PT%dM', ceil($reminder * 60)) . "\r\n" .
+                    'ACTION:DISPLAY' . "\r\n" .
+                    sprintf('DESCRIPTION:%s at %s', sprintf('[%s] %s', $status, $event->title), date('l F j, H:i:s', $event->start)) . "\r\n" .
+                    'END:VALARM' . "\r\n";
             }
 
-            $calendar .= 'END:VEVENT'."\r\n";
+            $calendar .= 'END:VEVENT' . "\r\n";
         }
 
         $calendar .= 'END:VCALENDAR';
@@ -630,7 +633,7 @@ class EventController extends Controller
                 $replace = ['\;', '\,'];
                 $line = str_replace($search, $replace, $line);
             }
-            $calendar_wrapped .= wordwrap($line, 75, "\r\n ", true)."\r\n";
+            $calendar_wrapped .= wordwrap($line, 75, "\r\n ", true) . "\r\n";
         }
 
         return Response::make($calendar_wrapped)
@@ -658,13 +661,13 @@ class EventController extends Controller
         $category->icon = $request->input('icon');
         $category->save();
 
-        Session::flash('flash_message', 'The category '.$category->name.' has been created.');
+        Session::flash('flash_message', 'The category ' . $category->name . ' has been created.');
 
         return Redirect::back();
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      */
     public function categoryUpdate(Request $request, $id)
@@ -674,13 +677,13 @@ class EventController extends Controller
         $category->icon = $request->input('icon');
         $category->save();
 
-        Session::flash('flash_message', 'The category '.$category->name.' has been updated.');
+        Session::flash('flash_message', 'The category ' . $category->name . ' has been updated.');
 
         return Redirect::back();
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -696,7 +699,7 @@ class EventController extends Controller
         }
         $category->delete();
 
-        Session::flash('flash_message', 'The category '.$category->name.' has been deleted.');
+        Session::flash('flash_message', 'The category ' . $category->name . ' has been deleted.');
 
         return Redirect::route('event::category::admin', ['category' => null]);
     }
@@ -705,7 +708,7 @@ class EventController extends Controller
     {
         $event = Event::findOrFail($request->id);
         $newEvent = $event->replicate();
-        $newEvent->title = $newEvent->title.' [copy]';
+        $newEvent->title = $newEvent->title . ' [copy]';
 
         $oldStart = Carbon::createFromTimestamp($event->start);
         $newDate = Carbon::createFromFormat('Y-m-d', $request->input('newDate'));

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -29,7 +29,7 @@ class HomeController extends Controller
 
         $header = HeaderImage::inRandomOrder()->first();
 
-        if (!Auth::user()?->is_member) {
+        if (! Auth::user()?->is_member) {
             return view('website.home.external', ['companies' => $companies, 'header' => $header]);
         }
         $weekly = Newsitem::query()

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -23,12 +23,13 @@ class HomeController extends Controller
     {
         $companies = Company::query()
             ->where('in_logo_bar', true)
+            ->with('image')
             ->inRandomOrder()
             ->get();
 
         $header = HeaderImage::inRandomOrder()->first();
 
-        if (! Auth::user()?->is_member) {
+        if (!Auth::user()?->is_member) {
             return view('website.home.external', ['companies' => $companies, 'header' => $header]);
         }
         $weekly = Newsitem::query()
@@ -78,8 +79,19 @@ class HomeController extends Controller
             ->limit(6)
             ->get();
 
+        $featuredEvents = Event::getEventBlockQuery()
+            ->where([
+                ['is_featured', true],
+                ['end', '>=', date('U')],
+                ['secret', false],
+            ])
+            ->orderBy('start')
+            ->limit(6)
+            ->get();
+
         return view('website.home.members', [
             'upcomingEvents' => $upcomingEvents,
+            'featuredEvents' => $featuredEvents,
             'companies' => $companies,
             'message' => $message,
             'newsitems' => $newsitems,

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -29,7 +29,7 @@ class HomeController extends Controller
 
         $header = HeaderImage::inRandomOrder()->first();
 
-        if (! Auth::user()?->is_member) {
+        if (!Auth::user()?->is_member) {
             return view('website.home.external', ['companies' => $companies, 'header' => $header]);
         }
         $weekly = Newsitem::query()
@@ -74,6 +74,7 @@ class HomeController extends Controller
             ->where([
                 ['is_featured', false],
                 ['end', '>=', date('U')],
+                ['publication', '<', date('U')],
                 ['secret', false],
             ])
             ->limit(6)
@@ -83,6 +84,7 @@ class HomeController extends Controller
             ->where([
                 ['is_featured', true],
                 ['end', '>=', date('U')],
+                ['publication', '<', date('U')],
                 ['secret', false],
             ])
             ->orderBy('start')

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -21,7 +21,7 @@ class TicketController extends Controller
     /** @return View */
     public function index()
     {
-        return view('tickets.index', ['tickets' => Ticket::orderBy('id', 'desc')->paginate(20)]);
+        return view('tickets.index', ['tickets' => Ticket::orderBy('id', 'desc')->with('event', 'product', 'purchases')->paginate(20)]);
     }
 
     /** @return View */
@@ -35,7 +35,7 @@ class TicketController extends Controller
      */
     public function store(Request $request)
     {
-        if (! $request->has('is_members_only') && ! $request->has('is_prepaid') && ! Auth::user()->can('sysadmin')) {
+        if (!$request->has('is_members_only') && !$request->has('is_prepaid') && !Auth::user()->can('sysadmin')) {
             Session::flash('flash_message', 'Making tickets for external people payable via withdrawal is risky and usually not necessary. If you REALLY want this, please contact the Have You Tried Turning It Off And On Again committee.');
 
             return Redirect::back();
@@ -59,7 +59,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return View
      */
     public function edit($id)
@@ -70,12 +70,12 @@ class TicketController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      */
     public function update(Request $request, $id)
     {
-        if (! $request->has('is_members_only') && ! $request->has('is_prepaid') && ! Auth::user()->can('sysadmin')) {
+        if (!$request->has('is_members_only') && !$request->has('is_prepaid') && !Auth::user()->can('sysadmin')) {
             Session::flash('flash_message', 'Making tickets for external people payable via withdrawal is risky and usually not necessary. If you REALLY want this, please contact the Have You Tried Turninig It Off And On Again committee.');
 
             return Redirect::back();
@@ -106,7 +106,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -128,13 +128,13 @@ class TicketController extends Controller
     }
 
     /**
-     * @param  string  $barcode
+     * @param string $barcode
      * @return RedirectResponse
      */
     public function scan($barcode)
     {
         $ticket = TicketPurchase::where('barcode', $barcode)->first();
-        if ($ticket && ! $ticket->ticket->event->isEventAdmin(Auth::user())) {
+        if ($ticket && !$ticket->ticket->event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not allowed to scan for this event.');
 
             return Redirect::back();
@@ -151,12 +151,12 @@ class TicketController extends Controller
     }
 
     /**
-     * @param  int  $event
+     * @param int $event
      * @return array
      */
     public function scanApi($event, Request $request)
     {
-        if (! $request->has('barcode')) {
+        if (!$request->has('barcode')) {
             return [
                 'code' => 500,
                 'message' => 'Missing barcode',
@@ -178,7 +178,7 @@ class TicketController extends Controller
         /** @var TicketPurchase|null $ticket */
         $ticket = TicketPurchase::where('barcode', $request->barcode)->first();
 
-        if ($ticket != null && ! $ticket->ticket->event->isEventAdmin(Auth::user())) {
+        if ($ticket != null && !$ticket->ticket->event->isEventAdmin(Auth::user())) {
             return [
                 'code' => 500,
                 'message' => 'Unauthorized to scan',
@@ -195,7 +195,7 @@ class TicketController extends Controller
                     'data' => null,
                 ];
             }
-            if (! $unscan && $ticket->scanned !== null) {
+            if (!$unscan && $ticket->scanned !== null) {
                 return [
                     'code' => 403,
                     'message' => 'Ticket already used',
@@ -237,7 +237,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param  string  $barcode
+     * @param string $barcode
      * @return RedirectResponse
      */
     public function unscan($barcode = null)
@@ -249,7 +249,7 @@ class TicketController extends Controller
         }
 
         $ticket = TicketPurchase::where('barcode', $barcode)->first();
-        if ($ticket && ! $ticket->ticket->event->isEventAdmin(Auth::user())) {
+        if ($ticket && !$ticket->ticket->event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not allowed to scan for this event.');
 
             return Redirect::back();
@@ -267,7 +267,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return string
      */
     public function download($id)
@@ -276,7 +276,7 @@ class TicketController extends Controller
         $ticket = TicketPurchase::findOrFail($id);
         if ($ticket->user->id != Auth::id()) {
             abort(403, 'This is not your ticket!');
-        } elseif (! $ticket->canBeDownloaded()) {
+        } elseif (!$ticket->canBeDownloaded()) {
             Session::flash('flash_message', 'You need to pay for this ticket before you can download it.');
 
             return Redirect::back();
@@ -289,7 +289,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      */
     public function buyForEvent(Request $request, $id)
@@ -303,7 +303,7 @@ class TicketController extends Controller
             return Redirect::back();
         }
 
-        if (! $request->has('tickets')) {
+        if (!$request->has('tickets')) {
             Session::flash('flash_message', 'There are no tickets available for this event.');
 
             return Redirect::back();
@@ -312,35 +312,35 @@ class TicketController extends Controller
         foreach ($request->get('tickets') as $ticket_id => $amount) {
             $ticket = Ticket::find($ticket_id);
             $user_owns = TicketPurchase::where('user_id', Auth::id())->where('ticket_id', $ticket_id)->count();
-            if (! $ticket) {
+            if (!$ticket) {
                 Session::flash('flash_message', "Ticket ID#$ticket_id is not an existing ticket. Entire order cancelled.");
 
                 return Redirect::back();
             }
-            if ($ticket->members_only && ! Auth::user()->is_member) {
+            if ($ticket->members_only && !Auth::user()->is_member) {
                 Session::flash('flash_message', "Ticket ID#$ticket_id is only available to members. You are not a member. Entire order cancelled.");
 
                 return Redirect::back();
             }
             if ($ticket->event->id != $event->id) {
-                Session::flash('flash_message', "Ticket ID#$ticket_id is not a ticket for event '".$event->title."'. Entire order cancelled.");
+                Session::flash('flash_message', "Ticket ID#$ticket_id is not a ticket for event '" . $event->title . "'. Entire order cancelled.");
 
                 return Redirect::back();
             }
 
             if ($ticket->has_buy_limit && ($amount + $user_owns) > $ticket->buy_limit) {
-                Session::flash('flash_message', 'You tried to buy '.$amount." of ticket '".$ticket->product->name."'. The total limit per user for this ticket is ".$ticket->buy_limit.' and you have already bought '.$user_owns.'. Entire order cancelled.');
+                Session::flash('flash_message', 'You tried to buy ' . $amount . " of ticket '" . $ticket->product->name . "'. The total limit per user for this ticket is " . $ticket->buy_limit . ' and you have already bought ' . $user_owns . '. Entire order cancelled.');
 
                 return Redirect::back();
             }
 
             if ($amount > config('proto.maxtickets')) {
-                Session::flash('flash_message', 'You tried to buy more then '.config('proto.maxtickets')." of ticket '".$ticket->product->name."', you can only buy ".config('proto.maxtickets').' at a time. Entire order cancelled.');
+                Session::flash('flash_message', 'You tried to buy more then ' . config('proto.maxtickets') . " of ticket '" . $ticket->product->name . "', you can only buy " . config('proto.maxtickets') . ' at a time. Entire order cancelled.');
 
                 return Redirect::back();
             }
             if ($amount > $ticket->product->stock) {
-                Session::flash('flash_message', "You tried to buy $amount of ticket '".$ticket->product->name."', but only ".$ticket->product->stock.' are available. Entire order cancelled.');
+                Session::flash('flash_message', "You tried to buy $amount of ticket '" . $ticket->product->name . "', but only " . $ticket->product->stock . ' are available. Entire order cancelled.');
 
                 return Redirect::back();
             }
@@ -358,7 +358,7 @@ class TicketController extends Controller
                 $oid = $ticket->product->buyForUser(Auth::user(), 1, $ticket->product->price, null, null, null, sprintf('ticket_bought_by_%u', Auth::user()->id));
 
                 //Non-members can only buy prepaid tickets, as we have no way of resolving their payment otherwise.
-                if ($ticket->is_prepaid || ! Auth::user()->is_member) {
+                if ($ticket->is_prepaid || !Auth::user()->is_member) {
                     $prepaid_tickets[] = $oid;
                     $total_cost += $ticket->product->price;
                 }
@@ -367,7 +367,7 @@ class TicketController extends Controller
                     'ticket_id' => $ticket_id,
                     'orderline_id' => $oid,
                     'user_id' => Auth::id(),
-                    'barcode' => $oid.mt_rand(1000000000, 9999999999),
+                    'barcode' => $oid . mt_rand(1000000000, 9999999999),
                 ]);
                 $purchase->save();
 
@@ -376,7 +376,7 @@ class TicketController extends Controller
         }
 
         $payment_method = '';
-        if (config('omnomcom.mollie.use_fees') && ! $request->has('method') && count($prepaid_tickets) > 0) {
+        if (config('omnomcom.mollie.use_fees') && !$request->has('method') && count($prepaid_tickets) > 0) {
             Session::flash('flash_message', 'No payment method is selected!');
 
             return Redirect::back();
@@ -407,7 +407,7 @@ class TicketController extends Controller
             }
         }
 
-        if (! $sold) {
+        if (!$sold) {
             Session::flash('flash_message', "You didn't select any tickets to buy. Maybe buy some tickets?");
 
             return Redirect::back();

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -35,7 +35,7 @@ class TicketController extends Controller
      */
     public function store(Request $request)
     {
-        if (!$request->has('is_members_only') && !$request->has('is_prepaid') && !Auth::user()->can('sysadmin')) {
+        if (! $request->has('is_members_only') && ! $request->has('is_prepaid') && ! Auth::user()->can('sysadmin')) {
             Session::flash('flash_message', 'Making tickets for external people payable via withdrawal is risky and usually not necessary. If you REALLY want this, please contact the Have You Tried Turning It Off And On Again committee.');
 
             return Redirect::back();
@@ -59,7 +59,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return View
      */
     public function edit($id)
@@ -70,12 +70,12 @@ class TicketController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function update(Request $request, $id)
     {
-        if (!$request->has('is_members_only') && !$request->has('is_prepaid') && !Auth::user()->can('sysadmin')) {
+        if (! $request->has('is_members_only') && ! $request->has('is_prepaid') && ! Auth::user()->can('sysadmin')) {
             Session::flash('flash_message', 'Making tickets for external people payable via withdrawal is risky and usually not necessary. If you REALLY want this, please contact the Have You Tried Turninig It Off And On Again committee.');
 
             return Redirect::back();
@@ -106,7 +106,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -128,13 +128,13 @@ class TicketController extends Controller
     }
 
     /**
-     * @param string $barcode
+     * @param  string  $barcode
      * @return RedirectResponse
      */
     public function scan($barcode)
     {
         $ticket = TicketPurchase::where('barcode', $barcode)->first();
-        if ($ticket && !$ticket->ticket->event->isEventAdmin(Auth::user())) {
+        if ($ticket && ! $ticket->ticket->event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not allowed to scan for this event.');
 
             return Redirect::back();
@@ -151,12 +151,12 @@ class TicketController extends Controller
     }
 
     /**
-     * @param int $event
+     * @param  int  $event
      * @return array
      */
     public function scanApi($event, Request $request)
     {
-        if (!$request->has('barcode')) {
+        if (! $request->has('barcode')) {
             return [
                 'code' => 500,
                 'message' => 'Missing barcode',
@@ -178,7 +178,7 @@ class TicketController extends Controller
         /** @var TicketPurchase|null $ticket */
         $ticket = TicketPurchase::where('barcode', $request->barcode)->first();
 
-        if ($ticket != null && !$ticket->ticket->event->isEventAdmin(Auth::user())) {
+        if ($ticket != null && ! $ticket->ticket->event->isEventAdmin(Auth::user())) {
             return [
                 'code' => 500,
                 'message' => 'Unauthorized to scan',
@@ -195,7 +195,7 @@ class TicketController extends Controller
                     'data' => null,
                 ];
             }
-            if (!$unscan && $ticket->scanned !== null) {
+            if (! $unscan && $ticket->scanned !== null) {
                 return [
                     'code' => 403,
                     'message' => 'Ticket already used',
@@ -237,7 +237,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param string $barcode
+     * @param  string  $barcode
      * @return RedirectResponse
      */
     public function unscan($barcode = null)
@@ -249,7 +249,7 @@ class TicketController extends Controller
         }
 
         $ticket = TicketPurchase::where('barcode', $barcode)->first();
-        if ($ticket && !$ticket->ticket->event->isEventAdmin(Auth::user())) {
+        if ($ticket && ! $ticket->ticket->event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not allowed to scan for this event.');
 
             return Redirect::back();
@@ -267,7 +267,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return string
      */
     public function download($id)
@@ -276,7 +276,7 @@ class TicketController extends Controller
         $ticket = TicketPurchase::findOrFail($id);
         if ($ticket->user->id != Auth::id()) {
             abort(403, 'This is not your ticket!');
-        } elseif (!$ticket->canBeDownloaded()) {
+        } elseif (! $ticket->canBeDownloaded()) {
             Session::flash('flash_message', 'You need to pay for this ticket before you can download it.');
 
             return Redirect::back();
@@ -289,7 +289,7 @@ class TicketController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function buyForEvent(Request $request, $id)
@@ -303,7 +303,7 @@ class TicketController extends Controller
             return Redirect::back();
         }
 
-        if (!$request->has('tickets')) {
+        if (! $request->has('tickets')) {
             Session::flash('flash_message', 'There are no tickets available for this event.');
 
             return Redirect::back();
@@ -312,35 +312,35 @@ class TicketController extends Controller
         foreach ($request->get('tickets') as $ticket_id => $amount) {
             $ticket = Ticket::find($ticket_id);
             $user_owns = TicketPurchase::where('user_id', Auth::id())->where('ticket_id', $ticket_id)->count();
-            if (!$ticket) {
+            if (! $ticket) {
                 Session::flash('flash_message', "Ticket ID#$ticket_id is not an existing ticket. Entire order cancelled.");
 
                 return Redirect::back();
             }
-            if ($ticket->members_only && !Auth::user()->is_member) {
+            if ($ticket->members_only && ! Auth::user()->is_member) {
                 Session::flash('flash_message', "Ticket ID#$ticket_id is only available to members. You are not a member. Entire order cancelled.");
 
                 return Redirect::back();
             }
             if ($ticket->event->id != $event->id) {
-                Session::flash('flash_message', "Ticket ID#$ticket_id is not a ticket for event '" . $event->title . "'. Entire order cancelled.");
+                Session::flash('flash_message', "Ticket ID#$ticket_id is not a ticket for event '".$event->title."'. Entire order cancelled.");
 
                 return Redirect::back();
             }
 
             if ($ticket->has_buy_limit && ($amount + $user_owns) > $ticket->buy_limit) {
-                Session::flash('flash_message', 'You tried to buy ' . $amount . " of ticket '" . $ticket->product->name . "'. The total limit per user for this ticket is " . $ticket->buy_limit . ' and you have already bought ' . $user_owns . '. Entire order cancelled.');
+                Session::flash('flash_message', 'You tried to buy '.$amount." of ticket '".$ticket->product->name."'. The total limit per user for this ticket is ".$ticket->buy_limit.' and you have already bought '.$user_owns.'. Entire order cancelled.');
 
                 return Redirect::back();
             }
 
             if ($amount > config('proto.maxtickets')) {
-                Session::flash('flash_message', 'You tried to buy more then ' . config('proto.maxtickets') . " of ticket '" . $ticket->product->name . "', you can only buy " . config('proto.maxtickets') . ' at a time. Entire order cancelled.');
+                Session::flash('flash_message', 'You tried to buy more then '.config('proto.maxtickets')." of ticket '".$ticket->product->name."', you can only buy ".config('proto.maxtickets').' at a time. Entire order cancelled.');
 
                 return Redirect::back();
             }
             if ($amount > $ticket->product->stock) {
-                Session::flash('flash_message', "You tried to buy $amount of ticket '" . $ticket->product->name . "', but only " . $ticket->product->stock . ' are available. Entire order cancelled.');
+                Session::flash('flash_message', "You tried to buy $amount of ticket '".$ticket->product->name."', but only ".$ticket->product->stock.' are available. Entire order cancelled.');
 
                 return Redirect::back();
             }
@@ -358,7 +358,7 @@ class TicketController extends Controller
                 $oid = $ticket->product->buyForUser(Auth::user(), 1, $ticket->product->price, null, null, null, sprintf('ticket_bought_by_%u', Auth::user()->id));
 
                 //Non-members can only buy prepaid tickets, as we have no way of resolving their payment otherwise.
-                if ($ticket->is_prepaid || !Auth::user()->is_member) {
+                if ($ticket->is_prepaid || ! Auth::user()->is_member) {
                     $prepaid_tickets[] = $oid;
                     $total_cost += $ticket->product->price;
                 }
@@ -367,7 +367,7 @@ class TicketController extends Controller
                     'ticket_id' => $ticket_id,
                     'orderline_id' => $oid,
                     'user_id' => Auth::id(),
-                    'barcode' => $oid . mt_rand(1000000000, 9999999999),
+                    'barcode' => $oid.mt_rand(1000000000, 9999999999),
                 ]);
                 $purchase->save();
 
@@ -376,7 +376,7 @@ class TicketController extends Controller
         }
 
         $payment_method = '';
-        if (config('omnomcom.mollie.use_fees') && !$request->has('method') && count($prepaid_tickets) > 0) {
+        if (config('omnomcom.mollie.use_fees') && ! $request->has('method') && count($prepaid_tickets) > 0) {
             Session::flash('flash_message', 'No payment method is selected!');
 
             return Redirect::back();
@@ -407,7 +407,7 @@ class TicketController extends Controller
             }
         }
 
-        if (!$sold) {
+        if (! $sold) {
             Session::flash('flash_message', "You didn't select any tickets to buy. Maybe buy some tickets?");
 
             return Redirect::back();

--- a/app/Http/Controllers/UserAdminController.php
+++ b/app/Http/Controllers/UserAdminController.php
@@ -66,7 +66,7 @@ class UserAdminController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return View
      */
     public function details($id)
@@ -78,7 +78,7 @@ class UserAdminController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function update(Request $request, $id)
@@ -100,7 +100,7 @@ class UserAdminController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function impersonate($id)
@@ -108,11 +108,11 @@ class UserAdminController extends Controller
         /** @var User $user */
         $user = User::findOrFail($id);
 
-        if (!Auth::user()->can('sysadmin')) {
+        if (! Auth::user()->can('sysadmin')) {
             foreach ($user->roles as $role) {
                 /** @var Permission $permission */
                 foreach ($role->permissions as $permission) {
-                    if (!Auth::user()->can($permission->name)) {
+                    if (! Auth::user()->can($permission->name)) {
                         abort(403, 'You may not impersonate this person.');
                     }
                 }
@@ -143,7 +143,7 @@ class UserAdminController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function addMembership($id, Request $request)
@@ -157,7 +157,7 @@ class UserAdminController extends Controller
             return Redirect::back();
         }
 
-        if (!($user->address && $user->bank)) {
+        if (! ($user->address && $user->bank)) {
             Session::flash('flash_message', "This user really needs a bank account and address. Don't bypass the system!");
 
             return Redirect::back();
@@ -187,7 +187,7 @@ class UserAdminController extends Controller
         // Disabled because ProTube is down.
         // Removed; Here should the playsound new-member be played
 
-        Session::flash('flash_message', 'Congratulations! ' . $user->name . ' is now our newest member!');
+        Session::flash('flash_message', 'Congratulations! '.$user->name.' is now our newest member!');
 
         return Redirect::back();
     }
@@ -196,7 +196,7 @@ class UserAdminController extends Controller
      * Adds membership end date to member object.
      * Member object will be removed by cron job on end date.
      *
-     * @param int $id
+     * @param  int  $id
      *
      * @throws Exception
      */
@@ -209,7 +209,7 @@ class UserAdminController extends Controller
 
         Mail::to($user)->queue((new MembershipEnded($user))->onQueue('high'));
 
-        Session::flash('flash_message', 'Membership of ' . $user->name . ' has been terminated.');
+        Session::flash('flash_message', 'Membership of '.$user->name.' has been terminated.');
 
         return Redirect::back();
     }
@@ -217,7 +217,7 @@ class UserAdminController extends Controller
     public function EndMembershipInSeptember($id): RedirectResponse
     {
         $user = User::findOrFail($id);
-        if (!$user->is_member) {
+        if (! $user->is_member) {
             Session::flash('flash_message', 'The user needs to be a member for its membership to receive an end date!');
 
             return Redirect::back();
@@ -234,7 +234,7 @@ class UserAdminController extends Controller
     public function removeMembershipEnd($id): RedirectResponse
     {
         $user = User::findOrFail($id);
-        if (!$user->is_member) {
+        if (! $user->is_member) {
             Session::flash('flash_message', 'The user needs to be a member for its membership to receive an end date!');
 
             return Redirect::back();
@@ -247,11 +247,11 @@ class UserAdminController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      */
     public function setMembershipType(Request $request, $id): RedirectResponse
     {
-        if (!Auth::user()->can('board')) {
+        if (! Auth::user()->can('board')) {
             abort(403, 'Only board members can do this.');
         }
 
@@ -265,32 +265,32 @@ class UserAdminController extends Controller
         $member->is_pet = $type == 'pet';
         $member->save();
 
-        Session::flash('flash_message', $user->name . ' is now a ' . $type . ' member.');
+        Session::flash('flash_message', $user->name.' is now a '.$type.' member.');
 
         return Redirect::back();
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      */
     public function toggleNda($id): RedirectResponse
     {
-        if (!Auth::user()->can('board')) {
+        if (! Auth::user()->can('board')) {
             abort(403, 'Only board members can do this.');
         }
 
         /** @var User $user */
         $user = User::findOrFail($id);
-        $user->signed_nda = !$user->signed_nda;
+        $user->signed_nda = ! $user->signed_nda;
         $user->save();
 
-        Session::flash('flash_message', 'Toggled NDA status of ' . $user->name . '. Please verify if it is correct.');
+        Session::flash('flash_message', 'Toggled NDA status of '.$user->name.'. Please verify if it is correct.');
 
         return Redirect::back();
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      */
     public function unblockOmnomcom($id): RedirectResponse
     {
@@ -299,37 +299,37 @@ class UserAdminController extends Controller
         $user->disable_omnomcom = false;
         $user->save();
 
-        Session::flash('flash_message', 'OmNomCom unblocked for ' . $user->name . '.');
+        Session::flash('flash_message', 'OmNomCom unblocked for '.$user->name.'.');
 
         return Redirect::back();
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      */
     public function toggleStudiedCreate($id): RedirectResponse
     {
         /** @var User $user */
         $user = User::findOrFail($id);
-        $user->did_study_create = !$user->did_study_create;
+        $user->did_study_create = ! $user->did_study_create;
         $user->save();
 
-        Session::flash('flash_message', 'Toggled CreaTe status of ' . $user->name . '.');
+        Session::flash('flash_message', 'Toggled CreaTe status of '.$user->name.'.');
 
         return Redirect::back();
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      */
     public function toggleStudiedITech($id): RedirectResponse
     {
         /** @var User $user */
         $user = User::findOrFail($id);
-        $user->did_study_itech = !$user->did_study_itech;
+        $user->did_study_itech = ! $user->did_study_itech;
         $user->save();
 
-        Session::flash('flash_message', 'Toggled ITech status of ' . $user->name . '.');
+        Session::flash('flash_message', 'Toggled ITech status of '.$user->name.'.');
 
         return Redirect::back();
     }
@@ -371,7 +371,7 @@ class UserAdminController extends Controller
         $user = Auth::user();
         $member = Member::withTrashed()->where('membership_form_id', '=', $id)->first();
 
-        if ($user->id != $member->user_id && !$user->can('registermembers')) {
+        if ($user->id != $member->user_id && ! $user->can('registermembers')) {
             abort(403);
         }
 
@@ -381,7 +381,7 @@ class UserAdminController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return string
      */
     public function getNewMemberForm($id)
@@ -409,12 +409,12 @@ class UserAdminController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function destroyMemberForm($id)
     {
-        if ((!Auth::check() || !Auth::user()->can('board'))) {
+        if ((! Auth::check() || ! Auth::user()->can('board'))) {
             abort(403);
         }
 
@@ -423,20 +423,20 @@ class UserAdminController extends Controller
 
         $member->forceDelete();
 
-        Session::flash('flash_message', 'The digital membership form of ' . $user->name . ' signed on ' . $member->created_at . 'has been deleted!');
+        Session::flash('flash_message', 'The digital membership form of '.$user->name.' signed on '.$member->created_at.'has been deleted!');
 
         return Redirect::back();
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return string
      */
     public function printMemberForm($id)
     {
         $user = User::find($id);
 
-        if (!$user) {
+        if (! $user) {
             return 'This user could not be found!';
         }
 

--- a/app/Models/Committee.php
+++ b/app/Models/Committee.php
@@ -100,11 +100,11 @@ class Committee extends Model
     /** @return string */
     public function getEmailAddressAttribute()
     {
-        return $this->slug . '@' . config('proto.emaildomain');
+        return $this->slug.'@'.config('proto.emaildomain');
     }
 
     /**
-     * @param int $n the number of events to return
+     * @param  int  $n  the number of events to return
      * @return Event[]|Collection|_IH_Event_C
      */
     public function pastEvents(int $n)
@@ -131,7 +131,7 @@ class Committee extends Model
     }
 
     /**
-     * @param bool $includeSecret
+     * @param  bool  $includeSecret
      * @return Event[]
      */
     public function helpedEvents($includeSecret = false)
@@ -142,7 +142,7 @@ class Committee extends Model
         $events = [];
         foreach ($activities as $activity) {
             $event = $activity->event;
-            if ($event?->isPublished() || (!$event->secret || $includeSecret)) {
+            if ($event?->isPublished() || (! $event->secret || $includeSecret)) {
                 $events[] = $event;
             }
         }
@@ -184,7 +184,7 @@ class Committee extends Model
             } else {
                 if (
                     strtotime($membership->created_at) < date('U') &&
-                    (!$membership->deleted_at || strtotime($membership->deleted_at) > date('U'))
+                    (! $membership->deleted_at || strtotime($membership->deleted_at) > date('U'))
                 ) {
                     $members['members']['current'][] = $membership;
                 } elseif (strtotime($membership->created_at) > date('U')) {
@@ -199,7 +199,7 @@ class Committee extends Model
     }
 
     /**
-     * @param User $user
+     * @param  User  $user
      * @return bool Whether the use is a member of the committee.
      */
     public function isMember($user)

--- a/app/Models/Committee.php
+++ b/app/Models/Committee.php
@@ -56,6 +56,8 @@ class Committee extends Model
 
     protected $hidden = ['image_id'];
 
+    protected $with = ['image'];
+
     /** @return string */
     public function getPublicId()
     {
@@ -98,11 +100,11 @@ class Committee extends Model
     /** @return string */
     public function getEmailAddressAttribute()
     {
-        return $this->slug.'@'.config('proto.emaildomain');
+        return $this->slug . '@' . config('proto.emaildomain');
     }
 
     /**
-     * @param  int  $n  the number of events to return
+     * @param int $n the number of events to return
      * @return Event[]|Collection|_IH_Event_C
      */
     public function pastEvents(int $n)
@@ -129,7 +131,7 @@ class Committee extends Model
     }
 
     /**
-     * @param  bool  $includeSecret
+     * @param bool $includeSecret
      * @return Event[]
      */
     public function helpedEvents($includeSecret = false)
@@ -140,7 +142,7 @@ class Committee extends Model
         $events = [];
         foreach ($activities as $activity) {
             $event = $activity->event;
-            if ($event?->isPublished() || (! $event->secret || $includeSecret)) {
+            if ($event?->isPublished() || (!$event->secret || $includeSecret)) {
                 $events[] = $event;
             }
         }
@@ -182,7 +184,7 @@ class Committee extends Model
             } else {
                 if (
                     strtotime($membership->created_at) < date('U') &&
-                    (! $membership->deleted_at || strtotime($membership->deleted_at) > date('U'))
+                    (!$membership->deleted_at || strtotime($membership->deleted_at) > date('U'))
                 ) {
                     $members['members']['current'][] = $membership;
                 } elseif (strtotime($membership->created_at) > date('U')) {
@@ -197,7 +199,7 @@ class Committee extends Model
     }
 
     /**
-     * @param  User  $user
+     * @param User $user
      * @return bool Whether the use is a member of the committee.
      */
     public function isMember($user)

--- a/app/Models/Dinnerform.php
+++ b/app/Models/Dinnerform.php
@@ -86,7 +86,7 @@ class Dinnerform extends Model
     /** @return string A timespan string with format 'D H:i'. */
     public function generateTimespanText()
     {
-        return $this->start->format('D H:i') . ' - ' . Carbon::parse($this->end)->format('D H:i');
+        return $this->start->format('D H:i').' - '.Carbon::parse($this->end)->format('D H:i');
     }
 
     /** @return bool Whether the dinnerform is currently open. */

--- a/app/Models/Dinnerform.php
+++ b/app/Models/Dinnerform.php
@@ -58,6 +58,8 @@ class Dinnerform extends Model
         'end' => 'datetime',
     ];
 
+    protected $with = ['event'];
+
     /** @return BelongsTo */
     public function event()
     {
@@ -84,7 +86,7 @@ class Dinnerform extends Model
     /** @return string A timespan string with format 'D H:i'. */
     public function generateTimespanText()
     {
-        return $this->start->format('D H:i').' - '.Carbon::parse($this->end)->format('D H:i');
+        return $this->start->format('D H:i') . ' - ' . Carbon::parse($this->end)->format('D H:i');
     }
 
     /** @return bool Whether the dinnerform is currently open. */

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -104,17 +104,18 @@ class Event extends Model
     }
 
     /**
-     * @param string $public_id
+     * @param  string  $public_id
      * @return Model
      */
     public static function fromPublicId($public_id)
     {
         return self::findOrFail(self::getIdFromPublicId($public_id));
     }
-    
+
     public static function getIdFromPublicId($public_id)
     {
         $id = Hashids::connection('event')->decode($public_id);
+
         return count($id) > 0 ? $id[0] : 0;
     }
 
@@ -140,8 +141,8 @@ class Event extends Model
         }
 
         //show non-secret events only when published
-        if (!$this->secret) {
-            if (!$this->publication || $this->isPublished()) {
+        if (! $this->secret) {
+            if (! $this->publication || $this->isPublished()) {
                 return true;
             }
         }
@@ -224,7 +225,7 @@ class Event extends Model
     }
 
     /**
-     * @param User $user
+     * @param  User  $user
      * @return bool Whether the user is organising the activity.
      */
     public function isOrganising($user)
@@ -254,24 +255,24 @@ class Event extends Model
     }
 
     /**
-     * @param string $long_format Format when timespan is larger than 24 hours.
-     * @param string $short_format Format when timespan is smaller than 24 hours.
-     * @param string $combiner Character to separate start and end time.
+     * @param  string  $long_format  Format when timespan is larger than 24 hours.
+     * @param  string  $short_format  Format when timespan is smaller than 24 hours.
+     * @param  string  $combiner  Character to separate start and end time.
      * @return string Timespan text in given format
      */
     public function generateTimespanText($long_format, $short_format, $combiner)
     {
-        return date($long_format, $this->start) . ' ' . $combiner . ' ' . (
+        return date($long_format, $this->start).' '.$combiner.' '.(
             (($this->end - $this->start) < 3600 * 24)
                 ?
                 date($short_format, $this->end)
                 :
                 date($long_format, $this->end)
-            );
+        );
     }
 
     /**
-     * @param User $user
+     * @param  User  $user
      * @return bool Whether the user is an admin of the event.
      */
     public function isEventAdmin($user)
@@ -280,7 +281,7 @@ class Event extends Model
     }
 
     /**
-     * @param User $user
+     * @param  User  $user
      * @return bool Whether the user is an ERO at the event
      */
     public function isEventEro($user)
@@ -291,7 +292,7 @@ class Event extends Model
         if (date('U') > $this->end) {
             return false;
         }
-        if (!$this->activity) {
+        if (! $this->activity) {
             return false;
         }
         $eroHelping = HelpingCommittee::query()
@@ -299,16 +300,16 @@ class Event extends Model
             ->where('committee_id', config('proto.committee')['ero'])->first();
         if ($eroHelping) {
             return ActivityParticipation::query()
-                    ->where('activity_id', $this->activity->id)
-                    ->where('committees_activities_id', $eroHelping->id)
-                    ->where('user_id', $user->id)->count() > 0;
+                ->where('activity_id', $this->activity->id)
+                ->where('committees_activities_id', $eroHelping->id)
+                ->where('user_id', $user->id)->count() > 0;
         }
 
         return false;
     }
 
     /**
-     * @param User $user
+     * @param  User  $user
      * @return bool Whether the user has bought a ticket for the event.
      */
     public function hasBoughtTickets($user)
@@ -325,7 +326,7 @@ class Event extends Model
         }
         if ($this->activity) {
             $users = $users->merge($this->activity->allUsers->sort(function ($a, $b) {
-                return (int)isset($a->pivot->committees_activities_id); // prefer helper participation registration
+                return (int) isset($a->pivot->committees_activities_id); // prefer helper participation registration
             })->unique());
         }
 
@@ -373,7 +374,7 @@ class Event extends Model
     /** @return object */
     public function getFormattedDateAttribute()
     {
-        return (object)[
+        return (object) [
             'simple' => date('M d, Y', $this->start),
             'year' => date('Y', $this->start),
             'month' => date('M Y', $this->start),

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -104,14 +104,18 @@ class Event extends Model
     }
 
     /**
-     * @param  string  $public_id
+     * @param string $public_id
      * @return Model
      */
     public static function fromPublicId($public_id)
     {
+        return self::findOrFail(self::getIdFromPublicId($public_id));
+    }
+    
+    public static function getIdFromPublicId($public_id)
+    {
         $id = Hashids::connection('event')->decode($public_id);
-
-        return self::findOrFail(count($id) > 0 ? $id[0] : 0);
+        return count($id) > 0 ? $id[0] : 0;
     }
 
     /** @return BelongsTo */
@@ -136,8 +140,8 @@ class Event extends Model
         }
 
         //show non-secret events only when published
-        if (! $this->secret) {
-            if (! $this->publication || $this->isPublished()) {
+        if (!$this->secret) {
+            if (!$this->publication || $this->isPublished()) {
                 return true;
             }
         }
@@ -149,6 +153,7 @@ class Event extends Model
     {
         return Event::query()
             ->orderBy('start')
+            ->with('image')
             ->with('activity', function ($e) {
                 $e->withCount([
                     'users',
@@ -219,7 +224,7 @@ class Event extends Model
     }
 
     /**
-     * @param  User  $user
+     * @param User $user
      * @return bool Whether the user is organising the activity.
      */
     public function isOrganising($user)
@@ -249,24 +254,24 @@ class Event extends Model
     }
 
     /**
-     * @param  string  $long_format  Format when timespan is larger than 24 hours.
-     * @param  string  $short_format  Format when timespan is smaller than 24 hours.
-     * @param  string  $combiner  Character to separate start and end time.
+     * @param string $long_format Format when timespan is larger than 24 hours.
+     * @param string $short_format Format when timespan is smaller than 24 hours.
+     * @param string $combiner Character to separate start and end time.
      * @return string Timespan text in given format
      */
     public function generateTimespanText($long_format, $short_format, $combiner)
     {
-        return date($long_format, $this->start).' '.$combiner.' '.(
+        return date($long_format, $this->start) . ' ' . $combiner . ' ' . (
             (($this->end - $this->start) < 3600 * 24)
                 ?
                 date($short_format, $this->end)
                 :
                 date($long_format, $this->end)
-        );
+            );
     }
 
     /**
-     * @param  User  $user
+     * @param User $user
      * @return bool Whether the user is an admin of the event.
      */
     public function isEventAdmin($user)
@@ -275,7 +280,7 @@ class Event extends Model
     }
 
     /**
-     * @param  User  $user
+     * @param User $user
      * @return bool Whether the user is an ERO at the event
      */
     public function isEventEro($user)
@@ -286,7 +291,7 @@ class Event extends Model
         if (date('U') > $this->end) {
             return false;
         }
-        if (! $this->activity) {
+        if (!$this->activity) {
             return false;
         }
         $eroHelping = HelpingCommittee::query()
@@ -294,16 +299,16 @@ class Event extends Model
             ->where('committee_id', config('proto.committee')['ero'])->first();
         if ($eroHelping) {
             return ActivityParticipation::query()
-                ->where('activity_id', $this->activity->id)
-                ->where('committees_activities_id', $eroHelping->id)
-                ->where('user_id', $user->id)->count() > 0;
+                    ->where('activity_id', $this->activity->id)
+                    ->where('committees_activities_id', $eroHelping->id)
+                    ->where('user_id', $user->id)->count() > 0;
         }
 
         return false;
     }
 
     /**
-     * @param  User  $user
+     * @param User $user
      * @return bool Whether the user has bought a ticket for the event.
      */
     public function hasBoughtTickets($user)
@@ -320,7 +325,7 @@ class Event extends Model
         }
         if ($this->activity) {
             $users = $users->merge($this->activity->allUsers->sort(function ($a, $b) {
-                return (int) isset($a->pivot->committees_activities_id); // prefer helper participation registration
+                return (int)isset($a->pivot->committees_activities_id); // prefer helper participation registration
             })->unique());
         }
 
@@ -368,7 +373,7 @@ class Event extends Model
     /** @return object */
     public function getFormattedDateAttribute()
     {
-        return (object) [
+        return (object)[
             'simple' => date('M d, Y', $this->start),
             'year' => date('Y', $this->start),
             'month' => date('M Y', $this->start),

--- a/app/Models/Feedback.php
+++ b/app/Models/Feedback.php
@@ -47,6 +47,8 @@ class Feedback extends Model
 
     protected $guarded = ['id'];
 
+    protected $with = ['user', 'category'];
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(\App\Models\User::class);
@@ -69,7 +71,7 @@ class Feedback extends Model
 
     public function mayViewFeedback($user): bool
     {
-        if (! $this->category->review) {
+        if (!$this->category->review) {
             return true;
         }
         if ($this->reviewed) {

--- a/app/Models/Feedback.php
+++ b/app/Models/Feedback.php
@@ -71,7 +71,7 @@ class Feedback extends Model
 
     public function mayViewFeedback($user): bool
     {
-        if (!$this->category->review) {
+        if (! $this->category->review) {
             return true;
         }
         if ($this->reviewed) {

--- a/app/Models/Newsitem.php
+++ b/app/Models/Newsitem.php
@@ -59,6 +59,8 @@ class Newsitem extends Model
 
     protected $guarded = ['id'];
 
+    protected $with = ['featuredImage'];
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(\App\Models\User::class, 'user_id');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -152,6 +152,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
 
     protected $guarded = ['password', 'remember_token'];
 
+    protected $with = ['member'];
     protected $appends = ['is_member', 'photo_preview', 'welcome_message', 'is_protube_admin'];
 
     protected $hidden = ['password', 'remember_token', 'personal_key', 'deleted_at', 'created_at', 'image_id', 'tfa_totp_key', 'updated_at', 'diet'];
@@ -167,7 +168,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     }
 
     /**
-     * @param  string  $public_id
+     * @param string $public_id
      * @return mixed|User|null
      */
     public static function fromPublicId($public_id)
@@ -184,7 +185,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
      */
     public function isStale()
     {
-        return ! (
+        return !(
             $this->password ||
             $this->edu_username ||
             strtotime($this->created_at) > strtotime('-1 hour') ||
@@ -313,8 +314,8 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     /**
      * Use this method instead of $user->photo->generate to bypass the "no profile" problem.
      *
-     * @param  int  $w
-     * @param  int  $h
+     * @param int $w
+     * @param int $h
      * @return string Path to a resized version of someone's profile picture.
      */
     public function generatePhotoPath($w = 100, $h = 100)
@@ -327,7 +328,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     }
 
     /**
-     * @param  string  $password
+     * @param string $password
      *
      * @throws Exception
      */
@@ -363,10 +364,10 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     public function hasUnpaidOrderlines()
     {
         foreach ($this->orderlines as $orderline) {
-            if (! $orderline->isPayed()) {
+            if (!$orderline->isPayed()) {
                 return true;
             }
-            if ($orderline->orderline && $orderline->withdrawal->id !== 1 && ! $orderline->withdrawal->closed) {
+            if ($orderline->orderline && $orderline->withdrawal->id !== 1 && !$orderline->withdrawal->closed) {
                 return true;
             }
         }
@@ -419,7 +420,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     }
 
     /**
-     * @param  Committee  $committee
+     * @param Committee $committee
      * @return bool
      */
     public function isInCommittee($committee)
@@ -428,7 +429,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     }
 
     /**
-     * @param  string  $slug
+     * @param string $slug
      * @return bool
      */
     public function isInCommitteeBySlug($slug)
@@ -442,21 +443,21 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     public function isActiveMember()
     {
         return count(
-            CommitteeMembership::withTrashed()
-                ->where('user_id', $this->id)
-                ->where('created_at', '<', date('Y-m-d H:i:s'))
-                ->where(function ($q) {
-                    $q->whereNull('deleted_at')
-                        ->orWhere('deleted_at', '>', date('Y-m-d H:i:s'));
-                })
-                ->with('committee')
-                ->get()
-                ->where('committee.is_society', false)
-        ) > 0;
+                CommitteeMembership::withTrashed()
+                    ->where('user_id', $this->id)
+                    ->where('created_at', '<', date('Y-m-d H:i:s'))
+                    ->where(function ($q) {
+                        $q->whereNull('deleted_at')
+                            ->orWhere('deleted_at', '>', date('Y-m-d H:i:s'));
+                    })
+                    ->with('committee')
+                    ->get()
+                    ->where('committee.is_society', false)
+            ) > 0;
     }
 
     /**
-     * @param  int  $limit
+     * @param int $limit
      * @return Withdrawal[]
      */
     public function withdrawals($limit = 0)
@@ -481,7 +482,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
             return $this->website;
         }
 
-        return 'https://'.$this->website;
+        return 'https://' . $this->website;
     }
 
     /** @return string|null */
@@ -604,7 +605,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     /** @return void */
     public function toggleCalendarRelevantSetting()
     {
-        $this->pref_calendar_relevant_only = ! $this->pref_calendar_relevant_only;
+        $this->pref_calendar_relevant_only = !$this->pref_calendar_relevant_only;
         $this->save();
     }
 
@@ -617,7 +618,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     /** @return bool Whether user has a current membership that is not pending. */
     public function getIsMemberAttribute()
     {
-        return $this->member && ! $this->member->is_pending;
+        return $this->member && !$this->member->is_pending;
     }
 
     /** @return bool */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -153,6 +153,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     protected $guarded = ['password', 'remember_token'];
 
     protected $with = ['member'];
+
     protected $appends = ['is_member', 'photo_preview', 'welcome_message', 'is_protube_admin'];
 
     protected $hidden = ['password', 'remember_token', 'personal_key', 'deleted_at', 'created_at', 'image_id', 'tfa_totp_key', 'updated_at', 'diet'];
@@ -168,7 +169,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     }
 
     /**
-     * @param string $public_id
+     * @param  string  $public_id
      * @return mixed|User|null
      */
     public static function fromPublicId($public_id)
@@ -185,7 +186,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
      */
     public function isStale()
     {
-        return !(
+        return ! (
             $this->password ||
             $this->edu_username ||
             strtotime($this->created_at) > strtotime('-1 hour') ||
@@ -314,8 +315,8 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     /**
      * Use this method instead of $user->photo->generate to bypass the "no profile" problem.
      *
-     * @param int $w
-     * @param int $h
+     * @param  int  $w
+     * @param  int  $h
      * @return string Path to a resized version of someone's profile picture.
      */
     public function generatePhotoPath($w = 100, $h = 100)
@@ -328,7 +329,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     }
 
     /**
-     * @param string $password
+     * @param  string  $password
      *
      * @throws Exception
      */
@@ -364,10 +365,10 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     public function hasUnpaidOrderlines()
     {
         foreach ($this->orderlines as $orderline) {
-            if (!$orderline->isPayed()) {
+            if (! $orderline->isPayed()) {
                 return true;
             }
-            if ($orderline->orderline && $orderline->withdrawal->id !== 1 && !$orderline->withdrawal->closed) {
+            if ($orderline->orderline && $orderline->withdrawal->id !== 1 && ! $orderline->withdrawal->closed) {
                 return true;
             }
         }
@@ -420,7 +421,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     }
 
     /**
-     * @param Committee $committee
+     * @param  Committee  $committee
      * @return bool
      */
     public function isInCommittee($committee)
@@ -429,7 +430,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     }
 
     /**
-     * @param string $slug
+     * @param  string  $slug
      * @return bool
      */
     public function isInCommitteeBySlug($slug)
@@ -443,21 +444,21 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     public function isActiveMember()
     {
         return count(
-                CommitteeMembership::withTrashed()
-                    ->where('user_id', $this->id)
-                    ->where('created_at', '<', date('Y-m-d H:i:s'))
-                    ->where(function ($q) {
-                        $q->whereNull('deleted_at')
-                            ->orWhere('deleted_at', '>', date('Y-m-d H:i:s'));
-                    })
-                    ->with('committee')
-                    ->get()
-                    ->where('committee.is_society', false)
-            ) > 0;
+            CommitteeMembership::withTrashed()
+                ->where('user_id', $this->id)
+                ->where('created_at', '<', date('Y-m-d H:i:s'))
+                ->where(function ($q) {
+                    $q->whereNull('deleted_at')
+                        ->orWhere('deleted_at', '>', date('Y-m-d H:i:s'));
+                })
+                ->with('committee')
+                ->get()
+                ->where('committee.is_society', false)
+        ) > 0;
     }
 
     /**
-     * @param int $limit
+     * @param  int  $limit
      * @return Withdrawal[]
      */
     public function withdrawals($limit = 0)
@@ -482,7 +483,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
             return $this->website;
         }
 
-        return 'https://' . $this->website;
+        return 'https://'.$this->website;
     }
 
     /** @return string|null */
@@ -605,7 +606,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     /** @return void */
     public function toggleCalendarRelevantSetting()
     {
-        $this->pref_calendar_relevant_only = !$this->pref_calendar_relevant_only;
+        $this->pref_calendar_relevant_only = ! $this->pref_calendar_relevant_only;
         $this->save();
     }
 
@@ -618,7 +619,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     /** @return bool Whether user has a current membership that is not pending. */
     public function getIsMemberAttribute()
     {
-        return $this->member && !$this->member->is_pending;
+        return $this->member && ! $this->member->is_pending;
     }
 
     /** @return bool */

--- a/resources/views/dinnerform/admin_includes/dinnerform-list.blade.php
+++ b/resources/views/dinnerform/admin_includes/dinnerform-list.blade.php
@@ -55,10 +55,10 @@
                         <td>€{{ number_format($dinnerform->totalAmountWithDiscount(), 2) }}</td>
                         <td class="text-center px-4">
                             @if($dinnerform->orderedBy)
-                                    <a class="btn btn-info badge"
-                                       href="{{ route('user::profile', ['id' => $dinnerform->orderedBy->getPublicId()]) }}">
-                                        {{$dinnerform->orderedBy->name}}
-                                    </a>
+                                <a class="btn btn-info badge"
+                                   href="{{ route('user::profile', ['id' => $dinnerform->orderedBy->getPublicId()]) }}">
+                                    {{$dinnerform->orderedBy->name}}
+                                </a>
                             @endif
                         </td>
                         <td class="text-center px-4">
@@ -106,6 +106,8 @@
         </div>
 
     @endif
+
+    <div class="card-footer pb-0">{{ $dinnerformList->links() }}</div>
 
 </div>
 

--- a/resources/views/website/home/cards/featuredevents.blade.php
+++ b/resources/views/website/home/cards/featuredevents.blade.php
@@ -1,9 +1,4 @@
-@php
-    /** @var int $n */
-    $featuredevents = App\Models\Event::where('secret', false)->where('is_featured', true)->where('end', '>=', date('U'))->orderBy('start')->limit($n)->get()
-@endphp
-
-@if(count($featuredevents) > 0)
+@if(count($featuredEvents) > 0)
 
     <div class="card mb-3">
         <div class="card-header bg-dark text-white">
@@ -12,7 +7,7 @@
         <div class="card-body">
 
 
-            @foreach($featuredevents as $key => $event)
+            @foreach($featuredEvents as $key => $event)
 
                 @include('event.display_includes.event_block', ['event'=> $event, 'countdown' => true])
 

--- a/resources/views/website/home/members.blade.php
+++ b/resources/views/website/home/members.blade.php
@@ -15,7 +15,7 @@
 
     <div class="col-xl-4 col-md-12">
 
-        @include('website.home.cards.featuredevents', ['n' => 6])
+        @include('website.home.cards.featuredevents', ['featuredEvents' => $featuredEvents])
 
         @include('website.home.cards.leaderboards')
 


### PR DESCRIPTION
Fix the lazy loading of relations on a whole bunch of pages. 
This prevents the blade n+1 problem.
It will be improved in the future for other pages. 
Then I recommend also putting  Model::preventLazyLoading(!app()->isProduction()); in the boot method of our appservice provider to prevent these problems in the future.