### PR TITLE
Feature: Timetable and Calendar from ICal link

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -102,7 +102,9 @@ SEPA_CI=CREDITOR_ID
 
 FONTAWESOME_KIT=KIT_URL
 
-TIMETABLE_GOOGLE_CALENDAR_ID=timetable_id@import.calendar.google.com
+TIMETABLE_ICAL_LINK_Y1=https://ical.proto.utwente.nl/y1/ical.ics
+TIMETABLE_ICAL_LINK_Y2=https://ical.proto.utwente.nl/y2/ical.ics
+TIMETABLE_ICAL_LINK_Y3=https://ical.proto.utwente.nl/y3/ical.ics
 SMARTXP_GOOGLE_CALENDAR_ID=smartxp_id@import.calendar.google.com
 PROTOPENERS_GOOGLE_CALENDAR_ID=protopeners_id@import.calendar.google.com
 

--- a/.env.prod
+++ b/.env.prod
@@ -95,6 +95,8 @@ SEPA_CI=CREDITOR_ID
 
 FONTAWESOME_KIT=KIT_URL
 
-TIMETABLE_GOOGLE_CALENDAR_ID=timetable_id@import.calendar.google.com
+TIMETABLE_ICAL_LINK_Y1=https://ical.proto.utwente.nl/y1/ical.ics
+TIMETABLE_ICAL_LINK_Y2=https://ical.proto.utwente.nl/y2/ical.ics
+TIMETABLE_ICAL_LINK_Y3=https://ical.proto.utwente.nl/y3/ical.ics
 SMARTXP_GOOGLE_CALENDAR_ID=smartxp_id@import.calendar.google.com
 PROTOPENERS_GOOGLE_CALENDAR_ID=protopeners_id@import.calendar.google.com

--- a/app/Http/Controllers/SmartXpScreenController.php
+++ b/app/Http/Controllers/SmartXpScreenController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use Cache;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\View\View;
+use ICal\ICal;
 
 class SmartXpScreenController extends Controller
 {
@@ -29,11 +31,56 @@ class SmartXpScreenController extends Controller
     /** @return array */
     public function timetable()
     {
-        return CalendarController::returnGoogleCalendarEvents(
-            config('proto.google-calendar.timetable-id'),
-            date('c', strtotime('today')),
-            date('c', strtotime('tomorrow'))
-        );
+        $studies = [
+            'Create Year 1' => [
+                'short' => 'CreaTe Y1',
+                'year' => 1,
+                'type' => 'CRE MOD',
+                'ical' => 'https://cloud.timeedit.net/nl_utwente/web/student/ri69dQ34X34ZXtQ5uQ8ZZ074y1Z84YZ6Q929w08QQ62uj6109l9n443j50Z3kj1B21DB136B0m7D9Dt6029QFlAF36Eo944AF6CE26DB.ics',
+            ],
+
+            'Create Year 2' => [
+                'short' => 'CreaTe Y2',
+                'year' => 2,
+                'type' => 'CRE MOD',
+                'ical' => 'https://cloud.timeedit.net/nl_utwente/web/public/ri65Q304518Z5uQ3555X64Q95Z044XZ5n4Q5317Q0Y72y3wXZ86Xn804.ics',
+            ],
+        ];
+
+        foreach ($studies as $study => $value) {
+            $events = Cache::remember("timetable-$study", 3600, function () use ($value) {
+                $ical = new ICal(false, array(
+                    'defaultSpan' => 2,     // Default value
+                    'defaultTimeZone' => 'UTC',
+                    'defaultWeekStart' => 'MO',  // Default value
+                    'disableCharacterReplacement' => false, // Default value
+                    'filterDaysAfter' => null,  // Default value
+                    'filterDaysBefore' => null,  // Default value
+                    'httpUserAgent' => null,  // Default value
+                    'skipRecurrence' => false, // Default value
+                ));
+
+                $ical->initUrl($value['ical']);
+
+                return collect($ical->events());
+            });
+        }
+
+
+        return $events->map(function ($event) {
+            return [
+                'title' => $event->summary,
+                'place' => $event->location,
+                'start' => $event->dtstart_array[2],
+                'end' => $event->dtend_array[2],
+                'type' => null,
+                'year' => null,
+                'study' => null,
+                'studyShort' => null,
+                'over' => strtotime($event->dtend) < time(),
+                'current' => strtotime($event->dtstart) < time() && strtotime($event->dtend) > time(),
+            ];
+        });
     }
 
     /** @return array */
@@ -72,12 +119,12 @@ class SmartXpScreenController extends Controller
             'weekend' => [],
         ];
         $occupied = false;
-        $url = 'https://www.googleapis.com/calendar/v3/calendars/'.config('proto.google-calendar.smartxp-id').'/events?singleEvents=true&orderBy=startTime&key='.config('app-proto.google-key-private').'&timeMin='.urlencode(date('c', strtotime('last monday', strtotime('tomorrow')))).'&timeMax='.urlencode(date('c', strtotime('next monday')));
+        $url = 'https://www.googleapis.com/calendar/v3/calendars/' . config('proto.google-calendar.smartxp-id') . '/events?singleEvents=true&orderBy=startTime&key=' . config('app-proto.google-key-private') . '&timeMin=' . urlencode(date('c', strtotime('last monday', strtotime('tomorrow')))) . '&timeMax=' . urlencode(date('c', strtotime('next monday')));
 
         try {
             $data = json_decode(str_replace('$', '', file_get_contents($url)));
         } catch (Exception $e) {
-            return (object) ['roster' => $roster, 'occupied' => $occupied];
+            return (object)['roster' => $roster, 'occupied' => $occupied];
         }
 
         foreach ($data->items as $entry) {
@@ -90,7 +137,7 @@ class SmartXpScreenController extends Controller
             }
             $name = '';
             foreach ($name_exp as $val) {
-                $name .= $val.' ';
+                $name .= $val . ' ';
             }
             preg_match('/Type: (.*)/', $entry->description, $type);
             $current = strtotime($start_time) < time() && strtotime($end_time) > time();
