### PR TITLE
Seeder reparations

### DIFF
--- a/database/seeders/ImportLiveDataSeeder.php
+++ b/database/seeders/ImportLiveDataSeeder.php
@@ -32,7 +32,7 @@ class ImportLiveDataSeeder extends Seeder
             ['name' => 'accounts'],
             ['name' => 'achievement'],
             ['name' => 'activities'],
-            ['name' => 'committees'],
+            ['name' => 'committees', 'excluded_columns' => ['image']],
             ['name' => 'committees_activities'],
             ['name' => 'companies'],
             ['name' => 'events', 'excluded_columns' => ['formatted_date', 'is_future']],

--- a/database/seeders/ImportLiveDataSeeder.php
+++ b/database/seeders/ImportLiveDataSeeder.php
@@ -35,7 +35,7 @@ class ImportLiveDataSeeder extends Seeder
             ['name' => 'committees', 'excluded_columns' => ['image']],
             ['name' => 'committees_activities'],
             ['name' => 'companies'],
-            ['name' => 'events', 'excluded_columns' => ['formatted_date', 'is_future']],
+            ['name' => 'events', 'excluded_columns' => ['formatted_date', 'is_future', 'activity', 'category']],
             ['name' => 'event_categories'],
             ['name' => 'mailinglists'],
             ['name' => 'menuitems'],
@@ -87,7 +87,7 @@ class ImportLiveDataSeeder extends Seeder
                     unset($entry[$column]);
                 }
             }
-
+            
             DB::table($table['name'])->insert($entry);
         }
     }

--- a/database/seeders/ImportLiveDataSeeder.php
+++ b/database/seeders/ImportLiveDataSeeder.php
@@ -87,7 +87,7 @@ class ImportLiveDataSeeder extends Seeder
                     unset($entry[$column]);
                 }
             }
-            
+
             DB::table($table['name'])->insert($entry);
         }
     }


### PR DESCRIPTION
Breaking change in #2159 regarding the seeding of committees due to the added 'images' to the model: https://github.com/saproto/saproto/commit/6fddbe911fad6451147a6207c8378cce41115ecd#diff-36abf9185856578bbae38ce439239c7d4bca19bbe635c8c2941c7cc4d4310ca3R59 

<img width="751" alt="Scherm­afbeelding 2024-05-31 om 12 33 21" src="https://github.com/saproto/saproto/assets/43108191/91cfc0df-34c7-4bd3-90da-f6f981411258">
<img width="525" alt="Scherm­afbeelding 2024-05-31 om 12 34 54" src="https://github.com/saproto/saproto/assets/43108191/7e83a0ac-4d6f-4617-99d3-f6e37ad347fb">

The second breaking change came from #2119:
Line: https://github.com/saproto/saproto/commit/83a2ebe417462dd0f07d7f1ed268af329946e3f5#diff-45c2422d278ff0f70b1a349fd17abcf1c924d9090d7fccc78d473e3941a6205dR92


