### PR TITLE
Re add the discord methods in their own controller

### DIFF
--- a/app/Http/Controllers/DiscordController.php
+++ b/app/Http/Controllers/DiscordController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use GuzzleHttp\Exception\ClientException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
+use GuzzleHttp;
+use Session;
+
+class DiscordController extends Controller
+{
+    public function discordLinkRedirect()
+    {
+        $authoriseURL = 'https://discord.com/api/oauth2/authorize?';
+        $params = [
+            'client_id' => config('proto.discord_client_id'),
+            'redirect_uri' => route('api::discord::linked'),
+            'response_type' => 'code',
+            'scope' => 'identify',
+        ];
+
+        return redirect()->away($authoriseURL . http_build_query($params));
+    }
+
+    public function discordLinkCallback(Request $request)
+    {
+        $tokenURL = 'https://discord.com/api/oauth2/token';
+        $apiURLBase = 'https://discord.com/api/users/@me';
+        $tokenData = [
+            'client_id' => config('proto.discord_client_id'),
+            'client_secret' => config('proto.discord_secret'),
+            'grant_type' => 'authorization_code',
+            'code' => $request->get('code'),
+            'redirect_uri' => route('api::discord::linked'),
+            'scope' => 'identify',
+        ];
+
+        $client = new GuzzleHttp\Client();
+        try {
+            $accessTokenData = $client->post($tokenURL, ['form_params' => $tokenData]);
+            $accessTokenData = json_decode($accessTokenData->getBody());
+        } catch (ClientException) {
+            Session::flash('flash_message', 'Something went wrong when trying to link this Discord account. Try again later.');
+
+            return redirect()->route('user::dashboard');
+        }
+
+        $userData = Http::withToken($accessTokenData->access_token)->get($apiURLBase);
+        $userData = json_decode($userData);
+
+        if (User::firstWhere('discord_id', $userData->id)) {
+            session()->flash('flash_message', 'This Discord account is already linked to a user!');
+
+            return redirect()->route('user::dashboard');
+        }
+
+        $user = Auth::user();
+        $user->discord_id = $userData->id;
+        $user->save();
+
+        session()->flash('flash_message', 'Successfully linked Discord!');
+
+        return redirect()->route('user::dashboard');
+    }
+
+    public function discordUnlink()
+    {
+        $user = Auth::user();
+        $user->discord_id = null;
+        $user->save();
+
+        session()->flash('flash_message', 'Discord account has been unlinked.');
+
+        return redirect()->route('user::dashboard');
+    }
+}

--- a/app/Http/Controllers/DiscordController.php
+++ b/app/Http/Controllers/DiscordController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use GuzzleHttp;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
-use GuzzleHttp;
 use Session;
 
 class DiscordController extends Controller
@@ -22,7 +22,7 @@ class DiscordController extends Controller
             'scope' => 'identify',
         ];
 
-        return redirect()->away($authoriseURL . http_build_query($params));
+        return redirect()->away($authoriseURL.http_build_query($params));
     }
 
     public function discordLinkCallback(Request $request)

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,9 +24,9 @@ Route::group(['middleware' => ['forcedomain'], 'as' => 'api::'], function () {
     });
 
     Route::group(['prefix' => 'discord', 'as' => 'discord::'], function () {
-        Route::get('redirect', ['as' => 'redirect', 'middleware' => ['auth'], 'uses' => 'UserApiController@discordLinkRedirect']);
-        Route::get('linked', ['as' => 'linked', 'middleware' => ['auth'], 'uses' => 'UserApiController@discordLinkCallback']);
-        Route::get('unlink', ['as' => 'unlink', 'middleware' => ['auth'], 'uses' => 'UserApiController@discordUnlink']);
+        Route::get('redirect', ['as' => 'redirect', 'middleware' => ['auth'], 'uses' => 'DiscordController@discordLinkRedirect']);
+        Route::get('linked', ['as' => 'linked', 'middleware' => ['auth'], 'uses' => 'DiscordController@discordLinkCallback']);
+        Route::get('unlink', ['as' => 'unlink', 'middleware' => ['auth'], 'uses' => 'DiscordController@discordUnlink']);
         Route::get('verify/{userId}', ['as' => 'verify', 'middleware' => ['proboto'], 'uses' => 'ApiController@discordVerifyMember']);
     });
 


### PR DESCRIPTION
These where accidentally deleted with this [commit](https://github.com/saproto/saproto/commit/962e5a5aa59f2ce88463975aaae22c3dbf8596e8). I do not think these methods should have been in the userapicontroller. Now moved to their own DiscordController.
