### PR TITLE
Add a count of unlocked achievements to the user profile

### DIFF
--- a/resources/views/users/profile/includes/achievements.blade.php
+++ b/resources/views/users/profile/includes/achievements.blade.php
@@ -3,7 +3,7 @@
     <div class="card mb-3">
 
         <div class="card-header bg-dark text-white">
-            Unlocked achievements
+            Unlocked achievements ({{$user->achievements->count()}})
         </div>
 
         <div class="card-body">


### PR DESCRIPTION
Fixes #2217. Adds the unlocked count to the user profile.
![image](https://github.com/user-attachments/assets/de1321e8-24b9-4312-9f91-d42eafe62ffe)
