### PR TITLE
Fixed dark theme navbar link hover bg-color

### DIFF
--- a/resources/assets/sass/dark.scss
+++ b/resources/assets/sass/dark.scss
@@ -52,6 +52,7 @@ $link-hover-color: lighten($info, 10%);
 //navbar
 $navbar-dark-color: rgba(255, 255, 255, .75);
 $navbar-dark-hover-color: #fff;
+$dropdown-link-hover-bg: $dark;
 
 //photos
 $photo_pop-color: #fff;


### PR DESCRIPTION
Fixed navbar links being unreadable when hovered in dark theme.

**Before:**

![image](https://github.com/user-attachments/assets/5a30c48a-fe5e-48e9-a388-c024a3ecf5f9)

**After:**

![image](https://github.com/user-attachments/assets/916f50b0-af3b-4e4c-a106-a49b8cbcd427)
