### PR TITLE
Fix unnecessary ProTube call when removing role and add error handling

### DIFF
--- a/app/Http/Controllers/AuthorizationController.php
+++ b/app/Http/Controllers/AuthorizationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Models\Role;
 use App\Services\ProTubeApiService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -11,7 +12,6 @@ use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
 use Illuminate\View\View;
 use Permission;
-use Role;
 
 class AuthorizationController extends Controller
 {
@@ -42,21 +42,21 @@ class AuthorizationController extends Controller
         $user = User::query()->findOrFail($request->user);
 
         if ($user->hasRole($role)) {
-            Session::flash('flash_message', $user->name.' already has role: <strong>'.$role->name.'</strong>.');
+            Session::flash('flash_message', $user->name . ' already has role: <strong>' . $role->name . '</strong>.');
 
             return Redirect::back();
         }
 
         $user->assignRole($role);
 
-        Session::flash('flash_message', $user->name.' has been granted role: <strong>'.$role->name.'</strong>.');
+        Session::flash('flash_message', $user->name . ' has been granted role: <strong>' . $role->name . '</strong>.');
 
         return Redirect::back();
     }
 
     /**
-     * @param  int  $id
-     * @param  int  $userId
+     * @param  int  $id role ID
+     * @param  int  $userId user ID
      * @return RedirectResponse
      */
     public function revoke(Request $request, $id, $userId)
@@ -73,10 +73,19 @@ class AuthorizationController extends Controller
         $user = User::query()->findOrFail($userId);
         $user->removeRole($role);
 
-        // Call Protube webhook to remove this user's admin rights
-        ProTubeApiService::updateAdmin($user->id, false);
 
-        Session::flash('flash_message', '<strong>'.$role->name.'</strong> has been revoked from '.$user->name.'.');
+        // Call Protube webhook to remove this user's admin rights, only remove when role is protube
+        if ($role->name == 'protube') {
+            $updatedAdmin = ProTubeApiService::updateAdmin($user->id, false);
+            if (!$updatedAdmin) {
+                Session::flash('flash_message', 'Failed to remove ProTube admin status for ' . $user->name . '.');
+
+                return Redirect::back();
+            }
+        }
+
+
+        Session::flash('flash_message', '<strong>' . $role->name . '</strong> has been revoked from ' . $user->name . '.');
 
         return Redirect::back();
     }

--- a/app/Http/Controllers/AuthorizationController.php
+++ b/app/Http/Controllers/AuthorizationController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Role;
 use App\Models\User;
 use App\Services\ProTubeApiService;
 use Illuminate\Http\RedirectResponse;
@@ -12,11 +11,11 @@ use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
 use Illuminate\View\View;
 use Permission;
+use Spatie\Permission\Models\Role;
 
 class AuthorizationController extends Controller
 {
-    /** @return View */
-    public function index()
+    public function index(): view
     {
         $roles = Role::all();
         $permissions = Permission::all();
@@ -24,11 +23,7 @@ class AuthorizationController extends Controller
         return view('authorization.overview', ['roles' => $roles, 'permissions' => $permissions]);
     }
 
-    /**
-     * @param  int  $id
-     * @return RedirectResponse
-     */
-    public function grant(Request $request, $id)
+    public function grant(Request $request, int $id): RedirectResponse
     {
         if ($id == Config::integer('proto.rootrole')) {
             Session::flash('flash_message', 'This role can only be manually added in the database.');
@@ -37,7 +32,7 @@ class AuthorizationController extends Controller
         }
 
         /** @var Role $role */
-        $role = Role::findOrFail($id);
+        $role = Role::query()->findOrFail($id);
         /** @var User $user */
         $user = User::query()->findOrFail($request->user);
 
@@ -57,9 +52,8 @@ class AuthorizationController extends Controller
     /**
      * @param  int  $id  role ID
      * @param  int  $userId  user ID
-     * @return RedirectResponse
      */
-    public function revoke(Request $request, $id, $userId)
+    public function revoke(int $id, int $userId): RedirectResponse
     {
         if ($id == Config::integer('proto.rootrole')) {
             Session::flash('flash_message', 'This role can only be manually removed in the database.');
@@ -68,13 +62,13 @@ class AuthorizationController extends Controller
         }
 
         /** @var Role $role */
-        $role = Role::findOrFail($id);
+        $role = Role::query()->findOrFail($id);
         /** @var User $user */
         $user = User::query()->findOrFail($userId);
         $user->removeRole($role);
 
         // Call Protube webhook to remove this user's admin rights, only remove when role is protube
-        if ($role->name == 'protube') {
+        if ($role->name === 'protube') {
             $updatedAdmin = ProTubeApiService::updateAdmin($user->id, false);
             if (! $updatedAdmin) {
                 Session::flash('flash_message', 'Failed to remove ProTube admin status for '.$user->name.'.');

--- a/app/Http/Controllers/AuthorizationController.php
+++ b/app/Http/Controllers/AuthorizationController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\User;
 use App\Models\Role;
+use App\Models\User;
 use App\Services\ProTubeApiService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -42,21 +42,21 @@ class AuthorizationController extends Controller
         $user = User::query()->findOrFail($request->user);
 
         if ($user->hasRole($role)) {
-            Session::flash('flash_message', $user->name . ' already has role: <strong>' . $role->name . '</strong>.');
+            Session::flash('flash_message', $user->name.' already has role: <strong>'.$role->name.'</strong>.');
 
             return Redirect::back();
         }
 
         $user->assignRole($role);
 
-        Session::flash('flash_message', $user->name . ' has been granted role: <strong>' . $role->name . '</strong>.');
+        Session::flash('flash_message', $user->name.' has been granted role: <strong>'.$role->name.'</strong>.');
 
         return Redirect::back();
     }
 
     /**
-     * @param  int  $id role ID
-     * @param  int  $userId user ID
+     * @param  int  $id  role ID
+     * @param  int  $userId  user ID
      * @return RedirectResponse
      */
     public function revoke(Request $request, $id, $userId)
@@ -73,19 +73,17 @@ class AuthorizationController extends Controller
         $user = User::query()->findOrFail($userId);
         $user->removeRole($role);
 
-
         // Call Protube webhook to remove this user's admin rights, only remove when role is protube
         if ($role->name == 'protube') {
             $updatedAdmin = ProTubeApiService::updateAdmin($user->id, false);
-            if (!$updatedAdmin) {
-                Session::flash('flash_message', 'Failed to remove ProTube admin status for ' . $user->name . '.');
+            if (! $updatedAdmin) {
+                Session::flash('flash_message', 'Failed to remove ProTube admin status for '.$user->name.'.');
 
                 return Redirect::back();
             }
         }
 
-
-        Session::flash('flash_message', '<strong>' . $role->name . '</strong> has been revoked from ' . $user->name . '.');
+        Session::flash('flash_message', '<strong>'.$role->name.'</strong> has been revoked from '.$user->name.'.');
 
         return Redirect::back();
     }


### PR DESCRIPTION
Removing a role now only triggers a ProTube API call when the role is specifically the ProTube role. Additionally, error handling has been implemented to manage potential failures when the ProTube service is unavailable.

Fixes #2200