### PR TITLE
Fix the withdrawal XML

### DIFF
--- a/app/Console/Commands/EmailCron.php
+++ b/app/Console/Commands/EmailCron.php
@@ -44,6 +44,7 @@ class EmailCron extends Command
         $this->info('There are '.$emails->count().' queued e-mails.');
 
         foreach ($emails as $email) {
+            /** @var Email $email */
             $this->info('Sending e-mail <'.$email->subject.'>');
 
             $email->ready = false;
@@ -51,7 +52,7 @@ class EmailCron extends Command
             $email->sent_to = $email->recipients()->count();
             $email->save();
 
-            foreach ($email->recipients() as $recipient) {
+            foreach ($email->recipients()->get() as $recipient) {
                 Mail::to($recipient)
                     ->queue((new ManualEmail(
                         $email->sender_address.'@'.config('proto.emaildomain'),

--- a/app/Console/Commands/EndMemberships.php
+++ b/app/Console/Commands/EndMemberships.php
@@ -44,7 +44,7 @@ class EndMemberships extends Command
     public function handle(): void
     {
         $deleted = [];
-        foreach (Member::all()->whereNotNull('until') as $member) {
+        foreach (Member::query()->whereNotNull('until')->get() as $member) {
             if ($member->until < Carbon::now()->timestamp) {
                 (new UserAdminController)->endMembership($member->user->id);
                 $this->info("Membership from $member->proto_username ended!");

--- a/app/Console/Commands/UpdateWallstreetPrices.php
+++ b/app/Console/Commands/UpdateWallstreetPrices.php
@@ -51,7 +51,7 @@ class UpdateWallstreetPrices extends Command
         }
 
         /** @var WallstreetDrink $currentDrink */
-        foreach ($currentDrink->products() as $product) {
+        foreach ($currentDrink->products()->get() as $product) {
             //search for the latest price of the current product and if it does not exist take the current price
             $latestPrice = WallstreetPrice::query()->where('product_id', $product->id)->where('wallstreet_drink_id', $currentDrink->id)->orderBy('id', 'desc')->first();
             if ($latestPrice === null) {

--- a/app/Http/Controllers/BankController.php
+++ b/app/Http/Controllers/BankController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use AbcAeffchen\SepaUtilities\SepaUtilities;
 use App\Models\Bank;
 use App\Models\User;
 use Exception;
@@ -40,6 +41,24 @@ class BankController extends Controller
     public function store(Request $request)
     {
         $user = Auth::user();
+
+        if (! SepaUtilities::checkIBAN($request->input('iban'))) {
+            Session::flash('flash_message', 'Your IBAN is not valid.');
+
+            return Redirect::back();
+        }
+
+        if (! SepaUtilities::checkBIC($request->input('bic'))) {
+            Session::flash('flash_message', 'Your BIC is not valid.');
+
+            return Redirect::back();
+        }
+
+        if (! SepaUtilities::crossCheckIbanBic($request->input('iban'), $request->input('bic'))) {
+            Session::flash('flash_message', 'Your IBAN and BIC do not match.');
+
+            return Redirect::back();
+        }
 
         $bankdata = self::doVerifyIban($request->input('iban'), $request->input('bic'));
         if ($bankdata->status == false) {

--- a/app/Http/Controllers/WithdrawalController.php
+++ b/app/Http/Controllers/WithdrawalController.php
@@ -68,7 +68,7 @@ class WithdrawalController extends Controller
         $totalPerUser = [];
         foreach (OrderLine::unpayed()->whereHas('user')->with('product', 'product.ticket')->get() as $orderline) {
             /** @var OrderLine $orderline */
-            if (!array_key_exists($orderline->user->id, $totalPerUser)) {
+            if (! array_key_exists($orderline->user->id, $totalPerUser)) {
                 $totalPerUser[$orderline->user->id] = 0;
             }
 
@@ -127,7 +127,7 @@ class WithdrawalController extends Controller
 
         return view('omnomcom.accounts.orderlines-breakdown', [
             'accounts' => Account::generateAccountOverviewFromOrderlines($orderlines),
-            'title' => 'Accounts of withdrawal of ' . date('d-m-Y', strtotime($withdrawal->date)),
+            'title' => 'Accounts of withdrawal of '.date('d-m-Y', strtotime($withdrawal->date)),
             'total' => $withdrawal->total(),
         ]);
     }
@@ -315,7 +315,7 @@ class WithdrawalController extends Controller
         /** @var Withdrawal $withdrawal */
         $withdrawal = Withdrawal::query()->findOrFail($id);
 
-        if (!$withdrawal->orderlines()->exists()) {
+        if (! $withdrawal->orderlines()->exists()) {
             Session::flash('flash_message', 'Cannot export! This withdrawal is empty.');
 
             return Redirect::back();
@@ -349,7 +349,7 @@ class WithdrawalController extends Controller
         }
 
         $i = 1;
-        $userQuery = User::select(['id', 'name'])->without(['roles', 'member', 'photo'])->whereHas('orderlines', function ($q) use ($withdrawal) {
+        $userQuery = User::query()->select(['id', 'name'])->without(['roles', 'member', 'photo'])->whereHas('orderlines', function ($q) use ($withdrawal) {
             $q->where('payed_with_withdrawal', $withdrawal->id);
         })->withSum(['orderlines as orderlines_total' => function ($q) use ($withdrawal) {
             $q->where('payed_with_withdrawal', $withdrawal->id);
@@ -377,8 +377,8 @@ class WithdrawalController extends Controller
 
         try {
             $response = $directDebit->generateOutput()[0];
-        } catch (Exception $e) {
-            Session::flash('flash_message', "Error creating the xml file. Error: {$e->getMessage()}");
+        } catch (Exception $exception) {
+            Session::flash('flash_message', "Error creating the xml file. Error: {$exception->getMessage()}");
 
             return Redirect::back();
         }
@@ -470,8 +470,8 @@ class WithdrawalController extends Controller
                 continue;
             }
 
-            if (!in_array($orderline->user->id, array_keys($users))) {
-                $users[$orderline->user->id] = (object)[
+            if (! in_array($orderline->user->id, array_keys($users))) {
+                $users[$orderline->user->id] = (object) [
                     'user' => $orderline->user,
                     'orderlines' => [],
                     'total' => 0,

--- a/app/Models/Withdrawal.php
+++ b/app/Models/Withdrawal.php
@@ -72,7 +72,7 @@ class Withdrawal extends Model
 
     public function users(): HasManyThrough
     {
-        return $this->hasManyThrough(User::class, OrderLine::class, 'payed_with_withdrawal', 'id', 'id', 'user_id');
+        return $this->hasManyThrough(User::class, OrderLine::class, 'payed_with_withdrawal', 'id', 'id', 'user_id')->distinct();
     }
 
     public function total(): mixed

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "minimum-stability": "stable",
     "require": {
         "aacotroneo/laravel-saml2": "^2.1.0",
-        "abcaeffchen/sephpa": "^2.1",
+        "abcaeffchen/sephpa": "^2.1.2",
         "alaouy/youtube": "2.2.5",
         "biscolab/laravel-recaptcha": "^6",
         "ext-calendar": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "71197cd4017597a2382f9c498d0e1179",
+  "content-hash": "0e3308f4a00035af530801436daf231f",
   "packages": [
     {
       "name": "aacotroneo/laravel-saml2",
@@ -1904,21 +1904,21 @@
     },
     {
       "name": "intervention/image",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "source": {
         "type": "git",
         "url": "https://github.com/Intervention/image.git",
-        "reference": "1786ad5e1789050939d73cd195de4b8eaeeb34ed"
+        "reference": "1e0a2b6d767ef22a095924c6bcb2981da6de6f1e"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/Intervention/image/zipball/1786ad5e1789050939d73cd195de4b8eaeeb34ed",
-        "reference": "1786ad5e1789050939d73cd195de4b8eaeeb34ed",
+        "url": "https://api.github.com/repos/Intervention/image/zipball/1e0a2b6d767ef22a095924c6bcb2981da6de6f1e",
+        "reference": "1e0a2b6d767ef22a095924c6bcb2981da6de6f1e",
         "shasum": ""
       },
       "require": {
         "ext-mbstring": "*",
-        "intervention/gif": "^4.1",
+        "intervention/gif": "^4.2",
         "php": "^8.1"
       },
       "require-dev": {
@@ -1960,7 +1960,7 @@
       ],
       "support": {
         "issues": "https://github.com/Intervention/image/issues",
-        "source": "https://github.com/Intervention/image/tree/3.8.0"
+        "source": "https://github.com/Intervention/image/tree/3.9.0"
       },
       "funding": [
         {
@@ -1976,7 +1976,7 @@
           "type": "ko_fi"
         }
       ],
-      "time": "2024-08-16T14:57:26+00:00"
+      "time": "2024-10-06T15:37:56+00:00"
     },
     {
       "name": "jean85/pretty-package-versions",
@@ -10190,16 +10190,16 @@
     },
     {
       "name": "pestphp/pest",
-      "version": "v3.4.1",
+      "version": "v3.4.2",
       "source": {
         "type": "git",
         "url": "https://github.com/pestphp/pest.git",
-        "reference": "67f217852ce153134fbea8857487a3829904c086"
+        "reference": "2903a7e62100171d5faf4e50cda755ffeadedc57"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/pestphp/pest/zipball/67f217852ce153134fbea8857487a3829904c086",
-        "reference": "67f217852ce153134fbea8857487a3829904c086",
+        "url": "https://api.github.com/repos/pestphp/pest/zipball/2903a7e62100171d5faf4e50cda755ffeadedc57",
+        "reference": "2903a7e62100171d5faf4e50cda755ffeadedc57",
         "shasum": ""
       },
       "require": {
@@ -10210,11 +10210,11 @@
         "pestphp/pest-plugin-arch": "^3.0.0",
         "pestphp/pest-plugin-mutate": "^3.0.5",
         "php": "^8.2.0",
-        "phpunit/phpunit": "^11.4.1"
+        "phpunit/phpunit": "^11.4.2"
       },
       "conflict": {
         "filp/whoops": "<2.16.0",
-        "phpunit/phpunit": ">11.4.1",
+        "phpunit/phpunit": ">11.4.2",
         "sebastian/exporter": "<6.0.0",
         "webmozart/assert": "<1.11.0"
       },
@@ -10286,7 +10286,7 @@
       ],
       "support": {
         "issues": "https://github.com/pestphp/pest/issues",
-        "source": "https://github.com/pestphp/pest/tree/v3.4.1"
+        "source": "https://github.com/pestphp/pest/tree/v3.4.2"
       },
       "funding": [
         {
@@ -10298,7 +10298,7 @@
           "type": "github"
         }
       ],
-      "time": "2024-10-15T16:17:09+00:00"
+      "time": "2024-10-20T11:47:25+00:00"
     },
     {
       "name": "pestphp/pest-plugin",
@@ -11396,16 +11396,16 @@
     },
     {
       "name": "phpunit/phpunit",
-      "version": "11.4.1",
+      "version": "11.4.2",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/phpunit.git",
-        "reference": "7875627f15f4da7e7f0823d1f323f7295a77334e"
+        "reference": "1863643c3f04ad03dcb9c6996c294784cdda4805"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7875627f15f4da7e7f0823d1f323f7295a77334e",
-        "reference": "7875627f15f4da7e7f0823d1f323f7295a77334e",
+        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1863643c3f04ad03dcb9c6996c294784cdda4805",
+        "reference": "1863643c3f04ad03dcb9c6996c294784cdda4805",
         "shasum": ""
       },
       "require": {
@@ -11419,21 +11419,21 @@
         "phar-io/manifest": "^2.0.4",
         "phar-io/version": "^3.2.1",
         "php": ">=8.2",
-        "phpunit/php-code-coverage": "^11.0.6",
+        "phpunit/php-code-coverage": "^11.0.7",
         "phpunit/php-file-iterator": "^5.1.0",
         "phpunit/php-invoker": "^5.0.1",
         "phpunit/php-text-template": "^4.0.1",
         "phpunit/php-timer": "^7.0.1",
         "sebastian/cli-parser": "^3.0.2",
         "sebastian/code-unit": "^3.0.1",
-        "sebastian/comparator": "^6.1.0",
+        "sebastian/comparator": "^6.1.1",
         "sebastian/diff": "^6.0.2",
         "sebastian/environment": "^7.2.0",
         "sebastian/exporter": "^6.1.3",
         "sebastian/global-state": "^7.0.2",
         "sebastian/object-enumerator": "^6.0.1",
         "sebastian/type": "^5.1.0",
-        "sebastian/version": "^5.0.1"
+        "sebastian/version": "^5.0.2"
       },
       "suggest": {
         "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -11476,7 +11476,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/phpunit/issues",
         "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-        "source": "https://github.com/sebastianbergmann/phpunit/tree/11.4.1"
+        "source": "https://github.com/sebastianbergmann/phpunit/tree/11.4.2"
       },
       "funding": [
         {
@@ -11492,7 +11492,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2024-10-08T15:38:37+00:00"
+      "time": "2024-10-19T13:05:19+00:00"
     },
     {
       "name": "psy/psysh",
@@ -11804,16 +11804,16 @@
     },
     {
       "name": "sebastian/comparator",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/comparator.git",
-        "reference": "fa37b9e2ca618cb051d71b60120952ee8ca8b03d"
+        "reference": "5ef523a49ae7a302b87b2102b72b1eda8918d686"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa37b9e2ca618cb051d71b60120952ee8ca8b03d",
-        "reference": "fa37b9e2ca618cb051d71b60120952ee8ca8b03d",
+        "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5ef523a49ae7a302b87b2102b72b1eda8918d686",
+        "reference": "5ef523a49ae7a302b87b2102b72b1eda8918d686",
         "shasum": ""
       },
       "require": {
@@ -11869,7 +11869,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/comparator/issues",
         "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-        "source": "https://github.com/sebastianbergmann/comparator/tree/6.1.0"
+        "source": "https://github.com/sebastianbergmann/comparator/tree/6.1.1"
       },
       "funding": [
         {
@@ -11877,7 +11877,7 @@
           "type": "github"
         }
       ],
-      "time": "2024-09-11T15:42:56+00:00"
+      "time": "2024-10-18T15:00:48+00:00"
     },
     {
       "name": "sebastian/complexity",
@@ -12812,7 +12812,7 @@
   ],
   "aliases": [],
   "minimum-stability": "stable",
-  "stability-flags": {},
+  "stability-flags": [],
   "prefer-stable": false,
   "prefer-lowest": false,
   "platform": {
@@ -12820,6 +12820,6 @@
     "ext-curl": "*",
     "ext-json": "*"
   },
-  "platform-dev": {},
+  "platform-dev": [],
   "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
The sepa library does throw an exception when it says not to. See https://github.com/AbcAeffchen/Sephpa/issues/44.
Now we catch the potential error. 

Found some additional querybuilders we accidentally not call get on.
Added some extra BIC and IBAN validation when creating a bank using the SepaUtilities library.

Now the xml generation also performs some validation so if the IBAN and BIC do not match each other the treasurer will get notified when making the xml and it will have to be fixed before generating the xml.