### PR TITLE
Hide participants count in the calendar depending on sign up open date

### DIFF
--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -288,17 +288,17 @@ class Activity extends Validatable
     /**
      * @return bool Whether people should be able to see the participant count (In the calendar) .
      */
-    public function participantsVisible(): bool {
-        if ( $this->hide_participants 
-            || date('U') < $this->registration_start 
-            || $this->participants == 0 
+    public function participantsVisible(): bool
+    {
+        if ($this->hide_participants
+            || date('U') < $this->registration_start
+            || $this->participants == 0
         ) {
             return false;
-        } 
+        }
+
         return true;
     }
-
-
 
     /**
      * @return bool Whether people can still unsubscribe from the activity.

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -286,6 +286,21 @@ class Activity extends Validatable
     }
 
     /**
+     * @return bool Whether people should be able to see the participant count (In the calendar) .
+     */
+    public function participantsVisible(): bool {
+        if ( $this->hide_participants 
+            || date('U') < $this->registration_start 
+            || $this->participants == 0 
+        ) {
+            return false;
+        } 
+        return true;
+    }
+
+
+
+    /**
      * @return bool Whether people can still unsubscribe from the activity.
      */
     public function canUnsubscribe()

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -104,7 +104,7 @@
 
             {{-- Signup Icon --}}
             <div class="d-flex justify-content-between">
-                @if($event->activity && $event->activity->participantsVisible())
+                @if($event->unique_users_count > 0 && $event->activity && $event->activity->participantsVisible())
                     <span>
                             <i class="fas fa-user-alt fa-fw" aria-hidden="true"></i>
                             {{$event->unique_users_count}}

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -104,7 +104,7 @@
 
             {{-- Signup Icon --}}
             <div class="d-flex justify-content-between">
-                @if($event->unique_users_count>0)
+                @if($event->activity && $event->activity->participantsVisible())
                     <span>
                             <i class="fas fa-user-alt fa-fw" aria-hidden="true"></i>
                             {{$event->unique_users_count}}


### PR DESCRIPTION
This commit hides the participant count in the calendar if the sign up date is in the future. 