### PR TITLE
Add concurrency to the test and fix php action

### DIFF
--- a/.github/workflows/fix_php_and_test.yml
+++ b/.github/workflows/fix_php_and_test.yml
@@ -1,5 +1,10 @@
 name: 🛠 Fix PHP, 🐘 Test and ⚙ Deploy Check
 on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   phplint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes it so if you commit shortly after each other only the last one will run