### PR TITLE
Fix/get generic search query

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -211,7 +211,7 @@ class SearchController extends Controller
         return $this->getGenericSearchQuery(Achievement::class, $request->get('q'), $search_attributes)?->get();
     }
 
-    private function getGenericSearchQuery(Model|string $model, string $query, array $attributes): ?Builder
+    private function getGenericSearchQuery(Model|string $model, string|null $query, array $attributes): ?Builder
     {
         $terms = explode(' ', str_replace('*', '%', $query));
         $query = $model::query();

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -211,9 +211,9 @@ class SearchController extends Controller
         return $this->getGenericSearchQuery(Achievement::class, $request->get('q'), $search_attributes)?->get();
     }
 
-    private function getGenericSearchQuery(Model|string $model, string|null $query, array $attributes): ?Builder
+    private function getGenericSearchQuery(Model|string $model, ?string $query, array $attributes): ?Builder
     {
-        if (!$query) {
+        if (! $query) {
             return null;
         }
 

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -213,6 +213,10 @@ class SearchController extends Controller
 
     private function getGenericSearchQuery(Model|string $model, string|null $query, array $attributes): ?Builder
     {
+        if (!$query) {
+            return null;
+        }
+
         $terms = explode(' ', str_replace('*', '%', $query));
         $query = $model::query();
 


### PR DESCRIPTION
The method now errors if the key is undefined in one of the requests. The check if the query is valid happens in the method so the null check should too. 