@@ -98,7 +145,7 @@ class SmartXpScreenController extends Controller
                 $occupied = true;
             }
             $day = strtolower(str_replace(['Saturday', 'Sunday'], ['weekend', 'weekend'], date('l', strtotime($start_time))));
-            $roster[$day][] = (object) [
+            $roster[$day][] = (object)[
                 'title' => $name,
                 'start' => strtotime($start_time),
                 'end' => strtotime($end_time),
@@ -108,13 +155,13 @@ class SmartXpScreenController extends Controller
             ];
         }
 
-        return (object) ['roster' => $roster, 'occupied' => $occupied];
+        return (object)['roster' => $roster, 'occupied' => $occupied];
     }
 
     /** @return View */
     public function canWork()
     {
         return view('smartxp.caniwork', ['timetable' => $this->smartxpTimetable()->roster,
-            'occupied' => $this->smartxpTimetable()->occupied, ]);
+            'occupied' => $this->smartxpTimetable()->occupied,]);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
     "vinkla/hashids": "^11.0",
     "willvincent/feeds": "^2.4",
     "laravel/legacy-factories": "^1.3",
-    "setasign/tfpdf": "^1.33"
+    "setasign/tfpdf": "^1.33",
+    "johngrogg/ics-parser": "^3.4"
   },
   "require-dev": {
     "barryvdh/laravel-ide-helper": "^2.8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "d79cd8543833dcdcbb279e3ff86e59a2",
+  "content-hash": "7e4acdfd37ceb8721a3188fc06b868b6",
   "packages": [
     {
       "name": "aacotroneo/laravel-saml2",
@@ -2605,6 +2605,70 @@
         "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.6"
       },
       "time": "2024-03-08T09:58:59+00:00"
+    },
+    {
+      "name": "johngrogg/ics-parser",
+      "version": "v3.4.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/u01jmg3/ics-parser.git",
+        "reference": "abb41a4a46256389aa4e6f582bad76f0d4cb3ebc"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/u01jmg3/ics-parser/zipball/abb41a4a46256389aa4e6f582bad76f0d4cb3ebc",
+        "reference": "abb41a4a46256389aa4e6f582bad76f0d4cb3ebc",
+        "shasum": ""
+      },
+      "require": {
+        "ext-mbstring": "*",
+        "php": ">=5.6.40"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^5|^9|^10"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-0": {
+          "ICal": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Jonathan Goode",
+          "role": "Developer/Owner"
+        },
+        {
+          "name": "John Grogg",
+          "email": "john.grogg@gmail.com",
+          "role": "Developer/Prior Owner"
+        }
+      ],
+      "description": "ICS Parser",
+      "homepage": "https://github.com/u01jmg3/ics-parser",
+      "keywords": [
+        "iCalendar",
+        "ical",
+        "ical-parser",
+        "ics",
+        "ics-parser",
+        "ifb"
+      ],
+      "support": {
+        "issues": "https://github.com/u01jmg3/ics-parser/issues",
+        "source": "https://github.com/u01jmg3/ics-parser/tree/v3.4.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/sponsors/u01jmg3",
+          "type": "github"
+        }
+      ],
+      "time": "2024-06-26T08:18:40+00:00"
     },
     {
       "name": "jwilsson/spotify-web-api-php",

--- a/config/proto.php
+++ b/config/proto.php
@@ -154,7 +154,26 @@ return [
     */
 
     'google-calendar' => [
-        'timetable-id' => env('TIMETABLE_GOOGLE_CALENDAR_ID'),
+        'studies' => [
+            [
+                'study' => 'Creative Technology',
+                'short' => 'CreaTe',
+                'year' => 1,
+                'ical' => env('TIMETABLE_ICAL_LINK_Y1'),
+            ],
+            [
+                'study' => 'Creative Technology',
+                'short' => 'CreaTe',
+                'year' => 2,
+                'ical' => env('TIMETABLE_ICAL_LINK_Y2'),
+            ],
+            [
+                'study' => 'Creative Technology',
+                'short' => 'CreaTe',
+                'year' => 3,
+                'ical' => env('TIMETABLE_ICAL_LINK_Y3'),
+            ],
+        ],
         'smartxp-id' => env('SMARTXP_GOOGLE_CALENDAR_ID'),
         'protopeners-id' => env('PROTOPENERS_GOOGLE_CALENDAR_ID'),
     ],
@@ -288,7 +307,7 @@ return [
     |
     */
 
-    'sepa_info' => (object) [
+    'sepa_info' => (object)[
         'iban' => env('SEPA_IBAN'),
         'bic' => env('SEPA_BIC'),
         'creditor_id' => env('SEPA_CI'),


### PR DESCRIPTION
The new TIMEEDIT system does not work with the way we used the calendar before (add it to a google calendar and then read from that) but does provide anonymous ICAL links. This PR moves the timetables on the smartxp and protopolis screens directly to that system. 