### PR TITLE
Change the SmartXP screen to show the random photos instead of ProTube

### DIFF
--- a/resources/views/smartxp/protube_iframe.blade.php
+++ b/resources/views/smartxp/protube_iframe.blade.php
@@ -8,7 +8,7 @@
     "
 >
     <iframe
-        src="https://protu.be/screen"
+        src="https://protu.be/photos"
         style="
             position: absolute;
             top: 0;


### PR DESCRIPTION
Fixes #2364.