### PR TITLE
Prevent the board from force signing up non members into events

### DIFF
--- a/app/Http/Controllers/ParticipationController.php
+++ b/app/Http/Controllers/ParticipationController.php
@@ -88,6 +88,7 @@ class ParticipationController extends Controller
 
             $data['committees_activities_id'] = $helping->id;
         } else {
+            abort_unless($user->is_member, 403, $user->name.' is not a member of the association and therefore can not be subscribed for '.$event->title.'.');
             abort_if($event->activity->isParticipating($user), 403, $user->name.' is already subscribed for '.$event->title.'.');
         }
 


### PR DESCRIPTION
A regular user is accidentally signed up for an event, which means we do not have any payment info etc. 
This adds a check to prevent this from happening.