### PR TITLE
Move IsAlfredThere to a websocket and clean up the code

### DIFF
--- a/app/Enums/IsAlfredThereEnum.php
+++ b/app/Enums/IsAlfredThereEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum IsAlfredThereEnum: string
+{
+    case THERE = 'there';
+    case AWAY = 'away';
+    case UNKNOWN = 'unknown';
+    case JUR = 'jur';
+    case TEXT_ONLY = 'text';
+}

--- a/app/Events/IsAlfredThereEvent.php
+++ b/app/Events/IsAlfredThereEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Override;
+
+class IsAlfredThereEvent implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public string $status, public ?string $text, public ?string $unix) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, Channel>
+     */
+    #[Override]
+    public function broadcastOn(): array
+    {
+        return [
+            new Channel('isalfredthere'),
+        ];
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'status' => $this->status,
+            'text' => $this->text,
+            'unix' => $this->unix,
+        ];
+    }
+}

--- a/app/Http/Controllers/IsAlfredThereController.php
+++ b/app/Http/Controllers/IsAlfredThereController.php
@@ -2,36 +2,34 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\IsAlfredThereEnum;
+use App\Events\IsAlfredThereEvent;
 use App\Models\HashMapItem;
-use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
-use stdClass;
 
 class IsAlfredThereController extends Controller
 {
-    public static $HashMapItemKey = 'is_alfred_there';
+    public static string $HashMapItemKey = 'is_alfred_there';
 
-    public static $HashMapTextKey = 'is_alfred_there_text';
+    public static string $HashMapUnixKey = 'is_alfred_there_unix';
+
+    public static string $HashMapTextKey = 'is_alfred_there_text';
 
     /** @return View */
     public function index()
     {
-        return view('isalfredthere.minisite');
-    }
-
-    /** @return false|string */
-    public function getApi()
-    {
-        return json_encode(self::getAlfredsStatusObject());
+        return view('isalfredthere.minisite', $this->getStatus());
     }
 
     /** @return View */
     public function edit()
     {
-        return view('isalfredthere.admin', ['status' => self::getAlfredsStatusObject()]);
+        return view('isalfredthere.admin',
+            $this->getStatus()
+        );
     }
 
     /**
@@ -39,65 +37,38 @@ class IsAlfredThereController extends Controller
      */
     public function update(Request $request)
     {
-        $text = self::getOrCreateHasMapItem(self::$HashMapTextKey);
-        $status = self::getOrCreateHasMapItem(self::$HashMapItemKey);
-        $new_status = $request->input('where_is_alfred');
-        $arrival_time = $request->input('back');
-
-        if ($new_status === 'there' || $new_status === 'unknown' || $new_status === 'jur') {
-            $status->value = $new_status;
-            $text->value = '';
-        } elseif ($new_status === 'away') {
-            $status->value = $arrival_time;
-            $text->value = $request->input('is_alfred_there_text');
-        } elseif ($new_status === 'text_only') {
-            $text->value = $request->input('is_alfred_there_text');
-            $status->value = 'unknown';
+        $text = $request->input('is_alfred_there_text');
+        $status = $request->input('where_is_alfred');
+        $unix = $request->input('back');
+        switch ($status) {
+            case IsAlfredThereEnum::UNKNOWN->value:
+            case IsAlfredThereEnum::JUR->value:
+                $text = '';
+                $unix = '';
+                break;
+            case IsAlfredThereEnum::THERE->value:
+            case IsAlfredThereEnum::TEXT_ONLY->value:
+                $unix = '';
+                break;
         }
 
-        $status->save();
-        $text->save();
+        $text = HashMapItem::query()->updateOrCreate(['key' => self::$HashMapTextKey], ['value' => $text]);
+
+        $status = HashMapItem::query()->updateOrCreate(['key' => self::$HashMapItemKey], ['value' => $status]);
+
+        $unix = HashMapItem::query()->updateOrCreate(['key' => self::$HashMapUnixKey], ['value' => $unix]);
+
+        IsAlfredThereEvent::dispatch($status->value, $text->value, $unix->value);
 
         return Redirect::back();
     }
 
-    /** @return HashMapItem */
-    public static function getOrCreateHasMapItem($key)
+    private function getStatus(): array
     {
-        $item = HashMapItem::query()->where('key', $key)->first();
-        if (! $item) {
-            return HashMapItem::query()->create([
-                'key' => $key,
-                'value' => '',
-            ]);
-        }
-
-        return $item;
-    }
-
-    /** @return stdClass */
-    public static function getAlfredsStatusObject()
-    {
-        $result = new stdClass;
-        $result->text = self::getOrCreateHasMapItem(self::$HashMapTextKey)->value;
-
-        $status = self::getOrCreateHasMapItem(self::$HashMapItemKey);
-        if ($status->value == 'there' || $status->value == 'jur' || $status->value == 'unknown') {
-            $result->status = $status->value;
-
-            return $result;
-        }
-
-        if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/', $status->value) === 1) {
-            $result->status = 'away';
-            $result->back = Carbon::parse($status->value)->format('Y-m-d H:i');
-            $result->backunix = Carbon::parse($status->value)->getTimestamp();
-
-            return $result;
-        }
-
-        $result->status = 'unknown';
-
-        return $result;
+        return [
+            'text' => HashMapItem::query()->firstOrCreate(['key' => self::$HashMapTextKey], ['value' => ''])->value,
+            'status' => HashMapItem::query()->firstOrCreate(['key' => self::$HashMapItemKey], ['value' => IsAlfredThereEnum::UNKNOWN])->value,
+            'unix' => HashMapItem::query()->firstOrCreate(['key' => self::$HashMapUnixKey], ['value' => ''])->value,
+        ];
     }
 }

