### PR TITLE
Let our file system reflect the default of laravel and add the public drive in the storage folder

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -29,12 +29,35 @@ return [
     */
 
     'disks' => [
-
         'local' => [
             'driver' => 'local',
-            'root' => storage_path('app'),
+            'root' => storage_path('app/private'),
+            'serve' => true,
+            'throw' => false,
+            'report' => false,
         ],
 
+        'public' => [
+            'driver' => 'local',
+            'root' => storage_path('app/public'),
+            'url' => env('APP_URL').'/storage',
+            'visibility' => 'public',
+            'throw' => false,
+            'report' => false,
+        ],
     ],
+    /*
+     |--------------------------------------------------------------------------
+     | Symbolic Links
+     |--------------------------------------------------------------------------
+     |
+     | Here you may configure the symbolic links that will be created when the
+     | `storage:link` Artisan command is executed. The array keys should be
+     | the locations of the links and the values should be their targets.
+     |
+     */
 
+    'links' => [
+        public_path('storage') => storage_path('app/public'),
+    ],
 ];


### PR DESCRIPTION
Before merging the application should be set in maintanance mode and the contents of storage/app should be moved to /storage/app/private. Also the php artisan storage:link command might need to be added to the deploy script