### PR TITLE
Migrate all our ids from unsigned ints to unsigned bigints (default since Laravel 11)

### DIFF
--- a/database/migrations/2024_11_30_014951_migrate_ids_to_bigints.php
+++ b/database/migrations/2024_11_30_014951_migrate_ids_to_bigints.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::table('dmx_channels', function ($table) {

--- a/database/migrations/2024_11_30_014951_migrate_ids_to_bigints.php
+++ b/database/migrations/2024_11_30_014951_migrate_ids_to_bigints.php
@@ -1,0 +1,157 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+//migration taken from https://gist.github.com/hrsa/7a45420329e745315ee02a08ddbf3d41 which itself is forked from https://gist.github.com/NBZ4live/04d5981eaf0244b57d0296b381e04195
+//this migration is used to change the charset of the database from utf8 to utf8mb4 which allows for emojis and other special characters to be stored in the database
+return new class extends Migration {
+    
+    public function up(): void
+    {
+        Schema::table('dmx_channels', function ($table) {
+            $table->integer('id')->unsigned()->primary()->change();
+        });
+
+        $this->dropForeign();
+
+        $defaultConnection = config('database.default');
+        $databaseName = config("database.connections.{$defaultConnection}.database");
+
+        // Get the list of all tables
+        $tableNames = DB::table('information_schema.tables')
+            ->where('table_schema', $databaseName)
+            ->where('table_type', '=', 'BASE TABLE')
+            ->get(['TABLE_NAME'])
+            ->pluck('TABLE_NAME');
+
+        // Get the list of all columns in the active db that have a collation
+        $columns = DB::table('information_schema.columns')
+            ->where('table_schema', $databaseName)
+            ->whereIn('table_name', $tableNames)
+            ->where(function ($query) {
+                $query->where('COLUMN_TYPE', 'int(10) unsigned')
+                    ->orWhere('COLUMN_TYPE', 'int(11)');
+            })->whereNotNull('COLUMN_KEY')
+            ->get();
+
+        // Iterate through the list and alter each column
+        foreach ($columns as $column) {
+            $tableName = $column->TABLE_NAME;
+            $columnName = $column->COLUMN_NAME;
+            $increment = $columnName === 'id' ? ' AUTO_INCREMENT' : '';
+
+            DB::unprepared("ALTER TABLE `{$tableName}` MODIFY `{$columnName}` BIGINT UNSIGNED{$increment};");
+        }
+
+        // Recreate the foreign keys
+        $this->reinstateForeign();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        // Revert the 'id' column change in the 'dmx_channels' table
+        Schema::table('dmx_channels', function ($table) {
+            $table->integer('id')->unsigned(false)->primary()->change();  // Revert to original type
+        });
+
+        // Drop foreign keys
+        $this->dropForeign();
+
+        // Revert column types from BIGINT UNSIGNED to original types (typically int or int unsigned)
+        $defaultConnection = config('database.default');
+        $databaseName = config("database.connections.{$defaultConnection}.database");
+
+        // Get the list of all tables
+        $tableNames = DB::table('information_schema.tables')
+            ->where('table_schema', $databaseName)
+            ->where('table_type', '=', 'BASE TABLE')
+            ->get(['TABLE_NAME'])
+            ->pluck('TABLE_NAME');
+
+        // Get the list of all columns in the active db that were changed to BIGINT UNSIGNED
+        $columns = DB::table('information_schema.columns')
+            ->where('table_schema', $databaseName)
+            ->whereIn('table_name', $tableNames)
+            ->where(function ($query) {
+                $query->where('COLUMN_TYPE', 'bigint(20) unsigned');
+            })
+            ->get();
+
+        // Iterate through the list and alter each column back to int(10) unsigned or int(11)
+        foreach ($columns as $column) {
+            $tableName = $column->TABLE_NAME;
+            $columnName = $column->COLUMN_NAME;
+
+            // Alter column type back to unsigned int (you may need to adjust depending on the original type)
+            $increment = $columnName === 'id' ? ' AUTO_INCREMENT' : '';
+
+            DB::unprepared("ALTER TABLE `{$tableName}` MODIFY `{$columnName}` INT(10) UNSIGNED{$increment};");
+        }
+
+        $this->reinstateForeign();
+    }
+
+    /**
+     * @return void
+     */
+    public function dropForeign(): void
+    {
+        Schema::table('role_user', function ($table) {
+            $table->dropForeign(['role_id']);
+            $table->dropForeign(['user_id']);
+        });
+
+        Schema::table('model_has_permissions', function ($table) {
+            $table->dropForeign(['permission_id']);
+        });
+
+        Schema::table('permission_role', function ($table) {
+            $table->dropForeign(['permission_id']);
+            $table->dropForeign(['role_id']);
+        });
+
+        Schema::table('model_has_roles', function ($table) {
+            $table->dropForeign(['role_id']);
+        });
+
+        Schema::table('pages_files', function ($table) {
+            $table->dropForeign(['file_id']);
+            $table->dropForeign(['page_id']);
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function reinstateForeign(): void
+    {
+        Schema::table('role_user', function ($table) {
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+
+        Schema::table('model_has_permissions', function ($table) {
+            $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
+        });
+
+        Schema::table('permission_role', function ($table) {
+            $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+        });
+
+        Schema::table('model_has_roles', function ($table) {
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+        });
+
+        Schema::table('pages_files', function ($table) {
+            $table->foreign('file_id')->references('id')->on('files')->onDelete('cascade');
+            $table->foreign('page_id')->references('id')->on('pages')->onDelete('cascade');
+        });
+    }
+};

--- a/database/migrations/2024_11_30_014951_migrate_ids_to_bigints.php
+++ b/database/migrations/2024_11_30_014951_migrate_ids_to_bigints.php
@@ -2,11 +2,12 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 //migration taken from https://gist.github.com/hrsa/7a45420329e745315ee02a08ddbf3d41 which itself is forked from https://gist.github.com/NBZ4live/04d5981eaf0244b57d0296b381e04195
 //this migration is used to change the charset of the database from utf8 to utf8mb4 which allows for emojis and other special characters to be stored in the database
-return new class extends Migration {
-    
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::table('dmx_channels', function ($table) {
@@ -50,8 +51,6 @@ return new class extends Migration {
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
     public function down(): void
     {
@@ -97,9 +96,6 @@ return new class extends Migration {
         $this->reinstateForeign();
     }
 
-    /**
-     * @return void
-     */
     public function dropForeign(): void
     {
         Schema::table('role_user', function ($table) {
@@ -126,9 +122,6 @@ return new class extends Migration {
         });
     }
 
-    /**
-     * @return void
-     */
     public function reinstateForeign(): void
     {
         Schema::table('role_user', function ($table) {

--- a/database/migrations/2024_11_30_014951_migrate_ids_to_bigints.php
+++ b/database/migrations/2024_11_30_014951_migrate_ids_to_bigints.php
@@ -4,10 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-//migration taken from https://gist.github.com/hrsa/7a45420329e745315ee02a08ddbf3d41 which itself is forked from https://gist.github.com/NBZ4live/04d5981eaf0244b57d0296b381e04195
-//this migration is used to change the charset of the database from utf8 to utf8mb4 which allows for emojis and other special characters to be stored in the database
-return new class extends Migration
-{
+return new class extends Migration {
     public function up(): void
     {
         Schema::table('dmx_channels', function ($table) {


### PR DESCRIPTION
It is good to migrate all ids and columns referencing ids to unsigned big integers. Not because I think we will soon reach the limit, but the new default laravel primary id is an biginteger. Because of this all foreignids need to be the same type, and I think it would be nicer if then all the ID's are the same. 