### PR TITLE
Disable lazyloading of attributes when in dev

### DIFF
--- a/app/Console/Commands/AchievementsCron.php
+++ b/app/Console/Commands/AchievementsCron.php
@@ -336,7 +336,7 @@ class AchievementsCron extends Command
     {
         $products = [];
         foreach ($categories as $category) {
-            $products = array_merge($products, ProductCategory::query()->find($category)->sortedProducts()->pluck('id')->toArray());
+            $products = array_merge($products, ProductCategory::query()->find($category)->sortedProducts()->get()->pluck('id')->toArray());
         }
 
         return $products;

--- a/app/Console/Commands/AchievementsCron.php
+++ b/app/Console/Commands/AchievementsCron.php
@@ -11,7 +11,6 @@ use App\Models\CommitteeMembership;
 use App\Models\Event;
 use App\Models\OrderLine;
 use App\Models\Product;
-use App\Models\ProductCategory;
 use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
@@ -137,10 +136,8 @@ class AchievementsCron extends Command
 
     /**
      * Give an achievement to a user.
-     *
-     * @param  User  $user
      */
-    private function giveAchievement($user, int $id): void
+    private function giveAchievement(User $user, int $id): void
     {
         $achievement = Achievement::query()->find($id);
 
@@ -162,40 +159,32 @@ class AchievementsCron extends Command
 
     /**
      * Achievement beast = earned 10 achievements or more.
-     *
-     * @param  User  $user
      */
-    private function achievementBeast($user): bool
+    private function achievementBeast(User $user): bool
     {
         return $user->achievements->count() >= 10;
     }
 
     /**
      * Old Fart = member for more than 5 years.
-     *
-     * @param  User  $user
      */
-    private function oldFart($user): bool
+    private function oldFart(User $user): bool
     {
         return $user->is_member && $user->member->created_at < Carbon::now()->subYears(5);
     }
 
     /**
      * Gotta catch 'em all! = be a member of at least 10 different committees.
-     *
-     * @param  User  $user
      */
-    private function gottaCatchEmAll($user): bool
+    private function gottaCatchEmAll(User $user): bool
     {
         return $user->committees()->count() >= 10;
     }
 
     /**
      * Big spender = paid more than the max. amount of money in a month (=€250).
-     *
-     * @param  User  $user
      */
-    private function bigSpender($user): bool
+    private function bigSpender(User $user): bool
     {
         if ($this->notFirstOfMonth()) {
             return false;
@@ -210,10 +199,8 @@ class AchievementsCron extends Command
 
     /**
      * 4ever committee member = has been a committee member for more than three years.
-     *
-     * @param  User  $user
      */
-    private function foreverMember($user): bool
+    private function foreverMember(User $user): bool
     {
         foreach ($user->committees as $committee) {
             $memberships = CommitteeMembership::withTrashed()
@@ -243,20 +230,17 @@ class AchievementsCron extends Command
     /**
      * FIRST!!!! = the first to buy a product.
      *
-     * @param  User  $user
      * @param  int[]  $firsts
      */
-    private function first($user, array $firsts): bool
+    private function first(User $user, array $firsts): bool
     {
         return in_array($user->id, $firsts);
     }
 
     /**
      * Attended a certain number of activities.
-     *
-     * @param  User  $user
      */
-    private function nThActivity($user, int $n): bool
+    private function nThActivity(User $user, int $n): bool
     {
         $participated = ActivityParticipation::query()->where('user_id', $user->id)->pluck('activity_id');
         $activities = Activity::query()->WhereIn('id', $participated)->pluck('event_id');
@@ -267,11 +251,8 @@ class AchievementsCron extends Command
 
     /**
      * Attended a certain percentage of signups in the last month.
-     *
-     * @param  User  $user
-     * @param  int  $possibleSignups
      */
-    private function percentageParticipation($user, int $percentage, $possibleSignups): bool
+    private function percentageParticipation(User $user, int $percentage, int $possibleSignups): bool
     {
         if ($this->notFirstOfMonth()) {
             return false;
@@ -297,10 +278,9 @@ class AchievementsCron extends Command
     /**
      * Bought a certain number of a set of products.
      *
-     * @param  User  $user
      * @param  int[]  $products
      */
-    private function nThProducts($user, array $products, int $n): bool
+    private function nThProducts(User $user, array $products, int $n): bool
     {
         return $user->orderlines()->whereIn('product_id', $products)->sum('units') >= $n;
     }
@@ -308,10 +288,9 @@ class AchievementsCron extends Command
     /**
      * A percentage of purchases were of a certain set of products.
      *
-     * @param  User  $user
      * @param  int[]  $products
      */
-    private function percentageProducts($user, array $products, float $p): bool
+    private function percentageProducts(User $user, array $products, float $p): bool
     {
         $orders = OrderLine::query()
             ->where('updated_at', '>', Carbon::now()->subMonths())
@@ -334,11 +313,8 @@ class AchievementsCron extends Command
      */
     private function categoryProducts(array $categories): array
     {
-        $products = [];
-        foreach ($categories as $category) {
-            $products = array_merge($products, ProductCategory::query()->find($category)->sortedProducts()->get()->pluck('id')->toArray());
-        }
-
-        return $products;
+        return Product::query()->whereHas('categories', static function ($q) use ($categories) {
+            $q->whereIn('product_categories.id', $categories);
+        })->get('id')->pluck('id')->toArray();
     }
 }

--- a/app/Http/Controllers/CommitteeController.php
+++ b/app/Http/Controllers/CommitteeController.php
@@ -52,7 +52,7 @@ class CommitteeController extends Controller
     {
         $committee = Committee::fromPublicId($id);
 
-        if (!$committee->public && !Auth::user()?->can('board') && !$committee?->isMember(Auth::user())) {
+        if (! $committee->public && ! Auth::user()?->can('board') && ! $committee?->isMember(Auth::user())) {
             abort(404);
         }
 
@@ -115,7 +115,7 @@ class CommitteeController extends Controller
         $committee->fill($request->all());
 
         // The is_active value is either unset or 'on' so only set it to false if selected.
-        $committee->is_active = !$request->has('is_active');
+        $committee->is_active = ! $request->has('is_active');
 
         $committee->save();
 
@@ -126,7 +126,7 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      *
      * @throws FileNotFoundException
@@ -183,13 +183,13 @@ class CommitteeController extends Controller
 
         $membership->save();
 
-        Session::flash('flash_message', 'You have added ' . $membership->user->name . ' to ' . $membership->committee->name . '.');
+        Session::flash('flash_message', 'You have added '.$membership->user->name.' to '.$membership->committee->name.'.');
 
         return Redirect::back();
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return View
      */
     public function editMembershipForm($id)
@@ -200,7 +200,7 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function updateMembershipForm(Request $request, $id)
@@ -231,7 +231,7 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -242,7 +242,7 @@ class CommitteeController extends Controller
         $membership = CommitteeMembership::withTrashed()->findOrFail($id);
         $committee_id = $membership->committee->id;
 
-        Session::flash('flash_message', 'You have removed ' . $membership->user->name . ' from ' . $membership->committee->name . '.');
+        Session::flash('flash_message', 'You have removed '.$membership->user->name.' from '.$membership->committee->name.'.');
 
         $membership->forceDelete();
 
@@ -264,14 +264,14 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse|View
      */
     public function showAnonMailForm($id)
     {
         $committee = Committee::fromPublicId($id);
 
-        if (!$committee->allow_anonymous_email) {
+        if (! $committee->allow_anonymous_email) {
             Session::flash('flash_message', 'This committee does not accept anonymous e-mail at this time.');
 
             return Redirect::back();
@@ -281,14 +281,14 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param int $id
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function sendAnonMailForm(Request $request, $id)
     {
         $committee = Committee::fromPublicId($id);
 
-        if (!$committee->allow_anonymous_email) {
+        if (! $committee->allow_anonymous_email) {
             Session::flash('flash_message', 'This committee does not accept anonymous e-mail at this time.');
 
             return Redirect::back();
@@ -299,9 +299,9 @@ class CommitteeController extends Controller
         $message_content = strip_tags($request->get('message'));
         $message_hash = md5($message_content);
 
-        Log::info('Anonymous e-mail with hash ' . $message_hash . ' sent to ' . $name . ' by user #' . Auth::user()->id);
+        Log::info('Anonymous e-mail with hash '.$message_hash.' sent to '.$name.' by user #'.Auth::user()->id);
 
-        Mail::to((object)[
+        Mail::to((object) [
             'name' => $committee->name,
             'email' => $committee->email,
         ])->queue((new AnonymousEmail($committee, $message_content, $message_hash))->onQueue('low'));

--- a/app/Http/Controllers/CommitteeController.php
+++ b/app/Http/Controllers/CommitteeController.php
@@ -52,11 +52,11 @@ class CommitteeController extends Controller
     {
         $committee = Committee::fromPublicId($id);
 
-        if (! $committee->public && (! Auth::check() || (! Auth::user()->can('board') && ! $committee->isMember(Auth::user())))) {
+        if (!$committee->public && !Auth::user()?->can('board') && !$committee?->isMember(Auth::user())) {
             abort(404);
         }
 
-        $pastEvents = $committee->pastEvents(6);
+        $pastEvents = $committee->pastEvents()->take(6);
 
         return view('committee.show', [
             'committee' => $committee,
@@ -115,7 +115,7 @@ class CommitteeController extends Controller
         $committee->fill($request->all());
 
         // The is_active value is either unset or 'on' so only set it to false if selected.
-        $committee->is_active = ! $request->has('is_active');
+        $committee->is_active = !$request->has('is_active');
 
         $committee->save();
 
@@ -126,7 +126,7 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      *
      * @throws FileNotFoundException
@@ -183,13 +183,13 @@ class CommitteeController extends Controller
 
         $membership->save();
 
-        Session::flash('flash_message', 'You have added '.$membership->user->name.' to '.$membership->committee->name.'.');
+        Session::flash('flash_message', 'You have added ' . $membership->user->name . ' to ' . $membership->committee->name . '.');
 
         return Redirect::back();
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return View
      */
     public function editMembershipForm($id)
@@ -200,7 +200,7 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      */
     public function updateMembershipForm(Request $request, $id)
@@ -231,7 +231,7 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      *
      * @throws Exception
@@ -242,7 +242,7 @@ class CommitteeController extends Controller
         $membership = CommitteeMembership::withTrashed()->findOrFail($id);
         $committee_id = $membership->committee->id;
 
-        Session::flash('flash_message', 'You have removed '.$membership->user->name.' from '.$membership->committee->name.'.');
+        Session::flash('flash_message', 'You have removed ' . $membership->user->name . ' from ' . $membership->committee->name . '.');
 
         $membership->forceDelete();
 
@@ -264,14 +264,14 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse|View
      */
     public function showAnonMailForm($id)
     {
         $committee = Committee::fromPublicId($id);
 
-        if (! $committee->allow_anonymous_email) {
+        if (!$committee->allow_anonymous_email) {
             Session::flash('flash_message', 'This committee does not accept anonymous e-mail at this time.');
 
             return Redirect::back();
@@ -281,14 +281,14 @@ class CommitteeController extends Controller
     }
 
     /**
-     * @param  int  $id
+     * @param int $id
      * @return RedirectResponse
      */
     public function sendAnonMailForm(Request $request, $id)
     {
         $committee = Committee::fromPublicId($id);
 
-        if (! $committee->allow_anonymous_email) {
+        if (!$committee->allow_anonymous_email) {
             Session::flash('flash_message', 'This committee does not accept anonymous e-mail at this time.');
 
             return Redirect::back();
@@ -299,9 +299,9 @@ class CommitteeController extends Controller
         $message_content = strip_tags($request->get('message'));
         $message_hash = md5($message_content);
 
-        Log::info('Anonymous e-mail with hash '.$message_hash.' sent to '.$name.' by user #'.Auth::user()->id);
+        Log::info('Anonymous e-mail with hash ' . $message_hash . ' sent to ' . $name . ' by user #' . Auth::user()->id);
 
-        Mail::to((object) [
+        Mail::to((object)[
             'name' => $committee->name,
             'email' => $committee->email,
         ])->queue((new AnonymousEmail($committee, $message_content, $message_hash))->onQueue('low'));

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -144,7 +144,7 @@ class EventController extends Controller
         $event->category()->associate($category);
         $event->save();
 
-        Session::flash('flash_message', "Your event '" . $event->title . "' has been added.");
+        Session::flash('flash_message', "Your event '".$event->title."' has been added.");
 
         return Redirect::route('event::show', ['id' => $event->getPublicId()]);
     }
@@ -210,9 +210,9 @@ class EventController extends Controller
         $changed_important_details = $event->start !== strtotime($request->start) || $event->end !== strtotime($request->end) || $event->location != $request->location;
 
         if ($changed_important_details) {
-            Session::flash('flash_message', "Your event '" . $event->title . "' has been saved. <br><b class='text-warning'>You updated some important information. Don't forget to update your participants with this info!</b>");
+            Session::flash('flash_message', "Your event '".$event->title."' has been saved. <br><b class='text-warning'>You updated some important information. Don't forget to update your participants with this info!</b>");
         } else {
-            Session::flash('flash_message', "Your event '" . $event->title . "' has been saved.");
+            Session::flash('flash_message', "Your event '".$event->title."' has been saved.");
         }
 
         return Redirect::back();
@@ -232,10 +232,10 @@ class EventController extends Controller
                 $query->whereHas('Category', static function ($q) use ($category) {
                     $q->where('id', $category->id)->where('deleted_at', null);
                 });
-            })->where('start', '>', strtotime($year . '-01-01 00:00:01'))
-            ->where('start', '<', strtotime($year . '-12-31 23:59:59'))
+            })->where('start', '>', strtotime($year.'-01-01 00:00:01'))
+            ->where('start', '<', strtotime($year.'-12-31 23:59:59'))
             ->get()
-            ->groupBy(fn(Event $event) => Carbon::createFromTimestamp($event->start)->month);
+            ->groupBy(fn (Event $event) => Carbon::createFromTimestamp($event->start)->month);
 
         $years = $this->getAvailableYears();
 
@@ -249,7 +249,7 @@ class EventController extends Controller
 
     private function getAvailableYears(): Collection
     {
-        return Cache::remember('event::availableyears', Carbon::now()->diff(Carbon::now()->endOfDay()), static fn() => collect(DB::select('SELECT DISTINCT Year(FROM_UNIXTIME(start)) AS start FROM events ORDER BY Year(FROM_UNIXTIME(start))'))->pluck('start'));
+        return Cache::remember('event::availableyears', Carbon::now()->diff(Carbon::now()->endOfDay()), static fn () => collect(DB::select('SELECT DISTINCT Year(FROM_UNIXTIME(start)) AS start FROM events ORDER BY Year(FROM_UNIXTIME(start))'))->pluck('start'));
     }
 
     /**
@@ -263,12 +263,12 @@ class EventController extends Controller
         $event = Event::query()->findOrFail($id);
 
         if ($event->activity !== null) {
-            Session::flash('flash_message', "You cannot delete event '" . $event->title . "' since it has a participation details.");
+            Session::flash('flash_message', "You cannot delete event '".$event->title."' since it has a participation details.");
 
             return Redirect::back();
         }
 
-        Session::flash('flash_message', "The event '" . $event->title . "' has been deleted.");
+        Session::flash('flash_message', "The event '".$event->title."' has been deleted.");
 
         $event->delete();
 
@@ -288,9 +288,10 @@ class EventController extends Controller
      */
     public function admin(int $id)
     {
-        $event = Event::query()->findOrFail($id);
+        $event = Event::query()
+            ->with('tickets.purchases.user', 'tickets.purchases.orderline')->findOrFail($id);
 
-        if (!$event->isEventAdmin(Auth::user())) {
+        if (! $event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not an event admin for this event!');
 
             return Redirect::back();
@@ -306,7 +307,7 @@ class EventController extends Controller
     {
         $event = Event::query()->findOrFail($id);
 
-        if (!$event->isEventAdmin(Auth::user())) {
+        if (! $event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not an event admin for this event!');
 
             return Redirect::back();
@@ -323,7 +324,7 @@ class EventController extends Controller
         /** @var Activity $activity */
         $activity = Activity::query()->findOrFail($id);
 
-        if ($activity->event && !$activity->event->over()) {
+        if ($activity->event && ! $activity->event->over()) {
             Session::flash('flash_message', 'You cannot close an activity before it has finished.');
 
             return Redirect::back();
@@ -351,7 +352,7 @@ class EventController extends Controller
 
         $product = Product::query()->create([
             'account_id' => $account->id,
-            'name' => 'Activity: ' . ($activity->event ? $activity->event->title : $activity->comment),
+            'name' => 'Activity: '.($activity->event ? $activity->event->title : $activity->comment),
             'price' => $activity->price,
         ]);
         $product->save();
@@ -370,7 +371,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param Event $event
+     * @param  Event  $event
      * @return RedirectResponse
      */
     public function linkAlbum(Request $request, int $event)
@@ -383,7 +384,7 @@ class EventController extends Controller
         $album->event()->associate($event);
         $album->save();
 
-        Session::flash('flash_message', 'The album ' . $album->name . ' has been linked to this activity!');
+        Session::flash('flash_message', 'The album '.$album->name.' has been linked to this activity!');
 
         return Redirect::back();
     }
@@ -398,7 +399,7 @@ class EventController extends Controller
         $album->event()->dissociate();
         $album->save();
 
-        Session::flash('flash_message', 'The album ' . $album->name . ' has been unlinked from an activity!');
+        Session::flash('flash_message', 'The album '.$album->name.' has been unlinked from an activity!');
 
         return Redirect::back();
     }
@@ -421,22 +422,22 @@ class EventController extends Controller
 
         foreach ($events as $event) {
             if ($event->secret && ($user == null || $event->activity == null || (
-                        !$event->activity->isParticipating($user) &&
-                        !$event->activity->isHelping($user) &&
-                        !$event->isOrganising($user)
-                    ))) {
+                ! $event->activity->isParticipating($user) &&
+                ! $event->activity->isHelping($user) &&
+                ! $event->isOrganising($user)
+            ))) {
                 continue;
             }
 
-            $participants = ($user?->is_member && $event->activity ? $event->activity->users->map(static fn($item) => (object)[
+            $participants = ($user?->is_member && $event->activity ? $event->activity->users->map(static fn ($item) => (object) [
                 'name' => $item->name,
                 'photo' => $item->photo_preview,
             ]) : null);
-            $backupParticipants = ($user?->is_member && $event->activity ? $event->activity->backupUsers->map(static fn($item) => (object)[
+            $backupParticipants = ($user?->is_member && $event->activity ? $event->activity->backupUsers->map(static fn ($item) => (object) [
                 'name' => $item->name,
                 'photo' => $item->photo_preview,
             ]) : null);
-            $data[] = (object)[
+            $data[] = (object) [
                 'id' => $event->id,
                 'title' => $event->title,
                 'image' => ($event->image ? $event->image->generateImagePath(800, 300) : null),
@@ -460,7 +461,7 @@ class EventController extends Controller
                 'price' => ($event->activity ? $event->activity->price : null),
                 'no_show_fee' => ($event->activity ? $event->activity->no_show_fee : null),
                 'user_signedup' => ($user && $event->activity ? $event->activity->isParticipating($user) : null),
-                'user_signedup_backup' => (bool)($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->backup : null),
+                'user_signedup_backup' => (bool) ($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->backup : null),
                 'user_signedup_id' => ($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->id : null),
                 'can_signup' => ($user && $event->activity ? $event->activity->canSubscribe() : null),
                 'can_signup_backup' => ($user && $event->activity ? $event->activity->canSubscribeBackup() : null),
@@ -522,26 +523,26 @@ class EventController extends Controller
 VERSION:2.0
 PRODID:-//HYTTIOAOAc//S.A. Proto Calendar//EN
 CALSCALE:GREGORIAN
-' .
-            'X-WR-CALNAME:' . $calendar_name . "\r\n" .
-            "X-WR-CALDESC:All of Proto's events, straight from the website!" . "\r\n" .
-            'BEGIN:VTIMEZONE' . "\r\n" .
-            'TZID:Central European Standard Time' . "\r\n" .
-            'BEGIN:STANDARD' . "\r\n" .
-            'DTSTART:20161002T030000' . "\r\n" .
-            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=3;BYMINUTE=0;BYMONTH=10' . "\r\n" .
-            'TZNAME:Central European Standard Time' . "\r\n" .
-            'TZOFFSETFROM:+0200' . "\r\n" .
-            'TZOFFSETTO:+0100' . "\r\n" .
-            'END:STANDARD' . "\r\n" .
-            'BEGIN:DAYLIGHT' . "\r\n" .
-            'DTSTART:20160301T020000' . "\r\n" .
-            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=2;BYMINUTE=0;BYMONTH=3' . "\r\n" .
-            'TZNAME:Central European Daylight Time' . "\r\n" .
-            'TZOFFSETFROM:+0100' . "\r\n" .
-            'TZOFFSETTO:+0200' . "\r\n" .
-            'END:DAYLIGHT' . "\r\n" .
-            'END:VTIMEZONE' . "\r\n";
+'.
+            'X-WR-CALNAME:'.$calendar_name."\r\n".
+            "X-WR-CALDESC:All of Proto's events, straight from the website!"."\r\n".
+            'BEGIN:VTIMEZONE'."\r\n".
+            'TZID:Central European Standard Time'."\r\n".
+            'BEGIN:STANDARD'."\r\n".
+            'DTSTART:20161002T030000'."\r\n".
+            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=3;BYMINUTE=0;BYMONTH=10'."\r\n".
+            'TZNAME:Central European Standard Time'."\r\n".
+            'TZOFFSETFROM:+0200'."\r\n".
+            'TZOFFSETTO:+0100'."\r\n".
+            'END:STANDARD'."\r\n".
+            'BEGIN:DAYLIGHT'."\r\n".
+            'DTSTART:20160301T020000'."\r\n".
+            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=2;BYMINUTE=0;BYMONTH=3'."\r\n".
+            'TZNAME:Central European Daylight Time'."\r\n".
+            'TZOFFSETFROM:+0100'."\r\n".
+            'TZOFFSETTO:+0200'."\r\n".
+            'END:DAYLIGHT'."\r\n".
+            'END:VTIMEZONE'."\r\n";
 
         $reminder = $user?->pref_calendar_alarm;
 
@@ -554,11 +555,11 @@ CALSCALE:GREGORIAN
 
         foreach ($events as $event) {
             /** @var Event $event */
-            if (!$event->mayViewEvent($user)) {
+            if (! $event->mayViewEvent($user)) {
                 continue;
             }
 
-            if (!$event->force_calendar_sync && $relevant_only && !($event->isOrganising($user) || $event->activity?->user_has_tickets || $event->activity?->user_has_helper_participation || $event->activity?->user_has_participation)) {
+            if (! $event->force_calendar_sync && $relevant_only && ! ($event->isOrganising($user) || $event->activity?->user_has_tickets || $event->activity?->user_has_helper_participation || $event->activity?->user_has_participation)) {
                 continue;
             }
 
@@ -567,7 +568,7 @@ CALSCALE:GREGORIAN
             } elseif ($event->activity !== null && $event->activity->participants == -1) {
                 $info_text = 'Sign-up required, but no participant limit.';
             } elseif ($event->activity !== null && $event->activity->participants > 0) {
-                $info_text = 'Sign-up required! There are roughly ' . $event->activity->freeSpots() . ' of ' . $event->activity->participants . ' places left.';
+                $info_text = 'Sign-up required! There are roughly '.$event->activity->freeSpots().' of '.$event->activity->participants.' places left.';
             } elseif ($event->tickets_count > 0) {
                 $info_text = 'Ticket purchase required.';
             } else {
@@ -595,29 +596,29 @@ CALSCALE:GREGORIAN
             }
 
             $calendar .= 'BEGIN:VEVENT
-' .
-                sprintf('UID:%s@proto.utwente.nl', $event->id) . "\r\n" .
-                sprintf('DTSTAMP:%s', gmdate('Ymd\THis\Z', strtotime($event->created_at))) . "\r\n" .
-                sprintf('DTSTART:%s', date('Ymd\THis', $event->start)) . "\r\n" .
-                sprintf('DTEND:%s', date('Ymd\THis', $event->end)) . "\r\n" .
-                sprintf('SUMMARY:%s', empty($status) ? $event->title : sprintf('[%s] %s', $status, $event->title)) . "\r\n" .
-                sprintf('DESCRIPTION:%s', $info_text . ' More information: ' . route('event::show', ['id' => $event->getPublicId()])) . "\r\n" .
-                sprintf('LOCATION:%s', $event->location) . "\r\n" .
+'.
+                sprintf('UID:%s@proto.utwente.nl', $event->id)."\r\n".
+                sprintf('DTSTAMP:%s', gmdate('Ymd\THis\Z', strtotime($event->created_at)))."\r\n".
+                sprintf('DTSTART:%s', date('Ymd\THis', $event->start))."\r\n".
+                sprintf('DTEND:%s', date('Ymd\THis', $event->end))."\r\n".
+                sprintf('SUMMARY:%s', empty($status) ? $event->title : sprintf('[%s] %s', $status, $event->title))."\r\n".
+                sprintf('DESCRIPTION:%s', $info_text.' More information: '.route('event::show', ['id' => $event->getPublicId()]))."\r\n".
+                sprintf('LOCATION:%s', $event->location)."\r\n".
                 sprintf(
                     'ORGANIZER;CN=%s:MAILTO:%s',
                     ($event->committee ? $event->committee->name : 'S.A. Proto'),
                     ($event->committee ? $event->committee->email : 'board@proto.utwente.nl')
-                ) . "\r\n" .
-                sprintf('LAST_UPDATED:%s', gmdate('Ymd\THis\Z', strtotime($event->updated_at))) . "\r\n" .
-                sprintf('SEQUENCE:%s', $event->update_sequence) . "\r\n";
+                )."\r\n".
+                sprintf('LAST_UPDATED:%s', gmdate('Ymd\THis\Z', strtotime($event->updated_at)))."\r\n".
+                sprintf('SEQUENCE:%s', $event->update_sequence)."\r\n";
 
             if ($reminder && $status) {
                 $calendar .= 'BEGIN:VALARM
-' .
-                    sprintf('TRIGGER:-PT%dM', ceil($reminder * 60)) . "\r\n" .
-                    'ACTION:DISPLAY' . "\r\n" .
-                    sprintf('DESCRIPTION:%s at %s', sprintf('[%s] %s', $status, $event->title), date('l F j, H:i:s', $event->start)) . "\r\n" .
-                    'END:VALARM' . "\r\n";
+'.
+                    sprintf('TRIGGER:-PT%dM', ceil($reminder * 60))."\r\n".
+                    'ACTION:DISPLAY'."\r\n".
+                    sprintf('DESCRIPTION:%s at %s', sprintf('[%s] %s', $status, $event->title), date('l F j, H:i:s', $event->start))."\r\n".
+                    'END:VALARM'."\r\n";
             }
 
             $calendar .= 'END:VEVENT
@@ -634,7 +635,7 @@ CALSCALE:GREGORIAN
                 $line = str_replace($search, $replace, $line);
             }
 
-            $calendar_wrapped .= wordwrap($line, 75, "\r\n ", true) . "\r\n";
+            $calendar_wrapped .= wordwrap($line, 75, "\r\n ", true)."\r\n";
         }
 
         return Response::make($calendar_wrapped)
@@ -657,7 +658,7 @@ CALSCALE:GREGORIAN
         $diff = $newDate - $event->start;
 
         $newEvent = $event->withoutRelations()->replicate()->fill([
-            'title' => $event->title . ' [copy]',
+            'title' => $event->title.' [copy]',
             'secret' => $event->publication ? false : $event->secret,
             'start' => $newDate,
             'end' => $event->end + $diff,

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -144,7 +144,7 @@ class EventController extends Controller
         $event->category()->associate($category);
         $event->save();
 
-        Session::flash('flash_message', "Your event '".$event->title."' has been added.");
+        Session::flash('flash_message', "Your event '" . $event->title . "' has been added.");
 
         return Redirect::route('event::show', ['id' => $event->getPublicId()]);
     }
@@ -210,9 +210,9 @@ class EventController extends Controller
         $changed_important_details = $event->start !== strtotime($request->start) || $event->end !== strtotime($request->end) || $event->location != $request->location;
 
         if ($changed_important_details) {
-            Session::flash('flash_message', "Your event '".$event->title."' has been saved. <br><b class='text-warning'>You updated some important information. Don't forget to update your participants with this info!</b>");
+            Session::flash('flash_message', "Your event '" . $event->title . "' has been saved. <br><b class='text-warning'>You updated some important information. Don't forget to update your participants with this info!</b>");
         } else {
-            Session::flash('flash_message', "Your event '".$event->title."' has been saved.");
+            Session::flash('flash_message', "Your event '" . $event->title . "' has been saved.");
         }
 
         return Redirect::back();
@@ -232,10 +232,10 @@ class EventController extends Controller
                 $query->whereHas('Category', static function ($q) use ($category) {
                     $q->where('id', $category->id)->where('deleted_at', null);
                 });
-            })->where('start', '>', strtotime($year.'-01-01 00:00:01'))
-            ->where('start', '<', strtotime($year.'-12-31 23:59:59'))
+            })->where('start', '>', strtotime($year . '-01-01 00:00:01'))
+            ->where('start', '<', strtotime($year . '-12-31 23:59:59'))
             ->get()
-            ->groupBy(fn (Event $event) => Carbon::createFromTimestamp($event->start)->month);
+            ->groupBy(fn(Event $event) => Carbon::createFromTimestamp($event->start)->month);
 
         $years = $this->getAvailableYears();
 
@@ -249,7 +249,7 @@ class EventController extends Controller
 
     private function getAvailableYears(): Collection
     {
-        return Cache::remember('event::availableyears', Carbon::now()->diff(Carbon::now()->endOfDay()), static fn () => collect(DB::select('SELECT DISTINCT Year(FROM_UNIXTIME(start)) AS start FROM events ORDER BY Year(FROM_UNIXTIME(start))'))->pluck('start'));
+        return Cache::remember('event::availableyears', Carbon::now()->diff(Carbon::now()->endOfDay()), static fn() => collect(DB::select('SELECT DISTINCT Year(FROM_UNIXTIME(start)) AS start FROM events ORDER BY Year(FROM_UNIXTIME(start))'))->pluck('start'));
     }
 
     /**
@@ -263,12 +263,12 @@ class EventController extends Controller
         $event = Event::query()->findOrFail($id);
 
         if ($event->activity !== null) {
-            Session::flash('flash_message', "You cannot delete event '".$event->title."' since it has a participation details.");
+            Session::flash('flash_message', "You cannot delete event '" . $event->title . "' since it has a participation details.");
 
             return Redirect::back();
         }
 
-        Session::flash('flash_message', "The event '".$event->title."' has been deleted.");
+        Session::flash('flash_message', "The event '" . $event->title . "' has been deleted.");
 
         $event->delete();
 
@@ -290,7 +290,7 @@ class EventController extends Controller
     {
         $event = Event::query()->findOrFail($id);
 
-        if (! $event->isEventAdmin(Auth::user())) {
+        if (!$event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not an event admin for this event!');
 
             return Redirect::back();
@@ -306,7 +306,7 @@ class EventController extends Controller
     {
         $event = Event::query()->findOrFail($id);
 
-        if (! $event->isEventAdmin(Auth::user())) {
+        if (!$event->isEventAdmin(Auth::user())) {
             Session::flash('flash_message', 'You are not an event admin for this event!');
 
             return Redirect::back();
@@ -323,7 +323,7 @@ class EventController extends Controller
         /** @var Activity $activity */
         $activity = Activity::query()->findOrFail($id);
 
-        if ($activity->event && ! $activity->event->over()) {
+        if ($activity->event && !$activity->event->over()) {
             Session::flash('flash_message', 'You cannot close an activity before it has finished.');
 
             return Redirect::back();
@@ -351,7 +351,7 @@ class EventController extends Controller
 
         $product = Product::query()->create([
             'account_id' => $account->id,
-            'name' => 'Activity: '.($activity->event ? $activity->event->title : $activity->comment),
+            'name' => 'Activity: ' . ($activity->event ? $activity->event->title : $activity->comment),
             'price' => $activity->price,
         ]);
         $product->save();
@@ -370,7 +370,7 @@ class EventController extends Controller
     }
 
     /**
-     * @param  Event  $event
+     * @param Event $event
      * @return RedirectResponse
      */
     public function linkAlbum(Request $request, int $event)
@@ -383,7 +383,7 @@ class EventController extends Controller
         $album->event()->associate($event);
         $album->save();
 
-        Session::flash('flash_message', 'The album '.$album->name.' has been linked to this activity!');
+        Session::flash('flash_message', 'The album ' . $album->name . ' has been linked to this activity!');
 
         return Redirect::back();
     }
@@ -398,7 +398,7 @@ class EventController extends Controller
         $album->event()->dissociate();
         $album->save();
 
-        Session::flash('flash_message', 'The album '.$album->name.' has been unlinked from an activity!');
+        Session::flash('flash_message', 'The album ' . $album->name . ' has been unlinked from an activity!');
 
         return Redirect::back();
     }
@@ -406,29 +406,37 @@ class EventController extends Controller
     public function apiUpcomingEvents(int $limit, Request $request): array
     {
         $user = Auth::user() ?? null;
-        $noFutureLimit = filter_var($request->get('no_future_limit', false), FILTER_VALIDATE_BOOLEAN);
+        $noFutureLimit = $request->boolean('no_future_limit', false);
 
-        $events = Event::query()->where('end', '>', strtotime('today'))->where('start', '<', strtotime($noFutureLimit ? '+10 years' : '+1 month'))->whereNull('publication')->orderBy('start', 'asc')->take($limit)->get();
+        $events = Event::query()
+            ->where('end', '>', strtotime('today'))
+            ->where('start', '<', strtotime($noFutureLimit ? '+10 years' : '+1 month'))
+            ->whereNull('publication')
+            ->orderBy('start')
+            ->with('activity.users.photo', 'activity.backupUsers', 'image', 'committee.users', 'tickets')
+            ->take($limit)
+            ->get();
+
         $data = [];
 
         foreach ($events as $event) {
             if ($event->secret && ($user == null || $event->activity == null || (
-                ! $event->activity->isParticipating($user) &&
-                ! $event->activity->isHelping($user) &&
-                ! $event->activity->isOrganising($user)
-            ))) {
+                        !$event->activity->isParticipating($user) &&
+                        !$event->activity->isHelping($user) &&
+                        !$event->isOrganising($user)
+                    ))) {
                 continue;
             }
 
-            $participants = ($user?->is_member && $event->activity ? $event->activity->users->map(static fn ($item) => (object) [
+            $participants = ($user?->is_member && $event->activity ? $event->activity->users->map(static fn($item) => (object)[
                 'name' => $item->name,
                 'photo' => $item->photo_preview,
             ]) : null);
-            $backupParticipants = ($user?->is_member && $event->activity ? $event->activity->backupUsers->map(static fn ($item) => (object) [
+            $backupParticipants = ($user?->is_member && $event->activity ? $event->activity->backupUsers->map(static fn($item) => (object)[
                 'name' => $item->name,
                 'photo' => $item->photo_preview,
             ]) : null);
-            $data[] = (object) [
+            $data[] = (object)[
                 'id' => $event->id,
                 'title' => $event->title,
                 'image' => ($event->image ? $event->image->generateImagePath(800, 300) : null),
@@ -452,7 +460,7 @@ class EventController extends Controller
                 'price' => ($event->activity ? $event->activity->price : null),
                 'no_show_fee' => ($event->activity ? $event->activity->no_show_fee : null),
                 'user_signedup' => ($user && $event->activity ? $event->activity->isParticipating($user) : null),
-                'user_signedup_backup' => (bool) ($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->backup : null),
+                'user_signedup_backup' => (bool)($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->backup : null),
                 'user_signedup_id' => ($user && $event->activity?->isParticipating($user) ? $event->activity->getParticipation($user)->id : null),
                 'can_signup' => ($user && $event->activity ? $event->activity->canSubscribe() : null),
                 'can_signup_backup' => ($user && $event->activity ? $event->activity->canSubscribeBackup() : null),
@@ -514,42 +522,43 @@ class EventController extends Controller
 VERSION:2.0
 PRODID:-//HYTTIOAOAc//S.A. Proto Calendar//EN
 CALSCALE:GREGORIAN
-'.
-            'X-WR-CALNAME:'.$calendar_name."\r\n".
-            "X-WR-CALDESC:All of Proto's events, straight from the website!"."\r\n".
-            'BEGIN:VTIMEZONE'."\r\n".
-            'TZID:Central European Standard Time'."\r\n".
-            'BEGIN:STANDARD'."\r\n".
-            'DTSTART:20161002T030000'."\r\n".
-            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=3;BYMINUTE=0;BYMONTH=10'."\r\n".
-            'TZNAME:Central European Standard Time'."\r\n".
-            'TZOFFSETFROM:+0200'."\r\n".
-            'TZOFFSETTO:+0100'."\r\n".
-            'END:STANDARD'."\r\n".
-            'BEGIN:DAYLIGHT'."\r\n".
-            'DTSTART:20160301T020000'."\r\n".
-            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=2;BYMINUTE=0;BYMONTH=3'."\r\n".
-            'TZNAME:Central European Daylight Time'."\r\n".
-            'TZOFFSETFROM:+0100'."\r\n".
-            'TZOFFSETTO:+0200'."\r\n".
-            'END:DAYLIGHT'."\r\n".
-            'END:VTIMEZONE'."\r\n";
+' .
+            'X-WR-CALNAME:' . $calendar_name . "\r\n" .
+            "X-WR-CALDESC:All of Proto's events, straight from the website!" . "\r\n" .
+            'BEGIN:VTIMEZONE' . "\r\n" .
+            'TZID:Central European Standard Time' . "\r\n" .
+            'BEGIN:STANDARD' . "\r\n" .
+            'DTSTART:20161002T030000' . "\r\n" .
+            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=3;BYMINUTE=0;BYMONTH=10' . "\r\n" .
+            'TZNAME:Central European Standard Time' . "\r\n" .
+            'TZOFFSETFROM:+0200' . "\r\n" .
+            'TZOFFSETTO:+0100' . "\r\n" .
+            'END:STANDARD' . "\r\n" .
+            'BEGIN:DAYLIGHT' . "\r\n" .
+            'DTSTART:20160301T020000' . "\r\n" .
+            'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYHOUR=2;BYMINUTE=0;BYMONTH=3' . "\r\n" .
+            'TZNAME:Central European Daylight Time' . "\r\n" .
+            'TZOFFSETFROM:+0100' . "\r\n" .
+            'TZOFFSETTO:+0200' . "\r\n" .
+            'END:DAYLIGHT' . "\r\n" .
+            'END:VTIMEZONE' . "\r\n";
 
         $reminder = $user?->pref_calendar_alarm;
 
         $relevant_only = $user?->pref_calendar_relevant_only;
-        $events = Event::query()
-            ->when(! $user, static fn ($query) => $query->where('secret', false))
-            ->with('committee')
+        $events = Event::getEventBlockQuery($user)
             ->where('start', '>', strtotime('-6 months'))
+            ->with('committee.users')
+            ->withCount('tickets')
             ->get();
+
         foreach ($events as $event) {
             /** @var Event $event */
-            if (! $event->mayViewEvent($user)) {
+            if (!$event->mayViewEvent($user)) {
                 continue;
             }
 
-            if (! $event->force_calendar_sync && $relevant_only && ! ($event->isOrganising($user) || $event->hasBoughtTickets($user) || ($event->activity && ($event->activity->isHelping($user) || $event->activity->isParticipating($user))))) {
+            if (!$event->force_calendar_sync && $relevant_only && !($event->isOrganising($user) || $event->activity?->user_has_tickets || $event->activity?->user_has_helper_participation || $event->activity?->user_has_participation)) {
                 continue;
             }
 
@@ -558,8 +567,8 @@ CALSCALE:GREGORIAN
             } elseif ($event->activity !== null && $event->activity->participants == -1) {
                 $info_text = 'Sign-up required, but no participant limit.';
             } elseif ($event->activity !== null && $event->activity->participants > 0) {
-                $info_text = 'Sign-up required! There are roughly '.$event->activity->freeSpots().' of '.$event->activity->participants.' places left.';
-            } elseif ($event->tickets->count() > 0) {
+                $info_text = 'Sign-up required! There are roughly ' . $event->activity->freeSpots() . ' of ' . $event->activity->participants . ' places left.';
+            } elseif ($event->tickets_count > 0) {
                 $info_text = 'Ticket purchase required.';
             } else {
                 $info_text = 'No sign-up necessary.';
@@ -572,13 +581,13 @@ CALSCALE:GREGORIAN
                     $status = 'Organizing';
                     $info_text .= ' You are organizing this activity.';
                 } elseif ($event->activity) {
-                    if ($event->activity->isHelping($user)) {
+                    if ($event->activity->user_has_helper_participation) {
                         $status = 'Helping';
                         $info_text .= ' You are helping with this activity.';
-                    } elseif ($event->activity->isOnBackupList($user)) {
+                    } elseif ($event->activity->user_has_backup_participation) {
                         $status = 'On back-up list';
                         $info_text .= ' You are on the back-up list for this activity';
-                    } elseif ($event->activity->isParticipating($user) || $event->hasBoughtTickets($user)) {
+                    } elseif ($event->activity->user_has_participation || $event->user_has_tickets) {
                         $status = 'Participating';
                         $info_text .= ' You are participating in this activity.';
                     }
@@ -586,29 +595,29 @@ CALSCALE:GREGORIAN
             }
 
             $calendar .= 'BEGIN:VEVENT
-'.
-                sprintf('UID:%s@proto.utwente.nl', $event->id)."\r\n".
-                sprintf('DTSTAMP:%s', gmdate('Ymd\THis\Z', strtotime($event->created_at)))."\r\n".
-                sprintf('DTSTART:%s', date('Ymd\THis', $event->start))."\r\n".
-                sprintf('DTEND:%s', date('Ymd\THis', $event->end))."\r\n".
-                sprintf('SUMMARY:%s', empty($status) ? $event->title : sprintf('[%s] %s', $status, $event->title))."\r\n".
-                sprintf('DESCRIPTION:%s', $info_text.' More information: '.route('event::show', ['id' => $event->getPublicId()]))."\r\n".
-                sprintf('LOCATION:%s', $event->location)."\r\n".
+' .
+                sprintf('UID:%s@proto.utwente.nl', $event->id) . "\r\n" .
+                sprintf('DTSTAMP:%s', gmdate('Ymd\THis\Z', strtotime($event->created_at))) . "\r\n" .
+                sprintf('DTSTART:%s', date('Ymd\THis', $event->start)) . "\r\n" .
+                sprintf('DTEND:%s', date('Ymd\THis', $event->end)) . "\r\n" .
+                sprintf('SUMMARY:%s', empty($status) ? $event->title : sprintf('[%s] %s', $status, $event->title)) . "\r\n" .
+                sprintf('DESCRIPTION:%s', $info_text . ' More information: ' . route('event::show', ['id' => $event->getPublicId()])) . "\r\n" .
+                sprintf('LOCATION:%s', $event->location) . "\r\n" .
                 sprintf(
                     'ORGANIZER;CN=%s:MAILTO:%s',
                     ($event->committee ? $event->committee->name : 'S.A. Proto'),
                     ($event->committee ? $event->committee->email : 'board@proto.utwente.nl')
-                )."\r\n".
-                sprintf('LAST_UPDATED:%s', gmdate('Ymd\THis\Z', strtotime($event->updated_at)))."\r\n".
-                sprintf('SEQUENCE:%s', $event->update_sequence)."\r\n";
+                ) . "\r\n" .
+                sprintf('LAST_UPDATED:%s', gmdate('Ymd\THis\Z', strtotime($event->updated_at))) . "\r\n" .
+                sprintf('SEQUENCE:%s', $event->update_sequence) . "\r\n";
 
             if ($reminder && $status) {
                 $calendar .= 'BEGIN:VALARM
-'.
-                    sprintf('TRIGGER:-PT%dM', ceil($reminder * 60))."\r\n".
-                    'ACTION:DISPLAY'."\r\n".
-                    sprintf('DESCRIPTION:%s at %s', sprintf('[%s] %s', $status, $event->title), date('l F j, H:i:s', $event->start))."\r\n".
-                    'END:VALARM'."\r\n";
+' .
+                    sprintf('TRIGGER:-PT%dM', ceil($reminder * 60)) . "\r\n" .
+                    'ACTION:DISPLAY' . "\r\n" .
+                    sprintf('DESCRIPTION:%s at %s', sprintf('[%s] %s', $status, $event->title), date('l F j, H:i:s', $event->start)) . "\r\n" .
+                    'END:VALARM' . "\r\n";
             }
 
             $calendar .= 'END:VEVENT
@@ -625,7 +634,7 @@ CALSCALE:GREGORIAN
                 $line = str_replace($search, $replace, $line);
             }
 
-            $calendar_wrapped .= wordwrap($line, 75, "\r\n ", true)."\r\n";
+            $calendar_wrapped .= wordwrap($line, 75, "\r\n ", true) . "\r\n";
         }
 
         return Response::make($calendar_wrapped)
@@ -648,7 +657,7 @@ CALSCALE:GREGORIAN
         $diff = $newDate - $event->start;
 
         $newEvent = $event->withoutRelations()->replicate()->fill([
-            'title' => $event->title.' [copy]',
+            'title' => $event->title . ' [copy]',
             'secret' => $event->publication ? false : $event->secret,
             'start' => $newDate,
             'end' => $event->end + $diff,

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -39,7 +39,7 @@ class HomeController extends Controller
             ->take(4)
             ->get();
 
-        if (!Auth::user()?->is_member) {
+        if (! Auth::user()?->is_member) {
             return view('website.home.external', ['companies' => $companies, 'header' => $header, 'albums' => $albums]);
         }
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -39,7 +39,7 @@ class HomeController extends Controller
             ->take(4)
             ->get();
 
-        if (! Auth::user()?->is_member) {
+        if (!Auth::user()?->is_member) {
             return view('website.home.external', ['companies' => $companies, 'header' => $header, 'albums' => $albums]);
         }
 
@@ -65,6 +65,7 @@ class HomeController extends Controller
             })
             ->where('show_birthday', true)
             ->where('birthdate', 'LIKE', date('%-m-d'))
+            ->with('photo')
             ->get();
 
         $dinnerforms = Dinnerform::query()

--- a/app/Http/Controllers/OmNomController.php
+++ b/app/Http/Controllers/OmNomController.php
@@ -24,7 +24,6 @@ class OmNomController extends Controller
 {
     public function display(Request $request, ?string $store_slug = null)
     {
-
         if (empty($store_slug) && Auth::user()?->canAny(collect(Config::array('omnomcom.stores'))->pluck('roles')->flatten())) {
             return view('omnomcom.choose');
         }
@@ -41,8 +40,7 @@ class OmNomController extends Controller
             abort(403);
         }
 
-        $categories = $this->getCategories($store);
-
+        $categories = ProductCategory::query()->whereIn('id', $store['categories'])->with('sortedProducts.image')->get();
         $minors = collect();
 
         if ($store_slug === 'tipcie') {
@@ -51,6 +49,7 @@ class OmNomController extends Controller
                 ->whereHas('member', static function ($q) {
                     $q->whereNot('membership_type', MembershipTypeEnum::PENDING)->whereNot('membership_type', MembershipTypeEnum::PET);
                 })
+                ->with('photo')
                 ->get();
         }
 
@@ -96,12 +95,12 @@ class OmNomController extends Controller
             abort(403);
         }
 
-        $categories = $this->getCategories($store);
+        $categories = ProductCategory::query()->whereIn('id', $store['categories'])->with('sortedProducts.image')->get();
 
         $products = [];
         foreach ($categories as $category) {
             /** @var Product $product */
-            foreach ($category->products as $product) {
+            foreach ($category->sortedProducts as $product) {
                 if ($product->isVisible()) {
                     $products[] = $product;
                 }
@@ -325,22 +324,5 @@ class OmNomController extends Controller
         }
 
         return view('omnomcom.products.generateorder', ['orders' => $orders]);
-    }
-
-    private function getCategories(array $store): array
-    {
-        $categories = [];
-        foreach ($store['categories'] as $category) {
-            $cat = ProductCategory::query()->find($category);
-            if ($cat) {
-                $prods = $cat->sortedProducts();
-                $categories[] = (object) [
-                    'category' => $cat,
-                    'products' => $prods,
-                ];
-            }
-        }
-
-        return $categories;
     }
 }

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -52,7 +52,7 @@ class SearchController extends Controller
         if ($presearch_pages) {
             foreach ($presearch_pages as $page) {
                 /** @var Page $page */
-                if (!$page->is_member_only || Auth::user()?->is_member) {
+                if (! $page->is_member_only || Auth::user()?->is_member) {
                     $pages[] = $page;
                 }
             }
@@ -98,7 +98,7 @@ class SearchController extends Controller
         if ($presearch_photo_albums) {
             foreach ($presearch_photo_albums as $album) {
                 /** @var PhotoAlbum $album */
-                if (!$album->private || Auth::user()?->can('protography')) {
+                if (! $album->private || Auth::user()?->can('protography')) {
                     $photoAlbums[] = $album;
                 }
             }
@@ -116,7 +116,7 @@ class SearchController extends Controller
 
     public function ldapSearch(Request $request)
     {
-        if (!$request->has('query')) {
+        if (! $request->has('query')) {
             Session::flash('flash_message', 'Please include a search query.');
 
             return Redirect::back();
@@ -154,7 +154,7 @@ class SearchController extends Controller
         $result = LdapController::searchUtwente($search);
         // check that we have a valid response
         if (isset($result->error)) {
-            Session::flash('flash_message', 'Something went wrong while searching the UT LDAP server.' . ($result->error ? ' ' . $result->error : ''));
+            Session::flash('flash_message', 'Something went wrong while searching the UT LDAP server.'.($result->error ? ' '.$result->error : ''));
 
             return Redirect::back();
         }
@@ -177,7 +177,7 @@ class SearchController extends Controller
         $users = $this->getGenericSearchQuery(User::class, $request->get('q'), $search_attributes)?->with('photo')->get() ?? [];
         foreach ($users as $user) {
             /** @var User $user */
-            $result[] = (object)[
+            $result[] = (object) [
                 'id' => $user->id,
                 'name' => $user->name,
                 'is_member' => $user->is_member,
@@ -233,7 +233,7 @@ class SearchController extends Controller
             $check_at_least_one_valid_term = true;
         }
 
-        if (!$check_at_least_one_valid_term) {
+        if (! $check_at_least_one_valid_term) {
             return null;
         }
 

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -31,7 +31,7 @@ class SearchController extends Controller
                 User::class,
                 $term,
                 Auth::user()->can('board') ? ['id', 'name', 'calling_name', 'utwente_username', 'email'] : ['id', 'name', 'calling_name', 'email']
-            )?->get();
+            )?->with('photo')->get();
 
             if ($presearch_users) {
                 foreach ($presearch_users as $user) {
@@ -52,7 +52,7 @@ class SearchController extends Controller
         if ($presearch_pages) {
             foreach ($presearch_pages as $page) {
                 /** @var Page $page */
-                if (! $page->is_member_only || Auth::user()?->is_member) {
+                if (!$page->is_member_only || Auth::user()?->is_member) {
                     $pages[] = $page;
                 }
             }
@@ -98,7 +98,7 @@ class SearchController extends Controller
         if ($presearch_photo_albums) {
             foreach ($presearch_photo_albums as $album) {
                 /** @var PhotoAlbum $album */
-                if (! $album->private || Auth::user()?->can('protography')) {
+                if (!$album->private || Auth::user()?->can('protography')) {
                     $photoAlbums[] = $album;
                 }
             }
@@ -116,7 +116,7 @@ class SearchController extends Controller
 
     public function ldapSearch(Request $request)
     {
-        if (! $request->has('query')) {
+        if (!$request->has('query')) {
             Session::flash('flash_message', 'Please include a search query.');
 
             return Redirect::back();
@@ -154,7 +154,7 @@ class SearchController extends Controller
         $result = LdapController::searchUtwente($search);
         // check that we have a valid response
         if (isset($result->error)) {
-            Session::flash('flash_message', 'Something went wrong while searching the UT LDAP server.'.($result->error ? ' '.$result->error : ''));
+            Session::flash('flash_message', 'Something went wrong while searching the UT LDAP server.' . ($result->error ? ' ' . $result->error : ''));
 
             return Redirect::back();
         }
@@ -174,9 +174,10 @@ class SearchController extends Controller
     {
         $search_attributes = ['id', 'name', 'calling_name', 'utwente_username', 'email'];
         $result = [];
-        foreach ($this->getGenericSearchQuery(User::class, $request->get('q'), $search_attributes)?->get() ?? [] as $user) {
+        $users = $this->getGenericSearchQuery(User::class, $request->get('q'), $search_attributes)?->with('photo')->get() ?? [];
+        foreach ($users as $user) {
             /** @var User $user */
-            $result[] = (object) [
+            $result[] = (object)[
                 'id' => $user->id,
                 'name' => $user->name,
                 'is_member' => $user->is_member,
@@ -232,7 +233,7 @@ class SearchController extends Controller
             $check_at_least_one_valid_term = true;
         }
 
-        if (! $check_at_least_one_valid_term) {
+        if (!$check_at_least_one_valid_term) {
             return null;
         }
 

--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -14,7 +14,8 @@ class WelcomeController extends Controller
     /** @return View */
     public function index()
     {
-        return view('welcomemessages.list', ['messages' => WelcomeMessage::query()->orderBy('created_at', 'desc')->get()]);
+        $messages = WelcomeMessage::query()->orderBy('created_at', 'desc')->with('user')->get();
+        return view('welcomemessages.list', ['messages' => $messages]);
     }
 
     /**
@@ -27,7 +28,7 @@ class WelcomeController extends Controller
             'message' => 'required|string',
         ]);
         $message = WelcomeMessage::query()->where('user_id', $request->user_id)->first();
-        if (! $message) {
+        if (!$message) {
             $message = new WelcomeMessage;
             $message->user_id = $request->user_id;
             $message->message = $request->message;

--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -15,6 +15,7 @@ class WelcomeController extends Controller
     public function index()
     {
         $messages = WelcomeMessage::query()->orderBy('created_at', 'desc')->with('user')->get();
+
         return view('welcomemessages.list', ['messages' => $messages]);
     }
 
@@ -28,7 +29,7 @@ class WelcomeController extends Controller
             'message' => 'required|string',
         ]);
         $message = WelcomeMessage::query()->where('user_id', $request->user_id)->first();
-        if (!$message) {
+        if (! $message) {
             $message = new WelcomeMessage;
             $message->user_id = $request->user_id;
             $message->message = $request->message;

--- a/app/Http/Middleware/EnforceTFA.php
+++ b/app/Http/Middleware/EnforceTFA.php
@@ -18,7 +18,7 @@ class EnforceTFA
      */
     public function handle(Request $request, Closure $next): mixed
     {
-        if (App::environment('production') && Auth::check() && (Auth::user()->hasRole(Config::array('proto.tfaroles')) || Auth::user()->isInCommittee(Committee::whereSlug(Config::string('proto.rootcommittee'))->firstOrFail())) && ! Auth::user()->hasTFAEnabled() && (! $request->is('user/dashboard') && ! $request->is('auth/logout') && ! $request->is('user/quit_impersonating') && ! $request->is('user/*/2fa/*') && ! $request->is('user/2fa/*') && ! $request->is('api/*'))) {
+        if (App::environment('production') && Auth::check() && (Auth::user()->hasRole(Config::array('proto.tfaroles')) || Committee::whereSlug(Config::string('proto.rootcommittee'))->firstOrFail()?->isMember(Auth::user())) && ! Auth::user()->hasTFAEnabled() && (! $request->is('user/dashboard') && ! $request->is('auth/logout') && ! $request->is('user/quit_impersonating') && ! $request->is('user/*/2fa/*') && ! $request->is('user/2fa/*') && ! $request->is('api/*'))) {
             Session::flash('flash_message', 'Your account permissions require you to enable Two Factor Authentication on your account before being able to use your account.');
 
             return Redirect::route('user::dashboard::show', ['#2fa']);

--- a/app/Models/ActivityParticipation.php
+++ b/app/Models/ActivityParticipation.php
@@ -56,20 +56,17 @@ class ActivityParticipation extends Model
 
     protected $guarded = ['id'];
 
-    /** @return BelongsTo */
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class)->withTrashed();
     }
 
-    /** @return BelongsTo */
-    public function activity()
+    public function activity(): BelongsTo
     {
         return $this->belongsTo(Activity::class);
     }
 
-    /** @return BelongsTo */
-    public function help()
+    public function help(): BelongsTo
     {
         return $this->belongsTo(HelpingCommittee::class, 'committees_activities_id');
     }

--- a/app/Models/Committee.php
+++ b/app/Models/Committee.php
@@ -97,16 +97,13 @@ class Committee extends Model
 
     public function getEmailAttribute(): string
     {
-        return $this->slug . '@' . Config::string('proto.emaildomain');
+        return $this->slug.'@'.Config::string('proto.emaildomain');
     }
 
-    /**
-     * @return Builder
-     */
     public function pastEvents(): Builder
     {
         return $this->organizedEvents()->where('end', '<', time())->orderBy('start', 'desc')
-            ->when(!Auth::user()?->can('board'), static function ($q) {
+            ->unless(Auth::user()?->can('board'), static function ($q) {
                 $q->where('secret', '=', 0);
             });
     }
@@ -153,7 +150,7 @@ class Committee extends Model
             if ($membership->edition) {
                 $members['editions'][$membership->edition][] = $membership;
             } elseif (strtotime($membership->created_at) < date('U') &&
-                (!$membership->deleted_at || strtotime($membership->deleted_at) > date('U'))) {
+                (! $membership->deleted_at || strtotime($membership->deleted_at) > date('U'))) {
                 $members['members']['current'][] = $membership;
             } elseif (strtotime($membership->created_at) > date('U')) {
                 $members['members']['future'][] = $membership;
@@ -170,6 +167,6 @@ class Committee extends Model
      */
     public function isMember(User $user): bool
     {
-        return $user->isInCommittee($this);
+        return $this->users->where('users.id', $user->id)->count() > 0;
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -140,12 +140,12 @@ class Event extends Model
         }
 
         // show non-secret events only when published
-        return ! $this->secret && (! $this->publication || $this->isPublished());
+        return !$this->secret && (!$this->publication || $this->isPublished());
     }
 
     public static function getEventBlockQuery(?User $user = null): Builder
     {
-        if (! $user instanceof User) {
+        if (!$user instanceof User) {
             $user = Auth::user();
         }
 
@@ -154,11 +154,11 @@ class Event extends Model
             ->with('image')
             ->with('activity', static function ($e) use ($user) {
                 $e->withExists(['backupUsers as user_has_backup_participation' => static function ($q) use ($user) {
-                    $q->where('user_id', $user->id);
+                    $q->where('user_id', $user?->id);
                 }, 'helpingParticipations as user_has_helper_participation' => static function ($q) use ($user) {
-                    $q->where('user_id', $user->id);
+                    $q->where('user_id', $user?->id);
                 }, 'participation as user_has_participation' => static function ($q) use ($user) {
-                    $q->where('user_id', $user->id)
+                    $q->where('user_id', $user?->id)
                         ->whereNull('committees_activities_id');
                 },
                 ])->withCount([
@@ -166,7 +166,7 @@ class Event extends Model
                 ]);
             })->withExists(['tickets as user_has_tickets' => static function ($q) use ($user) {
                 $q->whereHas('purchases', static function ($q) use ($user) {
-                    $q->where('user_id', $user->id);
+                    $q->where('user_id', $user?->id);
                 });
             }]);
     }
@@ -241,20 +241,20 @@ class Event extends Model
     }
 
     /**
-     * @param  string  $long_format  Format when timespan is larger than 24 hours.
-     * @param  string  $short_format  Format when timespan is smaller than 24 hours.
-     * @param  string  $combiner  Character to separate start and end time.
+     * @param string $long_format Format when timespan is larger than 24 hours.
+     * @param string $short_format Format when timespan is smaller than 24 hours.
+     * @param string $combiner Character to separate start and end time.
      * @return string Timespan text in given format
      */
     public function generateTimespanText(string $long_format, string $short_format, string $combiner): string
     {
-        return date($long_format, $this->start).' '.$combiner.' '.(
+        return date($long_format, $this->start) . ' ' . $combiner . ' ' . (
             (($this->end - $this->start) < 3600 * 24)
                 ?
                 date($short_format, $this->end)
                 :
                 date($long_format, $this->end)
-        );
+            );
     }
 
     /**
@@ -286,7 +286,7 @@ class Event extends Model
             return false;
         }
 
-        if (! $this->activity) {
+        if (!$this->activity) {
             return false;
         }
 
@@ -295,9 +295,9 @@ class Event extends Model
             ->where('committee_id', Config::integer('proto.committee.ero'))->first();
         if ($eroHelping) {
             return ActivityParticipation::query()
-                ->where('activity_id', $this->activity->id)
-                ->where('committees_activities_id', $eroHelping->id)
-                ->where('user_id', $user->id)->count() > 0;
+                    ->where('activity_id', $this->activity->id)
+                    ->where('committees_activities_id', $eroHelping->id)
+                    ->where('user_id', $user->id)->count() > 0;
         }
 
         return false;
@@ -320,12 +320,12 @@ class Event extends Model
 
         if ($this->activity) {
             $users = $users->merge($this->activity->allUsers->sort(static function ($a, $b): int {
-                return (int) isset($a->pivot->committees_activities_id);
+                return (int)isset($a->pivot->committees_activities_id);
                 // prefer helper participation registration
             })->unique());
         }
 
-        return $users->sort(static fn ($a, $b): int => strcmp($a->name, $b->name));
+        return $users->sort(static fn($a, $b): int => strcmp($a->name, $b->name));
     }
 
     // recounts the unique users on an event to make the fetching of the event_block way faster
@@ -364,7 +364,7 @@ class Event extends Model
 
     public function getFormattedDateAttribute(): object
     {
-        return (object) [
+        return (object)[
             'simple' => date('M d, Y', $this->start),
             'year' => date('Y', $this->start),
             'month' => date('M Y', $this->start),

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -140,12 +140,12 @@ class Event extends Model
         }
 
         // show non-secret events only when published
-        return !$this->secret && (!$this->publication || $this->isPublished());
+        return ! $this->secret && (! $this->publication || $this->isPublished());
     }
 
     public static function getEventBlockQuery(?User $user = null): Builder
     {
-        if (!$user instanceof User) {
+        if (! $user instanceof User) {
             $user = Auth::user();
         }
 
@@ -241,20 +241,20 @@ class Event extends Model
     }
 
     /**
-     * @param string $long_format Format when timespan is larger than 24 hours.
-     * @param string $short_format Format when timespan is smaller than 24 hours.
-     * @param string $combiner Character to separate start and end time.
+     * @param  string  $long_format  Format when timespan is larger than 24 hours.
+     * @param  string  $short_format  Format when timespan is smaller than 24 hours.
+     * @param  string  $combiner  Character to separate start and end time.
      * @return string Timespan text in given format
      */
     public function generateTimespanText(string $long_format, string $short_format, string $combiner): string
     {
-        return date($long_format, $this->start) . ' ' . $combiner . ' ' . (
+        return date($long_format, $this->start).' '.$combiner.' '.(
             (($this->end - $this->start) < 3600 * 24)
                 ?
                 date($short_format, $this->end)
                 :
                 date($long_format, $this->end)
-            );
+        );
     }
 
     /**
@@ -286,7 +286,7 @@ class Event extends Model
             return false;
         }
 
-        if (!$this->activity) {
+        if (! $this->activity) {
             return false;
         }
 
@@ -295,9 +295,9 @@ class Event extends Model
             ->where('committee_id', Config::integer('proto.committee.ero'))->first();
         if ($eroHelping) {
             return ActivityParticipation::query()
-                    ->where('activity_id', $this->activity->id)
-                    ->where('committees_activities_id', $eroHelping->id)
-                    ->where('user_id', $user->id)->count() > 0;
+                ->where('activity_id', $this->activity->id)
+                ->where('committees_activities_id', $eroHelping->id)
+                ->where('user_id', $user->id)->count() > 0;
         }
 
         return false;
@@ -320,12 +320,12 @@ class Event extends Model
 
         if ($this->activity) {
             $users = $users->merge($this->activity->allUsers->sort(static function ($a, $b): int {
-                return (int)isset($a->pivot->committees_activities_id);
+                return (int) isset($a->pivot->committees_activities_id);
                 // prefer helper participation registration
             })->unique());
         }
 
-        return $users->sort(static fn($a, $b): int => strcmp($a->name, $b->name));
+        return $users->sort(static fn ($a, $b): int => strcmp($a->name, $b->name));
     }
 
     // recounts the unique users on an event to make the fetching of the event_block way faster
@@ -364,7 +364,7 @@ class Event extends Model
 
     public function getFormattedDateAttribute(): object
     {
-        return (object)[
+        return (object) [
             'simple' => date('M d, Y', $this->start),
             'year' => date('Y', $this->start),
             'month' => date('M Y', $this->start),

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -135,7 +135,7 @@ class Event extends Model
         }
 
         // only show secret events if the user is participating, helping or organising
-        if ($this->secret && ($user instanceof User && $this->activity && ($this->activity->isParticipating($user) || $this->activity->isHelping($user) || $this->activity->isOrganising($user)))) {
+        if ($this->secret && ($user instanceof User && $this->activity && ($this->activity->isParticipating($user) || $this->activity->isHelping($user) || $this->isOrganising($user)))) {
             return true;
         }
 
@@ -143,26 +143,30 @@ class Event extends Model
         return ! $this->secret && (! $this->publication || $this->isPublished());
     }
 
-    public static function getEventBlockQuery(): Builder
+    public static function getEventBlockQuery(?User $user = null): Builder
     {
+        if (! $user instanceof User) {
+            $user = Auth::user();
+        }
+
         return Event::query()
             ->orderBy('start')
             ->with('image')
-            ->with('activity', static function ($e) {
-                $e->withExists(['backupUsers as user_has_backup_participation' => static function ($q) {
-                    $q->where('user_id', Auth::id());
-                }, 'helpingParticipations as user_has_helper_participation' => static function ($q) {
-                    $q->where('user_id', Auth::id());
-                }, 'participation as user_has_participation' => static function ($q) {
-                    $q->where('user_id', Auth::id())
+            ->with('activity', static function ($e) use ($user) {
+                $e->withExists(['backupUsers as user_has_backup_participation' => static function ($q) use ($user) {
+                    $q->where('user_id', $user->id);
+                }, 'helpingParticipations as user_has_helper_participation' => static function ($q) use ($user) {
+                    $q->where('user_id', $user->id);
+                }, 'participation as user_has_participation' => static function ($q) use ($user) {
+                    $q->where('user_id', $user->id)
                         ->whereNull('committees_activities_id');
                 },
                 ])->withCount([
                     'users',
                 ]);
-            })->withExists(['tickets as user_has_tickets' => static function ($q) {
-                $q->whereHas('purchases', static function ($q) {
-                    $q->where('user_id', Auth::id());
+            })->withExists(['tickets as user_has_tickets' => static function ($q) use ($user) {
+                $q->whereHas('purchases', static function ($q) use ($user) {
+                    $q->where('user_id', $user->id);
                 });
             }]);
     }
@@ -212,7 +216,7 @@ class Event extends Model
      */
     public function isOrganising(User $user): bool
     {
-        return $this->committee && $user->isInCommittee($this->committee);
+        return $this->committee?->isMember($user) ?? false;
     }
 
     /** @return Collection|TicketPurchase[] */

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -61,19 +61,16 @@ class Page extends Model
 
     protected $with = ['featuredImage'];
 
-    /** @return BelongsTo */
     public function featuredImage(): BelongsTo
     {
         return $this->belongsTo(StorageEntry::class, 'featured_image_id');
     }
 
-    /** @return BelongsToMany */
     public function files(): BelongsToMany
     {
         return $this->belongsToMany(StorageEntry::class, 'pages_files', 'page_id', 'file_id');
     }
 
-    /** @return string */
     public function getUrl(): string
     {
         return route('page::show', $this->slug);

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -59,20 +59,22 @@ class Page extends Model
 
     protected $guarded = ['id'];
 
+    protected $with = ['featuredImage'];
+
     /** @return BelongsTo */
-    public function featuredImage()
+    public function featuredImage(): BelongsTo
     {
         return $this->belongsTo(StorageEntry::class, 'featured_image_id');
     }
 
     /** @return BelongsToMany */
-    public function files()
+    public function files(): BelongsToMany
     {
         return $this->belongsToMany(StorageEntry::class, 'pages_files', 'page_id', 'file_id');
     }
 
     /** @return string */
-    public function getUrl()
+    public function getUrl(): string
     {
         return route('page::show', $this->slug);
     }

--- a/app/Models/ProductCategory.php
+++ b/app/Models/ProductCategory.php
@@ -44,17 +44,14 @@ class ProductCategory extends Model
 
     protected $guarded = ['id'];
 
-    /** @return BelongsToMany */
-    public function products()
+    public function products(): BelongsToMany
     {
         return $this->belongsToMany(Product::class, 'products_categories', 'category_id', 'product_id');
     }
 
-    public function sortedProducts()
+    public function sortedProducts(): BelongsToMany
     {
-        $products = $this->belongsToMany(Product::class, 'products_categories', 'category_id', 'product_id')->get();
-
-        return $products->sortBy('name');
+        return $this->products()->orderBy('name');
     }
 
     #[Override]

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -106,11 +106,8 @@ class Ticket extends Model
 
     public function turnover(): int|float
     {
-        $total = 0;
-        foreach ($this->purchases as $purchase) {
-            $total += $purchase->orderline->total_price;
-        }
-
-        return $total;
+        return OrderLine::query()->whereHas('ticketPurchase', function ($query) {
+            $query->where('ticket_id', $this->id);
+        })->sum('total_price');
     }
 }

--- a/app/Models/TicketPurchase.php
+++ b/app/Models/TicketPurchase.php
@@ -51,8 +51,7 @@ class TicketPurchase extends Model
         return $this->belongsTo(Ticket::class, 'ticket_id');
     }
 
-    /** @return BelongsTo */
-    public function orderline()
+    public function orderline(): BelongsTo
     {
         return $this->belongsTo(OrderLine::class, 'orderline_id');
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -379,14 +379,7 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
 
     public function isInCommittee(Committee $committee): bool
     {
-        return $committee->users()->where('user_id', $this->id)->exists();
-    }
-
-    public function isInCommitteeBySlug(string $slug): bool
-    {
-        $committee = Committee::query()->where('slug', $slug)->first();
-
-        return $committee && $this->isInCommittee($committee);
+        return $committee->users->where('user_id', $this->id)->exists();
     }
 
     public function isActiveMember(): bool

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -20,7 +20,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Paginator::useBootstrapFive();
 
-        Model::preventLazyLoading(!app()->isProduction());
+        Model::preventLazyLoading(! app()->isProduction());
         view()->composer('*', function ($view) {
             view()->share('viewName', Str::replace('.', '-', $view->getName()));
         });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\MenuItem;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
@@ -19,6 +20,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Paginator::useBootstrapFive();
 
+        Model::preventLazyLoading(!app()->isProduction());
         view()->composer('*', function ($view) {
             view()->share('viewName', Str::replace('.', '-', $view->getName()));
         });

--- a/resources/views/committee/include/organised-events.blade.php
+++ b/resources/views/committee/include/organised-events.blade.php
@@ -19,7 +19,7 @@
     </div>
 @endif
 
-@if (count($pastEvents) > 0)
+@if ($pastEvents->count() > 0)
     <div class="card mb-3">
         <div class="card-header bg-dark text-white">Previously organised</div>
 
@@ -42,10 +42,10 @@
 @endif
 
 @php
-    $pastHelpedEvents = $committee->pastHelpedEvents(6);
+    $pastHelpedEvents = $committee->pastHelpedEvents()->take(6);
 @endphp
 
-@if (count($pastHelpedEvents) > 0)
+@if ($pastHelpedEvents->count() > 0)
     <div class="card mb-3">
         <div class="card-header bg-dark text-white">
             Events previously helped at

--- a/resources/views/event/admin.blade.php
+++ b/resources/views/event/admin.blade.php
@@ -1,5 +1,9 @@
 @extends('website.layouts.redesign.generic')
 
+@php
+    /** @var App\Models\Event $event */
+@endphp
+
 @section('page-title')
     Event Admin
 @endsection

--- a/resources/views/event/display_includes/helpers.blade.php
+++ b/resources/views/event/display_includes/helpers.blade.php
@@ -10,72 +10,72 @@
                     <strong>
                         {{ $instance->committee->name }}
                         @if ($instance->committee->isMember(Auth::user()) || Auth::user()->can('board'))
-                            ({{ $instance->users->count() }}/{{ $instance->amount }})
+                                ({{ $instance->users->count() }}/{{ $instance->amount }})
                         @endif
                     </strong>
 
-                @if ($event->activity->helpingUsers($instance->id)->count() < 1)
-                    <p class="card-text">
-                        No people are currently helping.
-                    </p>
-                @else
-                    @include(
-                        'event.display_includes.render_participant_list',
-                        [
-                            'participants' => $event->activity->helpingUsers($instance->id),
-                            'event' => $event,
-                        ]
-                    )
-                @endif
-
-                @if (! $event->activity->closed && $instance->committee->isMember(Auth::user()))
-                    @if ($event->activity->getHelpingParticipation($instance->committee, Auth::user()) !== null)
-                        <a
-                            class="btn btn-outline-warning btn-block mt-1"
-                            href="{{ route('event::deleteparticipation', ['participation_id' => $event->activity->getHelpingParticipation($instance->committee, Auth::user())->id]) }}"
-                        >
-                            I won't help anymore.
-                        </a>
-                    @elseif ($instance->users->count() < $instance->amount)
-                        <a
-                            class="btn btn-outline-success btn-block mt-1"
-                            href="{{ route('event::addparticipation', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
-                        >
-                            I'll help!
-                        </a>
+                    @if ($event->activity->helpingUsers($instance->id)->count() < 1)
+                        <p class="card-text">
+                            No people are currently helping.
+                        </p>
+                    @else
+                        @include(
+                            'event.display_includes.render_participant_list',
+                            [
+                                'participants' => $event->activity->helpingUsers($instance->id),
+                                'event' => $event,
+                            ]
+                        )
                     @endif
-                @endif
 
-                @if (Auth::user()->can('board') && ! $event->activity->closed)
-                    <form
-                        class="form-horizontal mt-2"
-                        method="post"
-                        action="{{ route('event::addparticipationfor', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
-                    >
-                        {{ csrf_field() }}
+                    @if (! $event->activity->closed && $instance->committee->isMember(Auth::user()))
+                        @if ($event->activity->getHelperParticipation(Auth::user(), $instance) !== null)
+                            <a
+                                class="btn btn-outline-warning btn-block mt-1"
+                                href="{{ route('event::deleteparticipation', ['participation_id' => $event->activity->getHelperParticipation(Auth::user(), $instance)->id]) }}"
+                            >
+                                I won't help anymore.
+                            </a>
+                        @elseif ($instance->users->count() < $instance->amount)
+                            <a
+                                class="btn btn-outline-success btn-block mt-1"
+                                href="{{ route('event::addparticipation', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
+                            >
+                                I'll help!
+                            </a>
+                        @endif
+                    @endif
 
-                        <div class="row mb-3">
-                            <div class="col-9">
-                                <div class="form-group autocomplete">
-                                    <input
-                                        class="form-control user-search"
-                                        name="user_id"
-                                        required
-                                    />
+                    @if (Auth::user()->can('board') && ! $event->activity->closed)
+                        <form
+                            class="form-horizontal mt-2"
+                            method="post"
+                            action="{{ route('event::addparticipationfor', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
+                        >
+                            {{ csrf_field() }}
+
+                            <div class="row mb-3">
+                                <div class="col-9">
+                                    <div class="form-group autocomplete">
+                                        <input
+                                            class="form-control user-search"
+                                            name="user_id"
+                                            required
+                                        />
+                                    </div>
+                                </div>
+                                <div class="col-3">
+                                    <button
+                                        class="btn btn-outline-primary btn-block"
+                                        type="submit"
+                                    >
+                                        <i class="fas fa-plus-circle"></i>
+                                    </button>
                                 </div>
                             </div>
-                            <div class="col-3">
-                                <button
-                                    class="btn btn-outline-primary btn-block"
-                                    type="submit"
-                                >
-                                    <i class="fas fa-plus-circle"></i>
-                                </button>
-                            </div>
-                        </div>
-                    </form>
+                        </form>
                     @endif
-                    </p>
+                </p>
             </li>
         @endforeach
     </ul>

--- a/resources/views/event/display_includes/helpers.blade.php
+++ b/resources/views/event/display_includes/helpers.blade.php
@@ -4,78 +4,78 @@
     </div>
 
     <ul class="list-group list-group-flush">
-        @foreach ($event->activity->helpingCommitteeInstances as $key => $instance)
+        @foreach ($event->activity->helpingCommitteeInstances()->with('committee') as $key => $instance)
             <li class="list-group-item">
                 <p class="card-title">
                     <strong>
                         {{ $instance->committee->name }}
                         @if ($instance->committee->isMember(Auth::user()) || Auth::user()->can('board'))
-                                ({{ $instance->users->count() }}/{{ $instance->amount }})
+                            ({{ $instance->users->count() }}/{{ $instance->amount }})
                         @endif
                     </strong>
 
-                    @if ($event->activity->helpingUsers($instance->id)->count() < 1)
-                        <p class="card-text">
-                            No people are currently helping.
-                        </p>
-                    @else
-                        @include(
-                            'event.display_includes.render_participant_list',
-                            [
-                                'participants' => $event->activity->helpingUsers($instance->id),
-                                'event' => $event,
-                            ]
-                        )
-                    @endif
+                @if ($event->activity->helpingUsers($instance->id)->count() < 1)
+                    <p class="card-text">
+                        No people are currently helping.
+                    </p>
+                @else
+                    @include(
+                        'event.display_includes.render_participant_list',
+                        [
+                            'participants' => $event->activity->helpingUsers($instance->id),
+                            'event' => $event,
+                        ]
+                    )
+                @endif
 
-                    @if (! $event->activity->closed && $instance->committee->isMember(Auth::user()))
-                        @if ($event->activity->getHelpingParticipation($instance->committee, Auth::user()) !== null)
-                            <a
-                                class="btn btn-outline-warning btn-block mt-1"
-                                href="{{ route('event::deleteparticipation', ['participation_id' => $event->activity->getHelpingParticipation($instance->committee, Auth::user())->id]) }}"
-                            >
-                                I won't help anymore.
-                            </a>
-                        @elseif ($instance->users->count() < $instance->amount)
-                            <a
-                                class="btn btn-outline-success btn-block mt-1"
-                                href="{{ route('event::addparticipation', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
-                            >
-                                I'll help!
-                            </a>
-                        @endif
-                    @endif
-
-                    @if (Auth::user()->can('board') && ! $event->activity->closed)
-                        <form
-                            class="form-horizontal mt-2"
-                            method="post"
-                            action="{{ route('event::addparticipationfor', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
+                @if (! $event->activity->closed && $instance->committee->isMember(Auth::user()))
+                    @if ($event->activity->getHelpingParticipation($instance->committee, Auth::user()) !== null)
+                        <a
+                            class="btn btn-outline-warning btn-block mt-1"
+                            href="{{ route('event::deleteparticipation', ['participation_id' => $event->activity->getHelpingParticipation($instance->committee, Auth::user())->id]) }}"
                         >
-                            {{ csrf_field() }}
+                            I won't help anymore.
+                        </a>
+                    @elseif ($instance->users->count() < $instance->amount)
+                        <a
+                            class="btn btn-outline-success btn-block mt-1"
+                            href="{{ route('event::addparticipation', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
+                        >
+                            I'll help!
+                        </a>
+                    @endif
+                @endif
 
-                            <div class="row mb-3">
-                                <div class="col-9">
-                                    <div class="form-group autocomplete">
-                                        <input
-                                            class="form-control user-search"
-                                            name="user_id"
-                                            required
-                                        />
-                                    </div>
-                                </div>
-                                <div class="col-3">
-                                    <button
-                                        class="btn btn-outline-primary btn-block"
-                                        type="submit"
-                                    >
-                                        <i class="fas fa-plus-circle"></i>
-                                    </button>
+                @if (Auth::user()->can('board') && ! $event->activity->closed)
+                    <form
+                        class="form-horizontal mt-2"
+                        method="post"
+                        action="{{ route('event::addparticipationfor', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
+                    >
+                        {{ csrf_field() }}
+
+                        <div class="row mb-3">
+                            <div class="col-9">
+                                <div class="form-group autocomplete">
+                                    <input
+                                        class="form-control user-search"
+                                        name="user_id"
+                                        required
+                                    />
                                 </div>
                             </div>
-                        </form>
+                            <div class="col-3">
+                                <button
+                                    class="btn btn-outline-primary btn-block"
+                                    type="submit"
+                                >
+                                    <i class="fas fa-plus-circle"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </form>
                     @endif
-                </p>
+                    </p>
             </li>
         @endforeach
     </ul>

--- a/resources/views/event/display_includes/participation.blade.php
+++ b/resources/views/event/display_includes/participation.blade.php
@@ -11,7 +11,7 @@
                         {{ $event->activity->closedAccount->account_number }} ,
                         {{ $event->activity->closedAccount->name }})
                     @else()
-                        (Unknown account.)
+                            (Unknown account.)
                     @endif
                 </li>
             @endif
@@ -43,7 +43,7 @@
                     @if ($event->activity->price > 0)
                         &euro;{{ number_format($event->activity->price, 2, '.', ',') }}
                     @else
-                        &euro;0,-
+                            &euro;0,-
                     @endif
                 </strong>
             </li>
@@ -86,14 +86,14 @@
                                 {{ $event->activity->isFull() ? 'Full!' : 'Closed!' }}
                                 Put me on the back-up list.
                             @else
-                                Sign me up!
+                                    Sign me up!
                             @endif
                             |
 
                             @if ($event->activity->price > 0)
                                 &euro;{{ number_format($event->activity->price, 2, '.', ',') }}
                             @else
-                                Free!
+                                    Free!
                             @endif
                         </strong>
                         <br />
@@ -160,7 +160,10 @@
                     @include(
                         'event.display_includes.render_participant_list',
                         [
-                            'participants' => $event->activity->users()->with('photo')->get(),
+                            'participants' => $event->activity
+                                ->users()
+                                ->with('photo')
+                                ->get(),
                             'event' => $event,
                         ]
                     )
@@ -229,26 +232,26 @@
                 This activity requires you to sign-up. You can only sign-up when
                 you are a member.
 
-            @if (! Auth::check())
-                <p class="card-text">
-                    Please
-                    <a
-                        href="{{ route('event::login', ['id' => $event->getPublicId()]) }}"
-                    >
-                        log-in
-                    </a>
-                    if you are already a member.
-                </p>
-            @elseif (! Auth::user()->is_member)
-                <p class="card-text">
-                    Please
-                    <a href="{{ route('becomeamember') }}">
-                        become a member
-                    </a>
-                    to sign-up for this activity.
-                </p>
+                @if (! Auth::check())
+                    <p class="card-text">
+                        Please
+                        <a
+                            href="{{ route('event::login', ['id' => $event->getPublicId()]) }}"
+                        >
+                            log-in
+                        </a>
+                        if you are already a member.
+                    </p>
+                @elseif (! Auth::user()->is_member)
+                    <p class="card-text">
+                        Please
+                        <a href="{{ route('becomeamember') }}">
+                            become a member
+                        </a>
+                        to sign-up for this activity.
+                    </p>
                 @endif
-                </p>
+            </p>
         </div>
     </div>
 @endif

--- a/resources/views/event/display_includes/participation.blade.php
+++ b/resources/views/event/display_includes/participation.blade.php
@@ -11,7 +11,7 @@
                         {{ $event->activity->closedAccount->account_number }} ,
                         {{ $event->activity->closedAccount->name }})
                     @else()
-                            (Unknown account.)
+                        (Unknown account.)
                     @endif
                 </li>
             @endif
@@ -43,7 +43,7 @@
                     @if ($event->activity->price > 0)
                         &euro;{{ number_format($event->activity->price, 2, '.', ',') }}
                     @else
-                            &euro;0,-
+                        &euro;0,-
                     @endif
                 </strong>
             </li>
@@ -86,14 +86,14 @@
                                 {{ $event->activity->isFull() ? 'Full!' : 'Closed!' }}
                                 Put me on the back-up list.
                             @else
-                                    Sign me up!
+                                Sign me up!
                             @endif
                             |
 
                             @if ($event->activity->price > 0)
                                 &euro;{{ number_format($event->activity->price, 2, '.', ',') }}
                             @else
-                                    Free!
+                                Free!
                             @endif
                         </strong>
                         <br />
@@ -160,7 +160,7 @@
                     @include(
                         'event.display_includes.render_participant_list',
                         [
-                            'participants' => $event->activity->users,
+                            'participants' => $event->activity->users()->with('photo')->get(),
                             'event' => $event,
                         ]
                     )
@@ -229,26 +229,26 @@
                 This activity requires you to sign-up. You can only sign-up when
                 you are a member.
 
-                @if (! Auth::check())
-                    <p class="card-text">
-                        Please
-                        <a
-                            href="{{ route('event::login', ['id' => $event->getPublicId()]) }}"
-                        >
-                            log-in
-                        </a>
-                        if you are already a member.
-                    </p>
-                @elseif (! Auth::user()->is_member)
-                    <p class="card-text">
-                        Please
-                        <a href="{{ route('becomeamember') }}">
-                            become a member
-                        </a>
-                        to sign-up for this activity.
-                    </p>
+            @if (! Auth::check())
+                <p class="card-text">
+                    Please
+                    <a
+                        href="{{ route('event::login', ['id' => $event->getPublicId()]) }}"
+                    >
+                        log-in
+                    </a>
+                    if you are already a member.
+                </p>
+            @elseif (! Auth::user()->is_member)
+                <p class="card-text">
+                    Please
+                    <a href="{{ route('becomeamember') }}">
+                        become a member
+                    </a>
+                    to sign-up for this activity.
+                </p>
                 @endif
-            </p>
+                </p>
         </div>
     </div>
 @endif

--- a/resources/views/omnomcom/categories/edit.blade.php
+++ b/resources/views/omnomcom/categories/edit.blade.php
@@ -70,7 +70,7 @@
                         </div>
 
                         <ul class="list-group list-group-flush">
-                            @foreach ($category->sortedProducts() as $product)
+                            @foreach ($category->sortedProducts()->get() as $product)
                                 <li class="list-group-item">
                                     {{ $product->name }}
                                     <a

--- a/resources/views/omnomcom/store/includes/categories.blade.php
+++ b/resources/views/omnomcom/store/includes/categories.blade.php
@@ -3,9 +3,9 @@
         @foreach ($categories as $category)
             <div
                 class="btn btn-lg btn-category btn-block bg-omnomcom rounded-0 px-2 py-2 text-start {{ $category == $categories[0] ? 'active' : '' }}"
-                data-id="{{ $category->category->id }}"
+                data-id="{{ $category->id }}"
             >
-                {{ $category->category->name }}
+                {{ $category->name }}
             </div>
         @endforeach
 

--- a/resources/views/omnomcom/store/includes/product_overview.blade.php
+++ b/resources/views/omnomcom/store/includes/product_overview.blade.php
@@ -4,12 +4,12 @@
 
         <div
             class="category-view {{ $category == $categories[0] ? '' : 'inactive' }}"
-            data-id="{{ $category->category->id }}"
+            data-id="{{ $category->id }}"
         >
             <?php /** @var $product \App\Models\Product */
             ?>
 
-            @foreach ($category->products as $product)
+            @foreach ($category->sortedProducts as $product)
                 @if ($product->isVisible())
                     <?php
                     if ($product->stock > 0) {

--- a/resources/views/website/navbar.blade.php
+++ b/resources/views/website/navbar.blade.php
@@ -657,7 +657,7 @@
                                         id="profile-picture"
                                         class="rounded-circle ms-2"
                                         alt="your profile picture"
-                                        src="{{ Auth::user()->generatePhotoPath(100, 100) }}"
+                                        src="{{ Auth::user()->load('photo')->generatePhotoPath() }}"
                                     />
                                 </a>
 


### PR DESCRIPTION
Add the line `Model::preventLazyLoading(! app()->isProduction());` to our AppserviceProvider.
This makes it so when in dev the framework will throw an error if an attribute is lazyloaded.
Also already fixed a bunch of the issues that break pages because of this.