### PR TITLE
Fix not being able to force sign up a helper if the user is signed in to the event itself

### DIFF
--- a/app/Http/Controllers/ParticipationController.php
+++ b/app/Http/Controllers/ParticipationController.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Session;
 class ParticipationController extends Controller
 {
     /**
-     * @return RedirectResponse|JsonResponse
+     * @return RedirectResponse
      */
     public function create(int $id, Request $request)
     {
@@ -30,9 +30,11 @@ class ParticipationController extends Controller
         $event = Event::query()->findOrFail($id);
         if (! $event->activity) {
             abort(403, 'You cannot subscribe for '.$event->title.'.');
-        } elseif ($request->has('helping_committee_id') && $event->activity->getHelperParticipation(Auth::user(), HelpingCommittee::query()->findOrFail($request->input('helping_committee_id'))) !== null) {
+        }
+
+        if ($request->has('helping_committee_id') && $event->activity->getHelperParticipation(Auth::user(), HelpingCommittee::query()->findOrFail($request->input('helping_committee_id'))) !== null) {
             abort(403, 'You are helping at '.$event->title.'.');
-        } elseif ($event->activity->getParticipation(Auth::user()) !== null) {
+        } elseif (! $request->has('helping_committee_id') && $event->activity->getParticipation(Auth::user()) !== null) {
             abort(403, 'You are already subscribed for '.$event->title.'.');
         } elseif (! $request->has('helping_committee_id') && (! $event->activity->canSubscribeBackup())) {
             abort(403, 'You cannot subscribe for '.$event->title.' at this time.');
@@ -41,8 +43,6 @@ class ParticipationController extends Controller
         }
 
         $data = ['activity_id' => $event->activity->id, 'user_id' => Auth::user()->id];
-
-        $is_web = Auth::guard('web')->user();
 
         if ($request->has('helping_committee_id')) {
             $helping = HelpingCommittee::query()->findOrFail($request->helping_committee_id);
@@ -55,15 +55,11 @@ class ParticipationController extends Controller
             }
 
             $data['committees_activities_id'] = $helping->id;
-        } elseif ($is_web) {
-            if ($event->activity->isFull() || ! $event->activity->canSubscribe()) {
-                Session::flash('flash_message', 'You have been placed on the back-up list for '.$event->title.'.');
-                $data['backup'] = true;
-            } else {
-                Session::flash('flash_message', 'You claimed a spot for '.$event->title.'.');
-            }
         } elseif ($event->activity->isFull() || ! $event->activity->canSubscribe()) {
+            Session::flash('flash_message', 'You have been placed on the back-up list for '.$event->title.'.');
             $data['backup'] = true;
+        } else {
+            Session::flash('flash_message', 'You claimed a spot for '.$event->title.'.');
         }
 
         $participation = new ActivityParticipation;
@@ -71,20 +67,6 @@ class ParticipationController extends Controller
         $participation->save();
 
         $event->updateUniqueUsersCount();
-
-        if (! $is_web) {
-            if ($event->activity->isFull() || ! $event->activity->canSubscribe()) {
-                $message = 'You have been placed on the back-up list for '.$event->title.'.';
-            } else {
-                $message = 'You claimed a spot for '.$event->title.'.';
-            }
-
-            return response()->json([
-                'success' => true,
-                'message' => $message,
-                'participation_id' => $participation->id,
-            ]);
-        }
 
         if ($event->activity->redirect_url) {
             return Redirect::to($event->activity->redirect_url);
@@ -115,19 +97,17 @@ class ParticipationController extends Controller
 
         if (! $event->activity) {
             abort(403, 'You cannot subscribe for '.$event->title.'.');
-        } elseif ($request->has('helping_committee_id') && $event->activity->getHelperParticipation($user, HelpingCommittee::query()->findOrFail($request->input('helping_committee_id'))) !== null) {
-            abort(403, 'You are helping at '.$event->title.'.');
-        } elseif ($event->activity->getParticipation($user) !== null) {
-            abort(403, 'You are already subscribed for '.$event->title.'.');
         } elseif ($event->activity->closed) {
             abort(403, 'This activity is closed, you cannot change participation anymore.');
+        } elseif ($request->has('helping_committee_id') && $event->activity->getHelperParticipation($user, HelpingCommittee::query()->findOrFail($request->input('helping_committee_id'))) !== null) {
+            abort(403, 'You are helping at '.$event->title.'.');
+        } elseif (! $request->has('helping_committee_id') && $event->activity->getParticipation($user) !== null) {
+            abort(403, 'You are already subscribed for '.$event->title.'.');
         }
 
         Session::flash('flash_message', 'You added '.$user->name.' for '.$event->title.'.');
 
-        $participation = new ActivityParticipation;
-        $participation->fill($data);
-        $participation->save();
+        $participation = ActivityParticipation::query()->create($data);
 
         if (! isset($data['committees_activities_id']) || ! $data['committees_activities_id']) {
             $event->updateUniqueUsersCount();
@@ -148,72 +128,44 @@ class ParticipationController extends Controller
     public function destroy(int $participation_id)
     {
         /** @var ActivityParticipation|null $participation */
-        $participation = ActivityParticipation::query()->where('id', $participation_id)->with('activity', 'activity.event', 'user')->first();
+        $participation = ActivityParticipation::query()->with('activity', 'activity.event', 'user')->findorFail($participation_id);
 
-        if (! $participation) {
-            Session::flash('flash_message', 'The participation is not found.');
+        abort_unless($participation->user->id == Auth::id() || Auth::user()->can('board'), 403, 'You are not allowed to unsubscribe this user from this event.');
+
+        if ($participation->committees_activities_id !== null) {
+
+            $message = $participation->user->name.' is not helping with '.$participation->activity->event->title.' anymore.';
+            Session::flash('flash_message', $message);
+
+            $participation->delete();
+            $participation->activity->event->updateUniqueUsersCount();
 
             return Redirect::back();
         }
 
-        $notify = false;
+        if ($participation->activity->closed) {
+            abort(403, 'This activity is closed, you cannot change participation anymore.');
+        }
+
+        if (! $participation->activity->canUnsubscribe() && ! $participation->backup && ! Auth::user()->can('board')) {
+            abort(403, 'You cannot unsubscribe for this event at this time.');
+        }
 
         if ($participation->user->id != Auth::id()) {
-            if (! Auth::user()->can('board')) {
-                abort(403);
-            }
-
-            $notify = true;
+            Mail::to($participation->user)->queue((new ActivityUnsubscribedFrom($participation))->onQueue('high'));
         }
 
-        $is_web = Auth::guard('web')->user();
+        Session::flash('flash_message', $participation->user->name.' is not attending '.$participation->activity->event->title.' anymore.');
 
-        if ($participation->committees_activities_id === null) {
-            if ($participation->activity->closed) {
-                abort(403, 'This activity is closed, you cannot change participation anymore.');
-            }
+        $participation->delete();
 
-            if (! $participation->activity->canUnsubscribe() && ! $participation->backup && ! Auth::user()->can('board')) {
-                abort(403, 'You cannot unsubscribe for this event at this time.');
-            }
-
-            if ($notify) {
-                Mail::to($participation->user)->queue((new ActivityUnsubscribedFrom($participation))->onQueue('high'));
-            }
-
-            $message = $participation->user->name.' is not attending '.$participation->activity->event->title.' anymore.';
-            if ($is_web) {
-                Session::flash('flash_message', $message);
-            }
-
-            $participation->delete();
-
-            $participation->activity->event->updateUniqueUsersCount();
-
-            if (! $participation->backup && $participation->activity->users()->count() < $participation->activity->participants) {
-                self::transferOneBackupUser($participation->activity);
-            }
-        } else {
-            $message = $participation->user->name.' is not helping with '.$participation->activity->event->title.' anymore.';
-            if ($is_web) {
-                Session::flash('flash_message', $message);
-            }
-
-            $participation->delete();
-            $participation->activity->event->updateUniqueUsersCount();
+        if (! $participation->backup && $participation->activity->users()->count() < $participation->activity->participants) {
+            self::transferOneBackupUser($participation->activity);
         }
 
-        if ($is_web) {
-            return Redirect::back();
-        }
+        $participation->activity->event->updateUniqueUsersCount();
 
-        abort(200, json_encode((object) [
-            'success' => true,
-            'message' => $message,
-        ]));
-
-        /**@phpstan-ignore-next-line */
-        return null;
+        return Redirect::back();
     }
 
     /**

--- a/app/Http/Controllers/ParticipationController.php
+++ b/app/Http/Controllers/ParticipationController.php
@@ -24,48 +24,37 @@ class ParticipationController extends Controller
     /**
      * @return RedirectResponse
      */
-    public function create(int $id, Request $request)
+    public function create(Event $event, Request $request)
     {
-        /** @var Event $event */
-        $event = Event::query()->findOrFail($id);
-        if (! $event->activity) {
-            abort(403, 'You cannot subscribe for '.$event->title.'.');
-        }
-
-        if ($request->has('helping_committee_id') && $event->activity->getHelperParticipation(Auth::user(), HelpingCommittee::query()->findOrFail($request->input('helping_committee_id'))) !== null) {
-            abort(403, 'You are helping at '.$event->title.'.');
-        } elseif (! $request->has('helping_committee_id') && $event->activity->getParticipation(Auth::user()) !== null) {
-            abort(403, 'You are already subscribed for '.$event->title.'.');
-        } elseif (! $request->has('helping_committee_id') && (! $event->activity->canSubscribeBackup())) {
-            abort(403, 'You cannot subscribe for '.$event->title.' at this time.');
-        } elseif ($event->activity->closed) {
-            abort(403, 'This activity is closed, you cannot change participation anymore.');
-        }
+        abort_if(! $event->activity, 403, $event->title.' does not have a signup.');
+        abort_if($event->activity->closed, 403, 'This activity is closed, you cannot change participation anymore.');
 
         $data = ['activity_id' => $event->activity->id, 'user_id' => Auth::user()->id];
 
         if ($request->has('helping_committee_id')) {
-            $helping = HelpingCommittee::query()->findOrFail($request->helping_committee_id);
-            if (! $helping->committee->isMember(Auth::user())) {
-                abort(403, 'You are not a member of the '.$helping->committee.' and thus cannot help on behalf of it.');
-            }
+            $helpingCommittee = HelpingCommittee::query()->findOrFail($request->input('helping_committee_id'));
+            abort_unless($event->activity->getHelperParticipation(Auth::user(), $helpingCommittee) === null, 403, 'You are already helping at '.$event->title.'.');
 
-            if ($helping->users->count() >= $helping->amount) {
-                abort(403, 'There are already enough people of your committee helping, thanks though!');
-            }
+            abort_unless($helpingCommittee->committee->isMember(Auth::user()), 403, 'You are not a member of the '.$helpingCommittee->committee.' and thus cannot help on behalf of it.');
+            abort_if($helpingCommittee->users->count() >= $helpingCommittee->amount, 403, 'There are already enough people of your committee helping, thanks though!');
 
-            $data['committees_activities_id'] = $helping->id;
-        } elseif ($event->activity->isFull() || ! $event->activity->canSubscribe()) {
+            $data['committees_activities_id'] = $helpingCommittee->id;
+            ActivityParticipation::query()->create($data);
+
+            return Redirect::back();
+        }
+
+        abort_unless($event->activity->getParticipation(Auth::user()) === null, 403, 'You are already subscribed for '.$event->title.'.');
+        abort_unless($event->activity->canSubscribeBackup(), 403, 'You cannot subscribe for '.$event->title.' at this time.');
+
+        if ($event->activity->isFull() || ! $event->activity->canSubscribe()) {
             Session::flash('flash_message', 'You have been placed on the back-up list for '.$event->title.'.');
             $data['backup'] = true;
         } else {
             Session::flash('flash_message', 'You claimed a spot for '.$event->title.'.');
         }
 
-        $participation = new ActivityParticipation;
-        $participation->fill($data);
-        $participation->save();
-
+        ActivityParticipation::query()->create($data);
         $event->updateUniqueUsersCount();
 
         if ($event->activity->redirect_url) {
@@ -78,44 +67,35 @@ class ParticipationController extends Controller
     /**
      * @return RedirectResponse
      */
-    public function createFor(int $id, Request $request)
+    public function createFor(Event $event, Request $request)
     {
-        /** @var Event $event */
-        $event = Event::query()->findOrFail($id);
-        $user = User::query()->findOrFail($request->user_id);
+        abort_if(! $event->activity, 403, $event->title.' does not have a signup.');
+        abort_if($event->activity->closed, 403, 'This activity is closed, you cannot change participation anymore.');
+
+        $user = User::query()->findOrFail($request->input('user_id'));
 
         $data = ['activity_id' => $event->activity->id, 'user_id' => $user->id];
 
         if ($request->has('helping_committee_id')) {
-            $helping = HelpingCommittee::query()->findOrFail($request->helping_committee_id);
-            if (! $helping->committee->isMember($user)) {
-                abort(403, $user->name.' is not a member of the '.$helping->committee->name.' and thus cannot help on behalf of it.');
-            }
+            $helping = HelpingCommittee::query()->findOrFail($request->input('helping_committee_id'));
+
+            abort_unless($event->activity->getHelperParticipation($user, $helping) === null, 403, $user->name.' is already helping at '.$event->title.'.');
+            abort_unless($helping->committee->isMember($user), 403, $user->name.' is not a member of the '.$helping->committee->name.' and thus cannot help on behalf of it.');
 
             $data['committees_activities_id'] = $helping->id;
+        } else {
+            abort_if($event->activity->getParticipation($user) !== null, 403, $user->name.'is already subscribed for '.$event->title.'.');
         }
 
-        if (! $event->activity) {
-            abort(403, 'You cannot subscribe for '.$event->title.'.');
-        } elseif ($event->activity->closed) {
-            abort(403, 'This activity is closed, you cannot change participation anymore.');
-        } elseif ($request->has('helping_committee_id') && $event->activity->getHelperParticipation($user, HelpingCommittee::query()->findOrFail($request->input('helping_committee_id'))) !== null) {
-            abort(403, 'You are helping at '.$event->title.'.');
-        } elseif (! $request->has('helping_committee_id') && $event->activity->getParticipation($user) !== null) {
-            abort(403, 'You are already subscribed for '.$event->title.'.');
+        $participation = ActivityParticipation::query()->create($data);
+
+        if ($request->has('helping_committee_id')) {
+            $event->updateUniqueUsersCount();
         }
 
         Session::flash('flash_message', 'You added '.$user->name.' for '.$event->title.'.');
 
-        $participation = ActivityParticipation::query()->create($data);
-
-        if (! isset($data['committees_activities_id']) || ! $data['committees_activities_id']) {
-            $event->updateUniqueUsersCount();
-        }
-
-        $help_committee = ($helping->committee->name ?? null);
-
-        Mail::to($participation->user)->queue((new ActivitySubscribedTo($participation, $help_committee))->onQueue('high'));
+        Mail::to($participation->user)->queue((new ActivitySubscribedTo($participation, $helping->committee->name ?? null))->onQueue('high'));
 
         return Redirect::back();
     }
@@ -125,39 +105,32 @@ class ParticipationController extends Controller
      *
      * @throws Exception
      */
-    public function destroy(int $participation_id)
+    public function destroy(ActivityParticipation $participation)
     {
-        /** @var ActivityParticipation|null $participation */
-        $participation = ActivityParticipation::query()->with('activity', 'activity.event', 'user')->findorFail($participation_id);
+        $participation->load(['activity', 'activity.event', 'user']);
 
         abort_unless($participation->user->id == Auth::id() || Auth::user()->can('board'), 403, 'You are not allowed to unsubscribe this user from this event.');
 
+        // always allow deleting of helper participation
         if ($participation->committees_activities_id !== null) {
-
-            $message = $participation->user->name.' is not helping with '.$participation->activity->event->title.' anymore.';
-            Session::flash('flash_message', $message);
-
             $participation->delete();
+            Session::flash('flash_message', $participation->user->name.' is not helping with '.$participation->activity->event->title.' anymore.');
             $participation->activity->event->updateUniqueUsersCount();
 
             return Redirect::back();
         }
 
-        if ($participation->activity->closed) {
-            abort(403, 'This activity is closed, you cannot change participation anymore.');
-        }
+        abort_if($participation->activity->closed, 403, 'This activity is closed, you cannot change participation anymore.');
 
-        if (! $participation->activity->canUnsubscribe() && ! $participation->backup && ! Auth::user()->can('board')) {
-            abort(403, 'You cannot unsubscribe for this event at this time.');
-        }
+        abort_unless($participation->backup || $participation->activity->canUnsubscribe() || Auth::user()->can('board'), 403, 'You cannot unsubscribe for this event at this time.');
 
-        if ($participation->user->id != Auth::id()) {
+        if ($participation->user->id !== Auth::id()) {
             Mail::to($participation->user)->queue((new ActivityUnsubscribedFrom($participation))->onQueue('high'));
         }
 
-        Session::flash('flash_message', $participation->user->name.' is not attending '.$participation->activity->event->title.' anymore.');
-
         $participation->delete();
+
+        Session::flash('flash_message', $participation->user->name.' is not attending '.$participation->activity->event->title.' anymore.');
 
         if (! $participation->backup && $participation->activity->users()->count() < $participation->activity->participants) {
             self::transferOneBackupUser($participation->activity);
@@ -171,17 +144,11 @@ class ParticipationController extends Controller
     /**
      * @return JsonResponse
      */
-    public function togglePresence(int $participation_id)
+    public function togglePresence(ActivityParticipation $participation)
     {
-        /** @var ActivityParticipation $participation */
-        $participation = ActivityParticipation::query()->findOrFail($participation_id);
+        abort_unless($participation->activity->event->isEventAdmin(Auth::user()), 403, 'You are not an organizer for this event.');
 
-        if (! $participation->activity->event->isEventAdmin(Auth::user())) {
-            abort(403, 'You are not an organizer for this event.');
-        }
-
-        $participation->is_present = ! $participation->is_present;
-        $participation->save();
+        $participation->update(['is_present' => ! $participation->is_present]);
 
         return response()->json($participation->activity->getPresent());
     }
@@ -200,13 +167,14 @@ class ParticipationController extends Controller
             ->with('user', 'activity.event')
             ->first();
 
-        if ($backup_participation !== null) {
-            $backup_participation->backup = false;
-            $backup_participation->save();
-
-            $backup_participation->activity->event->updateUniqueUsersCount();
-
-            Mail::to($backup_participation->user)->queue((new ActivityMovedFromBackup($backup_participation))->onQueue('high'));
+        if ($backup_participation == null) {
+            return;
         }
+
+        $backup_participation->update(['backup' => false]);
+
+        $backup_participation->activity->event->updateUniqueUsersCount();
+
+        Mail::to($backup_participation->user)->queue((new ActivityMovedFromBackup($backup_participation))->onQueue('high'));
     }
 }

--- a/resources/views/event/checklist.blade.php
+++ b/resources/views/event/checklist.blade.php
@@ -130,7 +130,7 @@
         document.querySelectorAll('.is_present').forEach((el) => {
             el.onclick = (_) => {
                 get(
-                    '{{ route('event::togglepresence', ['id' => 'id']) }}'.replace(
+                    '{{ route('event::togglepresence', ['participation' => 'id']) }}'.replace(
                         'id',
                         el.getAttribute('data-id')
                     )

--- a/resources/views/event/display_includes/helpers.blade.php
+++ b/resources/views/event/display_includes/helpers.blade.php
@@ -34,7 +34,7 @@
                                 class="btn btn-outline-warning btn-block mt-1"
                                 href="{{
                                     route('event::deleteparticipation', [
-                                        'participation_id' => $instance->users
+                                        'participation' => $instance->users
                                             ->filter(function ($user) {
                                                 return $user->id === Auth::id();
                                             })
@@ -47,7 +47,7 @@
                         @elseif ($instance->users->count() < $instance->amount)
                             <a
                                 class="btn btn-outline-success btn-block mt-1"
-                                href="{{ route('event::addparticipation', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
+                                href="{{ route('event::addparticipation', ['event' => $event, 'helping_committee_id' => $instance->id]) }}"
                             >
                                 I'll help!
                             </a>
@@ -58,7 +58,7 @@
                         <form
                             class="form-horizontal mt-2"
                             method="post"
-                            action="{{ route('event::addparticipationfor', ['id' => $event->id, 'helping_committee_id' => $instance->id]) }}"
+                            action="{{ route('event::addparticipationfor', ['event' => $event, 'helping_committee_id' => $instance->id]) }}"
                         >
                             {{ csrf_field() }}
 

--- a/resources/views/event/display_includes/participation.blade.php
+++ b/resources/views/event/display_includes/participation.blade.php
@@ -66,7 +66,7 @@
                 @if ($event->activity->canUnsubscribe() || $authParticipation->backup)
                     <a
                         class="list-group-item bg-danger text-white"
-                        href="{{ route('event::deleteparticipation', ['participation_id' => $authParticipation->id]) }}"
+                        href="{{ route('event::deleteparticipation', ['participation' => $authParticipation->id]) }}"
                     >
                         @if ($authParticipation->backup)
                             Sign me out of the back-up list.
@@ -80,7 +80,7 @@
                 @if ($event->activity->canSubscribeBackup())
                     <a
                         class="list-group-item text-white bg-{{ $event->activity->isFull() || ! $event->activity->canSubscribe() ? 'warning' : 'success' }}"
-                        href="{{ route('event::addparticipation', ['id' => $event->id]) }}"
+                        href="{{ route('event::addparticipation', ['event' => $event]) }}"
                     >
                         <strong>
                             @if ($event->activity->isFull() || ! $event->activity->canSubscribe())
@@ -172,7 +172,7 @@
                 @if (Auth::user()->can('board') && ! $event->activity->closed)
                     <form
                         class="form-horizontal"
-                        action="{{ route('event::addparticipationfor', ['id' => $event->id]) }}"
+                        action="{{ route('event::addparticipationfor', ['event' => $event]) }}"
                         method="post"
                     >
                         {{ csrf_field() }}

--- a/resources/views/event/display_includes/render_participant_list.blade.php
+++ b/resources/views/event/display_includes/render_participant_list.blade.php
@@ -20,7 +20,7 @@
         </a>
         @if (Auth::user()->can('board') && $event && ! $event->activity->closed)
             <a
-                href="{{ route('event::deleteparticipation', ['participation_id' => $pid]) }}"
+                href="{{ route('event::deleteparticipation', ['participation' => $pid]) }}"
                 class="btn btn-outline-warning"
             >
                 <i class="fas fa-times" aria-hidden="true"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -554,15 +554,14 @@ Route::middleware('forcedomain')->group(function () {
         /* --- Related to presence & participation --- */
         Route::controller(ParticipationController::class)->group(function () {
             // Public routes
-            Route::get('togglepresence/{id}', 'togglePresence')->middleware(['auth'])->name('togglepresence');
+            Route::get('togglepresence/{participation}', 'togglePresence')->middleware(['auth'])->name('togglepresence');
 
             // Manage participation
-            Route::get('participate/{id}', 'create')->middleware(['member'])->name('addparticipation');
-            Route::get('unparticipate/{participation_id}', 'destroy')->name('deleteparticipation');
+            Route::get('participate/{event}', 'create')->middleware(['member'])->name('addparticipation');
+            Route::get('unparticipate/{participation}', 'destroy')->name('deleteparticipation');
 
             // Participate for someone else (Board only)
-            Route::post('participatefor/{id}', 'createFor')->middleware(['permission:board'])->name('addparticipationfor');
-
+            Route::post('participatefor/{event}', 'createFor')->middleware(['permission:board'])->name('addparticipationfor');
         });
 
         /* --- Buy tickets for an event (Public) --- */

--- a/tests/Feature/EventTimingTest.php
+++ b/tests/Feature/EventTimingTest.php
@@ -56,7 +56,7 @@ it('rejects participations before the signup opening', function (Carbon $time, E
     if ($time->isBefore($t0)) {
         Carbon::withTestNow($time, function () use ($user, $event) {
             $response = $this->actingAs($user)->get(
-                route('event::addparticipation', ['id' => $event->id]));
+                route('event::addparticipation', ['event' => $event]));
             $response->assertStatus(403);
             $response->assertDontSee('You claimed a spot for');
             $response->assertDontSee('You have been placed on the back-up list for');
@@ -72,7 +72,7 @@ it('allows participation when open', function (Carbon $time, Event $event, User 
     if ($time->isAfter($t0) || $time->equalTo($t0)) {
         Carbon::withTestNow($time, function () use ($user, $event) {
             $response = $this->actingAs($user)->get(
-                route('event::addparticipation', ['id' => $event->id]));
+                route('event::addparticipation', ['event' => $event]));
             $response->assertRedirect();
 
             $redirectUrl = $response->headers->get('Location');


### PR DESCRIPTION
This PR cleans up the participation controller. 

It remove the is_web check (we do not support the app anymore, so all our traffick comes through the Auth::web guard).
It also fixes that you are not able to sign up a helper for an event if you are in the event itself.
Additionally, it moves the controller over to route_model binding.