### PR TITLE
Remove the developer names from the minisites to fix the route serialization during caching

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Response as SupportResponse;
 use Illuminate\Support\Facades\Session;
@@ -22,10 +21,6 @@ use Illuminate\View\View;
 
 class SearchController extends Controller
 {
-    /**
-     * @param Request $request
-     * @return View
-     */
     public function search(Request $request): View
     {
         $term = $request->input('query');
@@ -57,7 +52,7 @@ class SearchController extends Controller
         if ($presearch_pages) {
             foreach ($presearch_pages as $page) {
                 /** @var Page $page */
-                if (!$page->is_member_only || Auth::user()?->is_member) {
+                if (! $page->is_member_only || Auth::user()?->is_member) {
                     $pages[] = $page;
                 }
             }
@@ -103,7 +98,7 @@ class SearchController extends Controller
         if ($presearch_photo_albums) {
             foreach ($presearch_photo_albums as $album) {
                 /** @var PhotoAlbum $album */
-                if (!$album->private || Auth::user()?->can('protography')) {
+                if (! $album->private || Auth::user()?->can('protography')) {
                     $photoAlbums[] = $album;
                 }
             }
@@ -148,13 +143,10 @@ class SearchController extends Controller
 
         return view('search.ldapsearch', [
             'term' => $query,
-            'data' => (array)$data,
+            'data' => (array) $data,
         ]);
     }
 
-    /**
-     * @return SupportResponse
-     */
     public function openSearch(): SupportResponse
     {
         return SupportResponse::make(ViewFacade::make('search.opensearch'))->header('Content-Type', 'text/xml');
@@ -166,7 +158,7 @@ class SearchController extends Controller
         $result = [];
         foreach ($this->getGenericSearchQuery(User::class, $request->get('q'), $search_attributes)?->get() ?? [] as $user) {
             /** @var User $user */
-            $result[] = (object)[
+            $result[] = (object) [
                 'id' => $user->id,
                 'name' => $user->name,
                 'is_member' => $user->is_member,
@@ -222,7 +214,7 @@ class SearchController extends Controller
             $check_at_least_one_valid_term = true;
         }
 
-        if (!$check_at_least_one_valid_term) {
+        if (! $check_at_least_one_valid_term) {
             return null;
         }
 

--- a/app/Models/PhotoAlbum.php
+++ b/app/Models/PhotoAlbum.php
@@ -51,25 +51,25 @@ class PhotoAlbum extends Model
     protected $guarded = ['id'];
 
     /** @return BelongsTo */
-    public function event()
+    public function event(): BelongsTo
     {
         return $this->belongsTo(Event::class, 'event_id');
     }
 
     /** @return HasOne */
-    private function thumbPhoto()
+    private function thumbPhoto(): HasOne
     {
         return $this->hasOne(Photo::class, 'id', 'thumb_id');
     }
 
     /** @return HasMany */
-    public function items()
+    public function items(): HasMany
     {
         return $this->hasMany(Photo::class, 'album_id');
     }
 
     /** @return string|null */
-    public function thumb()
+    public function thumb(): ?string
     {
         if ($this->thumb_id) {
             return $this->thumbPhoto()->first()->thumbnail();

--- a/app/Models/PhotoAlbum.php
+++ b/app/Models/PhotoAlbum.php
@@ -50,25 +50,21 @@ class PhotoAlbum extends Model
 
     protected $guarded = ['id'];
 
-    /** @return BelongsTo */
     public function event(): BelongsTo
     {
         return $this->belongsTo(Event::class, 'event_id');
     }
 
-    /** @return HasOne */
     private function thumbPhoto(): HasOne
     {
         return $this->hasOne(Photo::class, 'id', 'thumb_id');
     }
 
-    /** @return HasMany */
     public function items(): HasMany
     {
         return $this->hasMany(Photo::class, 'album_id');
     }
 
-    /** @return string|null */
     public function thumb(): ?string
     {
         if ($this->thumb_id) {

--- a/routes/minisites.php
+++ b/routes/minisites.php
@@ -35,12 +35,12 @@ foreach ($domains['isalfredthere'] as $domain) {
 
 foreach ($domains['static'] as $domain) {
     Route::group(['domain' => $domain], static function () {
-        Route::group(['prefix' => 'file', 'as' => 'file::'], static function () {
-            Route::get('{id}/{hash}', [FileController::class, 'get'])->name('get');
+        Route::group(['prefix' => 'file'], static function () {
+            Route::get('{id}/{hash}', [FileController::class, 'get']);
             Route::get('{id}/{hash}/{name}', [FileController::class, 'get']);
         });
-        Route::group(['prefix' => 'image', 'as' => 'image::'], static function () {
-            Route::get('{id}/{hash}', [FileController::class, 'getImage'])->name('get');
+        Route::group(['prefix' => 'image'], static function () {
+            Route::get('{id}/{hash}', [FileController::class, 'getImage']);
             Route::get('{id}/{hash}/{name}', [FileController::class, 'getImage']);
         });
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,7 @@ use App\Http\Controllers\QueryController;
 use App\Http\Controllers\RegistrationHelperController;
 use App\Http\Controllers\RfidCardController;
 use App\Http\Controllers\SearchController;
+
 /* --- use App\Http\Controllers\RadioController; --- */
 
 use App\Http\Controllers\ShortUrlController;
@@ -70,7 +71,7 @@ use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 
-require __DIR__.'/minisites.php';
+require __DIR__ . '/minisites.php';
 
 /* Route block convention:
  *
@@ -897,6 +898,13 @@ Route::middleware('forcedomain')->group(function () {
         Route::get('{id}/{hash}', 'getImage')->name('get');
         Route::get('{id}/{hash}/{name}', 'getImage');
     });
+
+    /* --- Fetching files: Public   --- */
+    Route::controller(FileController::class)->prefix('file')->name('file::')->group(function () {
+        Route::get('{id}/{hash}', 'get')->name('get');
+        Route::get('{id}/{hash}/{name}', 'get');
+    });
+
 
     /* --- Routes related to Spotify. (Board) --- */
     Route::get('spotify/oauth', [SpotifyController::class, 'oauthTool'])->name('spotify::oauth')->middleware(['auth', 'permission:board']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,7 +47,6 @@ use App\Http\Controllers\QueryController;
 use App\Http\Controllers\RegistrationHelperController;
 use App\Http\Controllers\RfidCardController;
 use App\Http\Controllers\SearchController;
-
 /* --- use App\Http\Controllers\RadioController; --- */
 
 use App\Http\Controllers\ShortUrlController;
@@ -71,7 +70,7 @@ use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 
-require __DIR__ . '/minisites.php';
+require __DIR__.'/minisites.php';
 
 /* Route block convention:
  *
@@ -904,7 +903,6 @@ Route::middleware('forcedomain')->group(function () {
         Route::get('{id}/{hash}', 'get')->name('get');
         Route::get('{id}/{hash}/{name}', 'get');
     });
-
 
     /* --- Routes related to Spotify. (Board) --- */
     Route::get('spotify/oauth', [SpotifyController::class, 'oauthTool'])->name('spotify::oauth')->middleware(['auth', 'permission:board']);


### PR DESCRIPTION
now the route:cache fails because the named routes file:: and image:: already exist. In the code we can just reference the normal routes in web.php. These only exist to add them to the domains but the relative paths are the same. 