--- a/resources/assets/js/echo.js
+++ b/resources/assets/js/echo.js
@@ -14,10 +14,9 @@ window.Echo = new Echo({
     encrypted: true,
     disableStats: true,
     enabledTransports: ['ws', 'wss'],
-    cluster: 'eu',
+    cluster: 'eu'
 });
 if (import.meta.env.DEV) {
-    console.log(window.Echo);
     Pusher.log = (msg) => {
         console.log(msg);
     };

--- a/resources/views/isalfredthere/admin.blade.php
+++ b/resources/views/isalfredthere/admin.blade.php
@@ -3,6 +3,10 @@
 @section('page-title')
     IsAlfredThere.nl
 @endsection
+@php
+    use App\Enums\IsAlfredThereEnum;
+    use Carbon\Carbon;
+@endphp
 
 @section('container')
 
@@ -23,11 +27,11 @@
                     <div class="card-body where_is_alfred">
 
                         <p>
-                            @if($status->status == 'there')
+                            @if($status == IsAlfredThereEnum::THERE->value)
                                 You are there!
-                            @elseif($status->status == 'away')
-                                You'll be back at {{ $status->back }}.
-                            @elseif($status->status == 'jur')
+                            @elseif($status == IsAlfredThereEnum::AWAY->value)
+                                You'll be back at {{ Carbon::parse($unix)->format('Y-m-d H:i') }}.
+                            @elseif($status == IsAlfredThereEnum::JUR->value)
                                 You do not seem to be Alfred. Do you happen to feel like a Jur today?
                             @else
                                 Your whereabouts are currently not known.
@@ -38,7 +42,8 @@
 
                         <div class="form-check">
                             <input class="form-check-input" type="radio" name="where_is_alfred" id="where_is_alfred_1"
-                                   value="there" required {{ $status->status == 'there' ? 'checked' : '' }}>
+                                   value="there"
+                                   required {{ $status == IsAlfredThereEnum::THERE->value ? 'checked' : '' }}>
                             <label class="form-check-label" for="where_is_alfred_1">
                                 I'm there!
                             </label>
@@ -46,7 +51,7 @@
 
                         <div class="form-check">
                             <input class="form-check-input" type="radio" name="where_is_alfred" id="where_is_jur"
-                                   value="jur" required {{ $status->status == 'jur' ? 'checked' : '' }}>
+                                   value="jur" required {{ $status == IsAlfredThereEnum::JUR->value ? 'checked' : '' }}>
                             <label class="form-check-label" for="where_is_jur">
                                 I'm not Alfred, I'm Jur!
                             </label>
@@ -54,7 +59,8 @@
 
                         <div class="form-check">
                             <input class="form-check-input" type="radio" name="where_is_alfred" id="where_is_alfred_2"
-                                   value="away" required {{ $status->status == 'away' ? 'checked' : '' }}>
+                                   value="away"
+                                   required {{ $status == IsAlfredThereEnum::AWAY->value ? 'checked' : '' }}>
                             <label class="form-check-label" for="where_is_alfred_2">
                                 I'll be back in a while!
                             </label>
@@ -62,7 +68,8 @@
 
                         <div class="form-check">
                             <input class="form-check-input" type="radio" name="where_is_alfred" id="where_is_alfred_3"
-                                   value="unknown" required {{ $status->status == 'unknown' ? 'checked' : '' }}>
+                                   value="unknown"
+                                   required {{ $status == IsAlfredThereEnum::UNKNOWN->value ? 'checked' : '' }}>
                             <label class="form-check-label" for="where_is_alfred_3">
                                 I'd like to reset my whereabouts!
                             </label>
@@ -70,8 +77,8 @@
 
                         <div class="form-check">
                             <input class="form-check-input" type="radio" name="where_is_alfred" id="where_is_alfred_4"
-                                   value="text_only"
-                                   required {{ ($status->status == 'unknown' && !empty($status->text)) ? 'checked' : '' }}>
+                                   value="text"
+                                   required {{ ($status == IsAlfredThereEnum::TEXT_ONLY->value) ? 'checked' : '' }}>
                             <label class="form-check-label" for="where_is_alfred_4">
                                 I would only like to display a message!
                             </label>
@@ -80,15 +87,15 @@
                         @include('components.forms.datetimepicker',[
                             'name' => 'back',
                             'label' => "I'll be back around:",
-                            'placeholder' => $status->status == 'away' ? $status->backunix : strtotime('now +1 hour'),
-                            'form_class_name' => $status->status == 'away' ? '' : 'd-none'
+                            'placeholder' => $status == IsAlfredThereEnum::AWAY->value ? Carbon::parse($unix)->timestamp : strtotime('now +1 hour'),
+                            'form_class_name' => $status == IsAlfredThereEnum::AWAY->value ? '' : 'd-none'
                         ])
 
                         <div id="alfred-text"
-                             class="{{($status->status == 'away'||($status->status=='unknown'&&!empty($status->text))) ? '' : 'd-none'}}">
+                             class="{{($status == IsAlfredThereEnum::AWAY->value||$status==IsAlfredThereEnum::TEXT_ONLY->value) ? '' : 'd-none'}}">
                             <br>
                             <input name="is_alfred_there_text" type="text" class="form-control"
-                                   placeholder="additional message" value="{{$status->text}}">
+                                   placeholder="additional message" value="{{$text}}">
                         </div>
 
                     </div>
@@ -116,12 +123,13 @@
         radioList.forEach(el => {
             el.addEventListener('change', _ => {
 
-                if (el.checked && el.value === 'away') {
+                if (el.checked && el.value === "{{
+                    IsAlfredThereEnum::AWAY}}") {
                     dateSelect.classList.remove('d-none');
                     alfredText.classList.remove('d-none');
                     alfredText.querySelector('input').placeholder = 'Additional message';
                     dateBack.required = true;
-                } else if (el.checked && el.value === 'text_only') {
+                } else if (el.checked && el.value === 'text') {
                     alfredText.classList.remove('d-none');
                     dateSelect.classList.add('d-none');
                     alfredText.querySelector('input').placeholder = 'Message!';

--- a/resources/views/isalfredthere/minisite.blade.php
+++ b/resources/views/isalfredthere/minisite.blade.php
@@ -150,7 +150,6 @@
         };
 
         const setNewStatus = (newStatus) => {
-            console.log(newStatus);
             // stop all timers
             window.timerList.forEach((timer) => {
                 timer.stop();

--- a/resources/views/isalfredthere/minisite.blade.php
+++ b/resources/views/isalfredthere/minisite.blade.php
@@ -34,12 +34,12 @@
                         class="far fa-face-grin-squint"></i>
                 </i> <i class="d-none" id="alfred-away" style="font-size: 120px;"><i
                         class="far fa-grimace"></i>
-                </i> <i class="" id="alfred-unknown" style="font-size: 120px;"><i
+                </i> <i class="d-none" id="alfred-unknown" style="font-size: 120px;"><i
                         class="fas fa-circle-question"></i>
                 </i>
             </div>
             <a href="//{{ config('app-proto.primary-domain') }}{{ route('homepage', [], false) }}">
-                <img src="{{ asset('images/logo/inverse.png') }}" alt="Proto logo" width="472px" height="120px">
+                <img src="{{ asset('images/logo/inverse.png') }}" alt="Proto logo" width="472px">
             </a>
 
         </div>
@@ -63,91 +63,100 @@
 @endpush
 
 @push('javascript')
+
+    @vite('resources/assets/js/echo.js')
+
     <script type="text/javascript" nonce="{{ csp_nonce() }}">
-        const status = document.getElementById('alfred-status');
+        const statusElement = document.getElementById('alfred-status');
         const text = document.getElementById('alfred-text');
         const time = document.getElementById('alfred-actualtime');
-        let oldStatus = null;
         const statuses = {
             there: {
                 text: 'Alfred is there!',
                 htmlElement: document.getElementById('alfred-there'),
-                color: 'bg-success',
+                color: 'bg-success'
             },
             jur: {
                 text: 'Jur is here to help you! <br> <div style="font-size: 20px;">You might have to check Flex Office though...</div>',
                 htmlElement: document.getElementById('jur-there'),
-                color: 'bg-success',
+                color: 'bg-success'
             },
             unknown: {
                 text: 'We couldn\'t find Alfred...',
                 htmlElement: document.getElementById('alfred-unknown'),
-                color: 'bg-warning',
+                color: 'bg-warning'
+            },
+            text: {
+                text: 'We couldn\'t find Alfred...',
+                htmlElement: document.getElementById('alfred-unknown'),
+                color: 'bg-warning'
             },
             away: {
                 text: 'Nope, Alfred will be back in a bit.',
                 htmlElement: document.getElementById('alfred-away'),
-                color: 'bg-danger',
+                color: 'bg-danger'
             },
             error: {
                 text: 'We couldn\'t find Alfred...',
                 htmlElement: document.getElementById('alfred-error'),
-                color: 'bg-warning',
-            },
+                color: 'bg-warning'
+            }
         };
 
         window.addEventListener('load', _ => {
-            lookForAlfred();
-            setInterval(lookForAlfred, 10000);
+            updateStatus({
+                status: "{{$status}}",
+                text: "{{$text}}",
+                unix: "{{$unix}}"
+            });
+
+            window.Echo.channel(`isalfredthere`)
+                .listen('IsAlfredThereEvent', (status) => {
+                    updateStatus(status);
+                })
+                .error((error) => {
+                    console.error(error);
+                    setTimeout(() => {
+                        window.location.reload();
+                    }, 10000);
+                });
         });
 
-        function lookForAlfred() {
-            get("{{route('api::isalfredthere')}}")
-                .then(data => {
-                    //set the extra text Alfred can set himself
-                    if (data.text.length > 0) {
-                        text.innerHTML = '"'.concat(data.text, '"');
-                    } else {
-                        text.innerHTML = '';
-                    }
+        const updateStatus = (status) => {
+            if (status.text?.length > 0) {
+                text.innerHTML = '"'.concat(status.text ?? '', '"');
+            } else {
+                text.innerHTML = '';
+            }
 
-                    // keep track if the status has changed, if not do nothing
-                    if (oldStatus === data.status) {
-                        return;
-                    }
-                    oldStatus = data.status;
+            // hide all smileys
+            Object.keys(statuses).forEach((key) => {
+                statuses[key].htmlElement.classList.add('d-none');
+            });
 
-                    // hide all smileys
-                    Object.keys(statuses).forEach((key) => {
-                        statuses[key].htmlElement.classList.add('d-none');
-                    });
+            // set the new status
+            setNewStatus(statuses[status.status]);
 
-                    // set the new status
-                    setNewStatus(statuses[data.status]);
-
-                    // set the time submessage and start the timer if Alfred is away
-                    if (data.status === 'away') {
-                        time.innerHTML = `That would be ${data.back}.`;
-                        time.classList.remove('d-none');
-                        status.setAttribute('data-countdown-start', data.backunix);
-                        window.timerList.forEach((timer) => {
-                            timer.start();
-                        });
-                    }
-                })
-                .catch(error => {
-                    console.error(error);
-                    setNewStatus(statuses.error);
+            // set the time submessage and start the timer if Alfred is away
+            if (status.status === 'away') {
+                const date = new window.moment(status.unix);
+                time.innerHTML = `That would be ${date.format('DD-MM-Y HH:mm')}.`;
+                time.classList.remove('d-none');
+                statusElement.setAttribute('data-countdown-start', date.unix());
+                window.timerList.forEach((timer) => {
+                    timer.start();
                 });
-        }
+            }
+        };
 
         const setNewStatus = (newStatus) => {
+            console.log(newStatus);
             // stop all timers
             window.timerList.forEach((timer) => {
                 timer.stop();
             });
             // set the big status text
-            status.innerHTML = newStatus.text;
+            statusElement.innerHTML = newStatus.text;
 
             //reveal the correct smiley
             newStatus.htmlElement.classList.remove('d-none');

--- a/routes/api.php
+++ b/routes/api.php
@@ -69,8 +69,6 @@ Route::group(['middleware' => ['forcedomain'], 'as' => 'api::'], static function
         Route::get('all_prices/{id}', ['as' => 'all_prices', 'uses' => 'WallstreetController@getAllPrices']);
         Route::get('toggle_event', ['as' => 'toggle_event', 'uses' => 'WallstreetController@toggleEvent', 'middleware' => ['permission:tipcie']]);
     });
-    /* Route related to the IsAlfredThere API */
-    Route::get('isalfredthere', ['as' => 'isalfredthere', 'uses' => 'IsAlfredThereController@getApi']);
     /* Routes related to the OmNomCom Wrapped API */
     Route::get('wrapped')->middleware('auth:api')->uses('WrappedController@index')->name('wrapped');
 });

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -9,3 +9,5 @@ use Illuminate\Support\Facades\Broadcast;
 Broadcast::channel('App.User.*', fn ($user, $userId): bool => (int) $user->id === (int) $userId);
 
 Broadcast::channel('wallstreet-prices.{wallstreetId}', fn ($user, $wallstreetId) => Auth::user()->can('tipcie'));
+
+Broadcast::channel('isalfredthere', fn ($user): true => true);


### PR DESCRIPTION
Currently every screen that displays isAlfredThere does a request to our backend every 10 seconds. This is completely unneccesary since we have a websocket server. This PR cleans up the code, and lets the frontend update over the websocket. It also correctly lets the page load on first load. When the websockets fails it will go back to refreshing the page every 10 seconds.