### PR TITLE
Fix registrations made within a second landing on back-up list.

### DIFF
--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -249,7 +249,7 @@ class Activity extends Validatable
             return false;
         }
 
-        return Carbon::now()->format('U') > $this->registration_start && Carbon::now()->format('U') < $this->registration_end;
+        return Carbon::now()->format('U') >= $this->registration_start && Carbon::now()->format('U') < $this->registration_end;
     }
 
     /**

--- a/tests/Feature/EventTimingTest.php
+++ b/tests/Feature/EventTimingTest.php
@@ -1,13 +1,14 @@
 <?php
 
 use App\Models\Activity;
-use App\Models\User;
 use App\Models\Event;
 use App\Models\Member;
+use App\Models\User;
 use Illuminate\Support\Carbon;
+
 use function PHPUnit\Framework\assertTrue;
 
-$t0 =  Carbon::create(2000,1, 1, 12, 0, 0, 0);
+$t0 = Carbon::create(2000, 1, 1, 12, 0, 0, 0);
 
 dataset('models', [
     'model' => [
@@ -19,69 +20,70 @@ dataset('models', [
             ]);
 
             $event->activity->update([
-                'registration_start'=> $t0->copy()->timestamp,
-                'registration_end'=> $t0->copy()->addDay()->timestamp,
-                'deregistration_end'=> $t0->copy()->addDays(2)->timestamp,
-                'participants'=> -1,
-                ]);
+                'registration_start' => $t0->copy()->timestamp,
+                'registration_end' => $t0->copy()->addDay()->timestamp,
+                'deregistration_end' => $t0->copy()->addDays(2)->timestamp,
+                'participants' => -1,
+            ]);
+
             return $event;
         },
         fn () => User::factory()->has(Member::factory())->create(),
-    ]
+    ],
 ]);
 
 dataset('times', [
-    # before opening time
-   'm2000ms' => $t0->copy()->addMilliseconds(-2000),
-   'm1000ms' => $t0->copy()->addMilliseconds(-1000),
-   'm500ms' => $t0->copy()->addMilliseconds(-500),
-   'm250ms' => $t0->copy()->addMilliseconds(-250),
-   'm100ms' => $t0->copy()->addMilliseconds(-100),
-   'm50ms' => $t0->copy()->addMilliseconds(-50),
-   'm25ms' => $t0->copy()->addMilliseconds(-25),
-    # exactly on opening time
-   't0' => $t0->copy(),
-    # after opening time
-   'p50ms' => $t0->copy()->addMilliseconds(50),
-   'p100ms' => $t0->copy()->addMilliseconds(100),
-   'p250ms' => $t0->copy()->addMilliseconds(250),
-   'p500ms' => $t0->copy()->addMilliseconds(500),
-   'p1000ms' => $t0->copy()->addMilliseconds(1000),
-   'p2000ms' => $t0->copy()->addMilliseconds(2000),
+    // before opening time
+    'm2000ms' => $t0->copy()->addMilliseconds(-2000),
+    'm1000ms' => $t0->copy()->addMilliseconds(-1000),
+    'm500ms' => $t0->copy()->addMilliseconds(-500),
+    'm250ms' => $t0->copy()->addMilliseconds(-250),
+    'm100ms' => $t0->copy()->addMilliseconds(-100),
+    'm50ms' => $t0->copy()->addMilliseconds(-50),
+    'm25ms' => $t0->copy()->addMilliseconds(-25),
+    // exactly on opening time
+    't0' => $t0->copy(),
+    // after opening time
+    'p50ms' => $t0->copy()->addMilliseconds(50),
+    'p100ms' => $t0->copy()->addMilliseconds(100),
+    'p250ms' => $t0->copy()->addMilliseconds(250),
+    'p500ms' => $t0->copy()->addMilliseconds(500),
+    'p1000ms' => $t0->copy()->addMilliseconds(1000),
+    'p2000ms' => $t0->copy()->addMilliseconds(2000),
 ]);
 
-it('rejects participations before the signup opening', function(Carbon $time, Event $event, User $user) use ($t0) {
+it('rejects participations before the signup opening', function (Carbon $time, Event $event, User $user) use ($t0) {
     if ($time->isBefore($t0)) {
         Carbon::withTestNow($time, function () use ($user, $event) {
             $response = $this->actingAs($user)->get(
                 route('event::addparticipation', ['id' => $event->id]));
             $response->assertStatus(403);
-            $response->assertDontSee("You claimed a spot for");
-            $response->assertDontSee("You have been placed on the back-up list for");
-            $response->assertSee("You cannot subscribe for " . $event->title . " at this time");
+            $response->assertDontSee('You claimed a spot for');
+            $response->assertDontSee('You have been placed on the back-up list for');
+            $response->assertSee('You cannot subscribe for '.$event->title.' at this time');
         });
     } else {
-        # Skip for this test
+        // Skip for this test
         assertTrue(true);
     }
 })->with('times')->with('models');
 
-it('allows participation when open', function(Carbon $time, Event $event, User $user) use ($t0) {
+it('allows participation when open', function (Carbon $time, Event $event, User $user) use ($t0) {
     if ($time->isAfter($t0) || $time->equalTo($t0)) {
         Carbon::withTestNow($time, function () use ($user, $event) {
             $response = $this->actingAs($user)->get(
                 route('event::addparticipation', ['id' => $event->id]));
             $response->assertRedirect();
+
             $redirectUrl = $response->headers->get('Location');
             $response = $this->actingAs($user)->get($redirectUrl);
-            $response->assertSee("You claimed a spot for");
-            $response->assertDontSee("You have been placed on the back-up list for");
-            $response->assertDontSee("You cannot subscribe");
+            $response->assertSee('You claimed a spot for');
+            $response->assertDontSee('You have been placed on the back-up list for');
+            $response->assertDontSee('You cannot subscribe');
         });
     } else {
-        # Skip for this test
+        // Skip for this test
         assertTrue(true);
     }
 
 })->with('times')->with('models');
-

--- a/tests/Feature/EventTimingTest.php
+++ b/tests/Feature/EventTimingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Models\Activity;
+use App\Models\User;
+use App\Models\Event;
+use App\Models\Member;
+use Illuminate\Support\Carbon;
+use function PHPUnit\Framework\assertTrue;
+
+$t0 =  Carbon::create(2000,1, 1, 12, 0, 0, 0);
+
+dataset('models', [
+    'model' => [
+        function () use ($t0) {
+            $event = Event::factory()->has(Activity::factory())->create([
+                'secret' => false,
+                'start' => $t0->copy()->addDay()->timestamp,
+                'end' => $t0->copy()->addDays(2)->timestamp,
+            ]);
+
+            $event->activity->update([
+                'registration_start'=> $t0->copy()->timestamp,
+                'registration_end'=> $t0->copy()->addDay()->timestamp,
+                'deregistration_end'=> $t0->copy()->addDays(2)->timestamp,
+                'participants'=> -1,
+                ]);
+            return $event;
+        },
+        fn () => User::factory()->has(Member::factory())->create(),
+    ]
+]);
+
+dataset('times', [
+    # before opening time
+   'm2000ms' => $t0->copy()->addMilliseconds(-2000),
+   'm1000ms' => $t0->copy()->addMilliseconds(-1000),
+   'm500ms' => $t0->copy()->addMilliseconds(-500),
+   'm250ms' => $t0->copy()->addMilliseconds(-250),
+   'm100ms' => $t0->copy()->addMilliseconds(-100),
+   'm50ms' => $t0->copy()->addMilliseconds(-50),
+   'm25ms' => $t0->copy()->addMilliseconds(-25),
+    # exactly on opening time
+   't0' => $t0->copy(),
+    # after opening time
+   'p50ms' => $t0->copy()->addMilliseconds(50),
+   'p100ms' => $t0->copy()->addMilliseconds(100),
+   'p250ms' => $t0->copy()->addMilliseconds(250),
+   'p500ms' => $t0->copy()->addMilliseconds(500),
+   'p1000ms' => $t0->copy()->addMilliseconds(1000),
+   'p2000ms' => $t0->copy()->addMilliseconds(2000),
+]);
+
+it('rejects participations before the signup opening', function(Carbon $time, Event $event, User $user) use ($t0) {
+    if ($time->isBefore($t0)) {
+        Carbon::withTestNow($time, function () use ($user, $event) {
+            $response = $this->actingAs($user)->get(
+                route('event::addparticipation', ['id' => $event->id]));
+            $response->assertStatus(403);
+            $response->assertDontSee("You claimed a spot for");
+            $response->assertDontSee("You have been placed on the back-up list for");
+            $response->assertSee("You cannot subscribe for " . $event->title . " at this time");
+        });
+    } else {
+        # Skip for this test
+        assertTrue(true);
+    }
+})->with('times')->with('models');
+
+it('allows participation when open', function(Carbon $time, Event $event, User $user) use ($t0) {
+    if ($time->isAfter($t0) || $time->equalTo($t0)) {
+        Carbon::withTestNow($time, function () use ($user, $event) {
+            $response = $this->actingAs($user)->get(
+                route('event::addparticipation', ['id' => $event->id]));
+            $response->assertRedirect();
+            $redirectUrl = $response->headers->get('Location');
+            $response = $this->actingAs($user)->get($redirectUrl);
+            $response->assertSee("You claimed a spot for");
+            $response->assertDontSee("You have been placed on the back-up list for");
+            $response->assertDontSee("You cannot subscribe");
+        });
+    } else {
+        # Skip for this test
+        assertTrue(true);
+    }
+
+})->with('times')->with('models');
+


### PR DESCRIPTION
This single line change fixes the problem that anyone that happens to be fast enough to register within a second of the opening ends up on the back-up list of an event.

I caught due to some creative end-to-end testing in production.


```
   0|           1s          |              ... 
    ^       ^               ^ 
  opens   back-up         signed up
 ```             