### PR TITLE
Pre-fetch the font used on the site

### DIFF
--- a/app/Csp/Policies/ProtoPolicy.php
+++ b/app/Csp/Policies/ProtoPolicy.php
@@ -56,7 +56,7 @@ class ProtoPolicy extends Policy
                 ->addDirective(Directive::STYLE, [
                     Keyword::SELF,
                     Keyword::UNSAFE_INLINE,
-                    'https://fonts.googleapis.com/css',
+                    'https://fonts.googleapis.com/css2',
                     ...(App::environment('production') ? [] : ['http://localhost:*']),
                 ])
                 ->addDirective(Directive::IMG, [

--- a/resources/assets/sass/partials/_variables.scss
+++ b/resources/assets/sass/partials/_variables.scss
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Lato');
 $font-family-sans-serif: 'Lato', sans-serif;
 
 $primary: #83b71a;

--- a/resources/views/website/assets/stylesheets.blade.php
+++ b/resources/views/website/assets/stylesheets.blade.php
@@ -8,3 +8,10 @@
 @else
     @vite('resources/assets/sass/light.scss')
 @endif
+
+{{--load the font used on our website and prefetch it--}}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link
+    href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
+    rel="stylesheet">


### PR DESCRIPTION
Move the import of the font from css to the html head
This, combined with the prefetch makes it load in parallel with the css, instead of after it.