### PR TITLE
[Archived] Replace fontawesome kit with a npm package in case the fontawesome kit is over its usage

### DIFF
--- a/app/Csp/Policies/ProtoPolicy.php
+++ b/app/Csp/Policies/ProtoPolicy.php
@@ -68,7 +68,9 @@ class ProtoPolicy extends Policy
                     Keyword::SELF,
                     'data:',
                     'https://fonts.gstatic.com',
-                    'https://ka-f.fontawesome.com/',
+                    'https://proto.utwente.nl',
+                    'https://www.proto.utwente.nl',
+                    ...(getenv('APP_ENV') != 'production' ? ['http://localhost:*'] : []),
                 ])
                 ->addDirective(Directive::CONNECT, [
                     Keyword::SELF,
@@ -82,8 +84,6 @@ class ProtoPolicy extends Policy
                     'https://cdn.jsdelivr.net/codemirror.spell-checker/latest/en_US.aff',
                     'https://cdn.jsdelivr.net/codemirror.spell-checker/latest/en_US.dic',
                     'https://cdn.jsdelivr.net/npm/chart.js',
-                    'https://ka-f.fontawesome.com/',
-                    'https://api.fontawesome.com/',
                     ...(getenv('APP_ENV') != 'production' ? ['ws://localhost:*'] : []),
                 ]);
         } catch (InvalidValueSet|InvalidDirective $e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "codethereal-iconpicker": "^1.2.1",
         "cross-env": "^7.0.3",
         "easymde": "^2.18.0",
+        "fontawesome-free": "^1.0.4",
         "moment": "^2.29.2",
         "quagga": "^0.12.1",
         "signature_pad": "^3.0.0-beta.4",
@@ -1836,6 +1837,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/fontawesome-free": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fontawesome-free/-/fontawesome-free-1.0.4.tgz",
+      "integrity": "sha512-7sX6Lbg2oQiClFFFFitJlKg20h3YTBON6rdmq3uGjNwDo8G6EjF2bfj2OjjcCUmf4OvZCgyHaXfW2JseqissLw==",
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "codethereal-iconpicker": "^1.2.1",
     "cross-env": "^7.0.3",
     "easymde": "^2.18.0",
+    "fontawesome-free": "^1.0.4",
     "moment": "^2.29.2",
     "quagga": "^0.12.1",
     "signature_pad": "^3.0.0-beta.4",

--- a/resources/assets/sass/partials/_variables.scss
+++ b/resources/assets/sass/partials/_variables.scss
@@ -1,3 +1,5 @@
+@import '/node_modules/fontawesome-free/css/all.min.css';
+
 @import url('https://fonts.googleapis.com/css?family=Lato');
 $font-family-sans-serif: 'Lato', sans-serif;
 

--- a/resources/views/website/assets/javascripts.blade.php
+++ b/resources/views/website/assets/javascripts.blade.php
@@ -19,4 +19,5 @@
 
 @vite('resources/assets/js/application.js')
 
+{{-- Deprecated: The website self-hosts font awesome now  --}}
 {{-- <script src="https://kit.fontawesome.com/63e98a7060.js" crossorigin="anonymous"></script> --}}

--- a/resources/views/website/assets/javascripts.blade.php
+++ b/resources/views/website/assets/javascripts.blade.php
@@ -19,4 +19,4 @@
 
 @vite('resources/assets/js/application.js')
 
-<script src="https://kit.fontawesome.com/63e98a7060.js" crossorigin="anonymous"></script>
+{{-- <script src="https://kit.fontawesome.com/63e98a7060.js" crossorigin="anonymous"></script> --}}


### PR DESCRIPTION
This should permanently solve our fontawesome woes.

Might increase bandwidth on our end. 