### PR TITLE
Update the deploy.sh to clear and cache the config, views, routes and views on deploy

### DIFF
--- a/app/Console/Commands/SyncRoles.php
+++ b/app/Console/Commands/SyncRoles.php
@@ -49,7 +49,7 @@ class SyncRoles extends Command
         $permissions = [];
 
         foreach (Permission::all() as $permission) {
-            if (!in_array($permission->name, array_keys(config('permission.permissions')))) {
+            if (! in_array($permission->name, array_keys(config('permission.permissions')))) {
                 $permission->delete();
                 $this->warn("Removed '$permission->name' permission.");
             }
@@ -73,7 +73,7 @@ class SyncRoles extends Command
         $roles = [];
 
         foreach (Role::all() as $role) {
-            if (!in_array($role->name, array_keys(config('permission.roles')))) {
+            if (! in_array($role->name, array_keys(config('permission.roles')))) {
                 $role->delete();
                 $this->warn("Removed '$role->name' permission.");
             }

--- a/app/Console/Commands/SyncRoles.php
+++ b/app/Console/Commands/SyncRoles.php
@@ -49,14 +49,14 @@ class SyncRoles extends Command
         $permissions = [];
 
         foreach (Permission::all() as $permission) {
-            if (! in_array($permission->name, array_keys(config('permission.permissions')))) {
+            if (!in_array($permission->name, array_keys(config('permission.permissions')))) {
                 $permission->delete();
                 $this->warn("Removed '$permission->name' permission.");
             }
         }
 
         foreach (config('permission.permissions') as $name => $permission) {
-            $permissions[$name] = Permission::updateOrCreate(
+            $permissions[$name] = Permission::query()->updateOrCreate(
                 ['name' => $name],
                 [
                     'display_name' => $permission->display_name,
@@ -73,14 +73,14 @@ class SyncRoles extends Command
         $roles = [];
 
         foreach (Role::all() as $role) {
-            if (! in_array($role->name, array_keys(config('permission.roles')))) {
+            if (!in_array($role->name, array_keys(config('permission.roles')))) {
                 $role->delete();
                 $this->warn("Removed '$role->name' permission.");
             }
         }
 
         foreach (config('permission.roles') as $name => $role) {
-            $roles[$name] = Role::updateOrCreate(
+            $roles[$name] = Role::query()->updateOrCreate(
                 ['name' => $name],
                 [
                     'display_name' => $role->display_name,

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,11 +47,23 @@ mv new_build live
 echo "Migrating database..."
 (cd live && php artisan migrate --force)
 
+echo "Clearing laravel config..."
+(cd live && php artisan 'config:clear')
+
+echo "Clearing laravel events..."
+(cd live && php artisan 'event:clear')
+
+echo "Clearing laravel routes..."
+(cd live && php artisan 'route:clear')
+
+echo "Clearing laravel views..."
+(cd live && php artisan 'view:clear')
+
 echo "Syncing permissions and roles..."
 (cd live && php artisan 'proto:syncroles')
 
-echo "Clearing laravel config..."
-(cd live && php artisan 'config:clear')
+echo "Caching laravel (optimize)..."
+(cd live && php artisan 'optimize')
 
 echo "Bringing up new live build..."
 (cd live && php artisan up)


### PR DESCRIPTION
The current deploy script does not properly clear and cache all laravel files.
Since the route file does not contain duplicate names anymore everything can be cached again.
These commands do just that. The commands are already in the deploy script on the server.
See https://laravel.com/docs/11.x/deployment#optimization for more information