### PR TITLE
Update the profile pics to use the laravel media library on the public drive

### DIFF
--- a/app/Console/Commands/CopyProfilePictures.php
+++ b/app/Console/Commands/CopyProfilePictures.php
@@ -5,21 +5,21 @@ namespace App\Console\Commands;
 use App\Models\User;
 use Illuminate\Console\Command;
 
-class resizePhotos extends Command
+class CopyProfilePictures extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'proto:resize-photos';
+    protected $signature = 'proto:copy-profile-pictures';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Copies the profile pictures from our own storage entries to the laravel media library';
 
     /**
      * Execute the console command.

--- a/app/Console/Commands/FileCleanup.php
+++ b/app/Console/Commands/FileCleanup.php
@@ -45,7 +45,7 @@ class FileCleanup extends Command
             foreach ($files as $file) {
                 if ($file->isOrphan()) {
                     $count++;
-                    Storage::delete($file->filename);
+                    Storage::disk('local')->delete($file->filename);
                     $file->delete();
                 }
             }

--- a/app/Console/Commands/resizePhotos.php
+++ b/app/Console/Commands/resizePhotos.php
@@ -27,7 +27,9 @@ class resizePhotos extends Command
      */
     public function handle(): void
     {
-       User::whereHas('photo')->where('id', 2179)->with('photo')->chunkById(100, function ($users) {
+       User::whereHas('photo')->whereHas('roles', function ($q){
+           $q->where('name', 'sysadmin');
+       })->with('photo')->chunkById(100, function ($users) {
            /** @var User $user */
            foreach ($users as $user) {
                 $user->addMedia($user->photo->generateLocalPath())

--- a/app/Console/Commands/resizePhotos.php
+++ b/app/Console/Commands/resizePhotos.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class resizePhotos extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'proto:resize-photos';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+       User::whereHas('photo')->where('id', 2179)->with('photo')->chunkById(100, function ($users) {
+           /** @var User $user */
+           foreach ($users as $user) {
+                $user->addMedia($user->photo->generateLocalPath())
+                    ->usingName($user->photo->original_filename)
+                    ->usingFileName($user->photo->original_filename)
+                    ->preservingOriginal()
+                    ->toMediaCollection('profile_picture');
+                    $user->update([
+                        'image_id' => null
+                    ]);
+            }
+       });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -20,6 +20,7 @@ use App\Console\Commands\OmNomComCleanup;
 use App\Console\Commands\PrintActiveMembers;
 use App\Console\Commands\RefreshEventUniqueUsers;
 use App\Console\Commands\ReplaceQuestionMarkWithSingleQuoteInCodex;
+use App\Console\Commands\resizePhotos;
 use App\Console\Commands\ReviewFeedbackCron;
 use App\Console\Commands\ReviewStickersCron;
 use App\Console\Commands\SpotifySync;
@@ -78,6 +79,7 @@ class Kernel extends ConsoleKernel
         TempAdminCleanup::class,
         SyncUTAccounts::class,
         GoogleSync::class,
+        ResizePhotos::class,
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -20,7 +20,7 @@ use App\Console\Commands\OmNomComCleanup;
 use App\Console\Commands\PrintActiveMembers;
 use App\Console\Commands\RefreshEventUniqueUsers;
 use App\Console\Commands\ReplaceQuestionMarkWithSingleQuoteInCodex;
-use App\Console\Commands\resizePhotos;
+use App\Console\Commands\CopyProfilePictures;
 use App\Console\Commands\ReviewFeedbackCron;
 use App\Console\Commands\ReviewStickersCron;
 use App\Console\Commands\SpotifySync;
@@ -79,7 +79,7 @@ class Kernel extends ConsoleKernel
         TempAdminCleanup::class,
         SyncUTAccounts::class,
         GoogleSync::class,
-        ResizePhotos::class,
+        CopyProfilePictures::class,
     ];
 
     /**

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -72,7 +72,7 @@ class ApiController extends Controller
 
         if (Auth::check()) {
             $response->name = Auth::user()->name;
-            $response->photo = Auth::user()->generatePhotoPath(250, 250);
+            $response->photo = Auth::user()->smallPhoto();
             $response->token = Auth::user()->getToken()->token;
         } else {
             $response->token = 0;

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -439,11 +439,11 @@ class EventController extends Controller
 
             $participants = ($user?->is_member && $event->activity ? $event->activity->users->map(static fn ($item) => (object) [
                 'name' => $item->name,
-                'photo' => $item->photo_preview,
+                'photo' => $item->smallPhoto(),
             ]) : null);
             $backupParticipants = ($user?->is_member && $event->activity ? $event->activity->backupUsers->map(static fn ($item) => (object) [
                 'name' => $item->name,
-                'photo' => $item->photo_preview,
+                'photo' => $item->smallPhoto(),
             ]) : null);
             $data[] = (object) [
                 'id' => $event->id,

--- a/app/Http/Controllers/ProfilePictureController.php
+++ b/app/Http/Controllers/ProfilePictureController.php
@@ -9,49 +9,38 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileIsTooBig;
 
 class ProfilePictureController extends Controller
 {
     /**
-     * @return RedirectResponse
+     * @return RedirectResponse|string
      *
-     * @throws FileNotFoundException
      */
     public function update(Request $request)
     {
+        $request->validate([
+            'image' => 'required|image|max:5120', // max 5MB
+        ]);
+
         $user = Auth::user();
-
-        $image = $request->file('image');
-        if ($image) {
-            if (str_starts_with($image->getMimeType(), 'image')) {
-                $file = new StorageEntry;
-                $file->createFromFile($image);
-
-                $user->photo()->associate($file);
-                $user->save();
-            } else {
-                Session::flash('flash_message', 'This is not an image file!');
-
-                return Redirect::back();
-            }
-        } else {
-            Session::flash('flash_message', 'You forget an image to upload, silly!');
-
-            return Redirect::back();
+        try {
+           $user->addMediaFromRequest('image')->toMediaCollection('profile_picture');
+        } catch (FileDoesNotExist|FileIsTooBig $e) {
+            Session::flash('flash_message', $e->getMessage());
+            Redirect::back();
         }
-
         Session::flash('flash_message', 'Your profile picture has been updated!');
-
         return Redirect::back();
     }
 
     /** @return RedirectResponse */
     public function destroy()
     {
-        $user = Auth::user();
-
-        $user->photo()->dissociate();
-        $user->save();
+        foreach (Auth::user()->getMedia('profile_picture') as $media) {
+            $media->delete();
+        }
 
         Session::flash('flash_message', 'Your profile picture has been cleared!');
 

--- a/app/Models/StorageEntry.php
+++ b/app/Models/StorageEntry.php
@@ -171,7 +171,7 @@ class StorageEntry extends Model
 
     public function generateLocalPath(): string
     {
-        return storage_path('app/'.$this->filename);
+        return Storage::disk('local')->path($this->filename);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -250,11 +250,10 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
     public function registerMediaConversions(Media $media = null): void
     {
         $this->addMediaConversion('thumb')
-            ->format('webp')
-            ->nonOptimized()
-            ->fit(Fit::Crop, 100, 100)
             ->performOnCollections('profile_picture')
-            ->nonQueued();
+//            ->nonQueued()
+            ->fit(Fit::Crop, 100, 100)
+            ->format('webp');
     }
 
     /**
@@ -678,12 +677,10 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
         });
     }
 
-    /**
-     * @return Attribute<string, never>
-     */
-    protected function photoPreview(): Attribute
+
+    public function smallPhoto(): string
     {
-        return Attribute::make(get: fn (): string => $this->generatePhotoPath());
+        return $this->photo ? $this->generatePhotoPath(150, 150):$this->getFirstMediaUrl('profile_picture', 'thumb');
     }
 
     public function getIcalUrl(): string

--- a/app/Services/MediaLibrary/CustomPathGenerator.php
+++ b/app/Services/MediaLibrary/CustomPathGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services\MediaLibrary;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\PathGenerator\PathGenerator;
+
+class CustomPathGenerator implements PathGenerator
+{
+    public function getPath(Media $media): string
+    {
+        return md5($media->id.config('app.key')).'/';
+    }
+
+    public function getPathForConversions(Media $media): string
+    {
+        return md5($media->id.config('app.key')).'/conversions/';
+    }
+
+    public function getPathForResponsiveImages(Media $media): string
+    {
+        return md5($media->id.config('app.key')).'/responsive-images/';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,8 @@
         "socialiteproviders/saml2": "^4.7",
         "google/apiclient": "^2.18.0",
         "ably/ably-php": "^1.1",
-        "anhskohbo/no-captcha": "^3.7"
+        "anhskohbo/no-captcha": "^3.7",
+        "spatie/laravel-medialibrary": "^11.13"
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "56b8299180dca9e608d73cec25a5ae31",
+    "content-hash": "8841e54c0d090e34244585f0163bf85d",
     "packages": [
         {
             "name": "abcaeffchen/sepa-utilities",
@@ -1328,6 +1328,87 @@
                 }
             ],
             "time": "2025-05-26T15:08:54+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-19T14:15:21+00:00"
         },
         {
             "name": "daverandom/libdns",
@@ -4918,6 +4999,84 @@
             "time": "2025-02-23T10:38:31+00:00"
         },
         {
+            "name": "maennchen/zipstream-php",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "aeadcf5c412332eb426c0f9b4485f6accba2a99f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/aeadcf5c412332eb426c0f9b4485f6accba2a99f",
+                "reference": "aeadcf5c412332eb426c0f9b4485f6accba2a99f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-zlib": "*",
+                "php-64bit": "^8.2"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.7",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.16",
+                "guzzlehttp/guzzle": "^7.5",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpunit/phpunit": "^11.0",
+                "vimeo/psalm": "^6.0"
+            },
+            "suggest": {
+                "guzzlehttp/psr7": "^2.4",
+                "psr/http-message": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
+                }
+            ],
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "support": {
+                "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/maennchen",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-27T12:07:53+00:00"
+        },
+        {
             "name": "milon/barcode",
             "version": "v12.0.0",
             "source": {
@@ -7962,6 +8121,134 @@
             "time": "2022-04-22T08:51:55+00:00"
         },
         {
+            "name": "spatie/image",
+            "version": "3.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/image.git",
+                "reference": "df315a480113081c5c27958bee9bf3f97f36fe76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/image/zipball/df315a480113081c5c27958bee9bf3f97f36fe76",
+                "reference": "df315a480113081c5c27958bee9bf3f97f36fe76",
+                "shasum": ""
+            },
+            "require": {
+                "ext-exif": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^8.2",
+                "spatie/image-optimizer": "^1.7.5",
+                "spatie/temporary-directory": "^2.2",
+                "symfony/process": "^6.4|^7.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-imagick": "*",
+                "laravel/sail": "^1.34",
+                "pestphp/pest": "^2.28",
+                "phpstan/phpstan": "^1.10.50",
+                "spatie/pest-plugin-snapshots": "^2.1",
+                "spatie/pixelmatch-php": "^1.0",
+                "spatie/ray": "^1.40.1",
+                "symfony/var-dumper": "^6.4|7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Image\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Manipulate images with an expressive API",
+            "homepage": "https://github.com/spatie/image",
+            "keywords": [
+                "image",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/image/tree/3.8.4"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-06-04T08:18:18+00:00"
+        },
+        {
+            "name": "spatie/image-optimizer",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/image-optimizer.git",
+                "reference": "4fd22035e81d98fffced65a8c20d9ec4daa9671c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/image-optimizer/zipball/4fd22035e81d98fffced65a8c20d9ec4daa9671c",
+                "reference": "4fd22035e81d98fffced65a8c20d9ec4daa9671c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.3|^8.0",
+                "psr/log": "^1.0 | ^2.0 | ^3.0",
+                "symfony/process": "^4.2|^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^1.21",
+                "phpunit/phpunit": "^8.5.21|^9.4.4",
+                "symfony/var-dumper": "^4.2|^5.0|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ImageOptimizer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily optimize images using PHP",
+            "homepage": "https://github.com/spatie/image-optimizer",
+            "keywords": [
+                "image-optimizer",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/image-optimizer/issues",
+                "source": "https://github.com/spatie/image-optimizer/tree/1.8.0"
+            },
+            "time": "2024-11-04T08:24:54+00:00"
+        },
+        {
             "name": "spatie/laravel-csp",
             "version": "2.10.3",
             "source": {
@@ -8125,6 +8412,115 @@
                 }
             ],
             "time": "2025-06-12T09:42:08+00:00"
+        },
+        {
+            "name": "spatie/laravel-medialibrary",
+            "version": "11.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-medialibrary.git",
+                "reference": "e2324b2f138ec41181089a7dcf28489be93ede53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/e2324b2f138ec41181089a7dcf28489be93ede53",
+                "reference": "e2324b2f138ec41181089a7dcf28489be93ede53",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^3.4",
+                "ext-exif": "*",
+                "ext-fileinfo": "*",
+                "ext-json": "*",
+                "illuminate/bus": "^10.2|^11.0|^12.0",
+                "illuminate/conditionable": "^10.2|^11.0|^12.0",
+                "illuminate/console": "^10.2|^11.0|^12.0",
+                "illuminate/database": "^10.2|^11.0|^12.0",
+                "illuminate/pipeline": "^10.2|^11.0|^12.0",
+                "illuminate/support": "^10.2|^11.0|^12.0",
+                "maennchen/zipstream-php": "^3.1",
+                "php": "^8.2",
+                "spatie/image": "^3.3.2",
+                "spatie/laravel-package-tools": "^1.16.1",
+                "spatie/temporary-directory": "^2.2",
+                "symfony/console": "^6.4.1|^7.0"
+            },
+            "conflict": {
+                "php-ffmpeg/php-ffmpeg": "<0.6.1"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.293.10",
+                "ext-imagick": "*",
+                "ext-pdo_sqlite": "*",
+                "ext-zip": "*",
+                "guzzlehttp/guzzle": "^7.8.1",
+                "larastan/larastan": "^2.7|^3.0",
+                "league/flysystem-aws-s3-v3": "^3.22",
+                "mockery/mockery": "^1.6.7",
+                "orchestra/testbench": "^7.0|^8.17|^9.0|^10.0",
+                "pestphp/pest": "^2.28|^3.5",
+                "phpstan/extension-installer": "^1.3.1",
+                "spatie/laravel-ray": "^1.33",
+                "spatie/pdf-to-image": "^2.2|^3.0",
+                "spatie/pest-plugin-snapshots": "^2.1"
+            },
+            "suggest": {
+                "league/flysystem-aws-s3-v3": "Required to use AWS S3 file storage",
+                "php-ffmpeg/php-ffmpeg": "Required for generating video thumbnails",
+                "spatie/pdf-to-image": "Required for generating thumbnails of PDFs and SVGs"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\MediaLibrary\\MediaLibraryServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\MediaLibrary\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Associate files with Eloquent models",
+            "homepage": "https://github.com/spatie/laravel-medialibrary",
+            "keywords": [
+                "cms",
+                "conversion",
+                "downloads",
+                "images",
+                "laravel",
+                "laravel-medialibrary",
+                "media",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-medialibrary/issues",
+                "source": "https://github.com/spatie/laravel-medialibrary/tree/11.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-22T12:25:27+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",
@@ -8429,6 +8825,67 @@
                 }
             ],
             "time": "2025-02-14T10:18:38+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "580eddfe9a0a41a902cac6eeb8f066b42e65a32b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/580eddfe9a0a41a902cac6eeb8f066b42e65a32b",
+                "reference": "580eddfe9a0a41a902cac6eeb8f066b42e65a32b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-13T13:04:43+00:00"
         },
         {
             "name": "spatie/typescript-transformer",

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -1,0 +1,287 @@
+<?php
+
+use App\Services\MediaLibrary\CustomPathGenerator;
+
+return [
+
+    /*
+     * The disk on which to store added files and derived images by default. Choose
+     * one or more of the disks you've configured in config/filesystems.php.
+     */
+    'disk_name' => env('MEDIA_DISK', 'public'),
+
+    /*
+     * The maximum file size of an item in bytes.
+     * Adding a larger file will result in an exception.
+     */
+    'max_file_size' => 1024 * 1024 * 10, // 10MB
+
+    /*
+     * This queue connection will be used to generate derived and responsive images.
+     * Leave empty to use the default queue connection.
+     */
+    'queue_connection_name' => env('QUEUE_CONNECTION', 'sync'),
+
+    /*
+     * This queue will be used to generate derived and responsive images.
+     * Leave empty to use the default queue.
+     */
+    'queue_name' => env('MEDIA_QUEUE', 'low'),
+
+    /*
+     * By default all conversions will be performed on a queue.
+     */
+    'queue_conversions_by_default' => env('QUEUE_CONVERSIONS_BY_DEFAULT', true),
+
+    /*
+     * Should database transactions be run after database commits?
+     */
+    'queue_conversions_after_database_commit' => env('QUEUE_CONVERSIONS_AFTER_DB_COMMIT', true),
+
+    /*
+     * The fully qualified class name of the media model.
+     */
+    'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
+
+    /*
+     * The fully qualified class name of the media observer.
+     */
+    'media_observer' => Spatie\MediaLibrary\MediaCollections\Models\Observers\MediaObserver::class,
+
+    /*
+     * When enabled, media collections will be serialised using the default
+     * laravel model serialization behaviour.
+     *
+     * Keep this option disabled if using Media Library Pro components (https://medialibrary.pro)
+     */
+    'use_default_collection_serialization' => false,
+
+    /*
+     * The fully qualified class name of the model used for temporary uploads.
+     *
+     * This model is only used in Media Library Pro (https://medialibrary.pro)
+     */
+    'temporary_upload_model' => Spatie\MediaLibraryPro\Models\TemporaryUpload::class,
+
+    /*
+     * When enabled, Media Library Pro will only process temporary uploads that were uploaded
+     * in the same session. You can opt to disable this for stateless usage of
+     * the pro components.
+     */
+    'enable_temporary_uploads_session_affinity' => true,
+
+    /*
+     * When enabled, Media Library pro will generate thumbnails for uploaded file.
+     */
+    'generate_thumbnails_for_temporary_uploads' => true,
+
+    /*
+     * This is the class that is responsible for naming generated files.
+     */
+    'file_namer' => Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer::class,
+
+    /*
+     * The class that contains the strategy for determining a media file's path.
+     */
+    'path_generator' => CustomPathGenerator::class,
+
+    /*
+     * The class that contains the strategy for determining how to remove files.
+     */
+    'file_remover_class' => Spatie\MediaLibrary\Support\FileRemover\DefaultFileRemover::class,
+
+    /*
+     * Here you can specify which path generator should be used for the given class.
+     */
+    'custom_path_generators' => [
+        // Model::class => PathGenerator::class
+        // or
+        // 'model_morph_alias' => PathGenerator::class
+    ],
+
+    /*
+     * When urls to files get generated, this class will be called. Use the default
+     * if your files are stored locally above the site root or on s3.
+     */
+    'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
+
+    /*
+     * Moves media on updating to keep path consistent. Enable it only with a custom
+     * PathGenerator that uses, for example, the media UUID.
+     */
+    'moves_media_on_update' => false,
+
+    /*
+     * Whether to activate versioning when urls to files get generated.
+     * When activated, this attaches a ?v=xx query string to the URL.
+     */
+    'version_urls' => false,
+
+    /*
+     * The media library will try to optimize all converted images by removing
+     * metadata and applying a little bit of compression. These are
+     * the optimizers that will be used by default.
+     */
+    'image_optimizers' => [
+        Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
+            '-m85', // set maximum quality to 85%
+            '--force', // ensure that progressive generation is always done also if a little bigger
+            '--strip-all', // this strips out all text information such as comments and EXIF data
+            '--all-progressive', // this will make sure the resulting image is a progressive one
+        ],
+        Spatie\ImageOptimizer\Optimizers\Pngquant::class => [
+            '--force', // required parameter for this package
+        ],
+        Spatie\ImageOptimizer\Optimizers\Optipng::class => [
+            '-i0', // this will result in a non-interlaced, progressive scanned image
+            '-o2', // this set the optimization level to two (multiple IDAT compression trials)
+            '-quiet', // required parameter for this package
+        ],
+        Spatie\ImageOptimizer\Optimizers\Svgo::class => [
+            '--disable=cleanupIDs', // disabling because it is known to cause troubles
+        ],
+        Spatie\ImageOptimizer\Optimizers\Gifsicle::class => [
+            '-b', // required parameter for this package
+            '-O3', // this produces the slowest but best results
+        ],
+        Spatie\ImageOptimizer\Optimizers\Cwebp::class => [
+            '-m 6', // for the slowest compression method in order to get the best compression.
+            '-pass 10', // for maximizing the amount of analysis pass.
+            '-mt', // multithreading for some speed improvements.
+            '-q 90', // quality factor that brings the least noticeable changes.
+        ],
+        Spatie\ImageOptimizer\Optimizers\Avifenc::class => [
+            '-a cq-level=23', // constant quality level, lower values mean better quality and greater file size (0-63).
+            '-j all', // number of jobs (worker threads, "all" uses all available cores).
+            '--min 0', // min quantizer for color (0-63).
+            '--max 63', // max quantizer for color (0-63).
+            '--minalpha 0', // min quantizer for alpha (0-63).
+            '--maxalpha 63', // max quantizer for alpha (0-63).
+            '-a end-usage=q', // rate control mode set to Constant Quality mode.
+            '-a tune=ssim', // SSIM as tune the encoder for distortion metric.
+        ],
+    ],
+
+    /*
+     * These generators will be used to create an image of media files.
+     */
+    'image_generators' => [
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Image::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Webp::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Avif::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Svg::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Video::class,
+    ],
+
+    /*
+     * The path where to store temporary files while performing image conversions.
+     * If set to null, storage_path('media-library/temp') will be used.
+     */
+    'temporary_directory_path' => null,
+
+    /*
+     * The engine that should perform the image conversions.
+     * Should be either `gd` or `imagick`.
+     */
+    'image_driver' => env('IMAGE_DRIVER', 'gd'),
+
+    /*
+     * FFMPEG & FFProbe binaries paths, only used if you try to generate video
+     * thumbnails and have installed the php-ffmpeg/php-ffmpeg composer
+     * dependency.
+     */
+    'ffmpeg_path' => env('FFMPEG_PATH', '/usr/bin/ffmpeg'),
+    'ffprobe_path' => env('FFPROBE_PATH', '/usr/bin/ffprobe'),
+
+    /*
+     * Here you can override the class names of the jobs used by this package. Make sure
+     * your custom jobs extend the ones provided by the package.
+     */
+    'jobs' => [
+        'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
+        'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
+    ],
+
+    /*
+     * When using the addMediaFromUrl method you may want to replace the default downloader.
+     * This is particularly useful when the url of the image is behind a firewall and
+     * need to add additional flags, possibly using curl.
+     */
+    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
+
+    /*
+     * When using the addMediaFromUrl method the SSL is verified by default.
+     * This is option disables SSL verification when downloading remote media.
+     * Please note that this is a security risk and should only be false in a local environment.
+     */
+    'media_downloader_ssl' => env('MEDIA_DOWNLOADER_SSL', true),
+
+    'remote' => [
+        /*
+         * Any extra headers that should be included when uploading media to
+         * a remote disk. Even though supported headers may vary between
+         * different drivers, a sensible default has been provided.
+         *
+         * Supported by S3: CacheControl, Expires, StorageClass,
+         * ServerSideEncryption, Metadata, ACL, ContentEncoding
+         */
+        'extra_headers' => [
+            'CacheControl' => 'max-age=604800',
+        ],
+    ],
+
+    'responsive_images' => [
+        /*
+         * This class is responsible for calculating the target widths of the responsive
+         * images. By default we optimize for filesize and create variations that each are 30%
+         * smaller than the previous one. More info in the documentation.
+         *
+         * https://docs.spatie.be/laravel-medialibrary/v9/advanced-usage/generating-responsive-images
+         */
+        'width_calculator' => Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator::class,
+
+        /*
+         * By default rendering media to a responsive image will add some javascript and a tiny placeholder.
+         * This ensures that the browser can already determine the correct layout.
+         * When disabled, no tiny placeholder is generated.
+         */
+        'use_tiny_placeholders' => true,
+
+        /*
+         * This class will generate the tiny placeholder used for progressive image loading. By default
+         * the media library will use a tiny blurred jpg image.
+         */
+        'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
+    ],
+
+    /*
+     * When enabling this option, a route will be registered that will enable
+     * the Media Library Pro Vue and React components to move uploaded files
+     * in a S3 bucket to their right place.
+     */
+    'enable_vapor_uploads' => env('ENABLE_MEDIA_LIBRARY_VAPOR_UPLOADS', false),
+
+    /*
+     * When converting Media instances to response the media library will add
+     * a `loading` attribute to the `img` tag. Here you can set the default
+     * value of that attribute.
+     *
+     * Possible values: 'lazy', 'eager', 'auto' or null if you don't want to set any loading instruction.
+     *
+     * More info: https://css-tricks.com/native-lazy-loading/
+     */
+    'default_loading_attribute_value' => null,
+
+    /*
+     * You can specify a prefix for that is used for storing all media.
+     * If you set this to `/my-subdir`, all your media will be stored in a `/my-subdir` directory.
+     */
+    'prefix' => env('MEDIA_PREFIX', ''),
+
+    /*
+     * When forcing lazy loading, media will be loaded even if you don't eager load media and you have
+     * disabled lazy loading globally in the service provider.
+     */
+    'force_lazy_loading' => env('FORCE_MEDIA_LIBRARY_LAZY_LOADING', true),
+];

--- a/database/migrations/2025_06_21_185748_create_media_table.php
+++ b/database/migrations/2025_06_21_185748_create_media_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->id();
+
+            $table->morphs('model');
+            $table->uuid()->nullable()->unique();
+            $table->string('collection_name');
+            $table->string('name');
+            $table->string('file_name');
+            $table->string('mime_type')->nullable();
+            $table->string('disk');
+            $table->string('conversions_disk')->nullable();
+            $table->unsignedBigInteger('size');
+            $table->json('manipulations');
+            $table->json('custom_properties');
+            $table->json('generated_conversions');
+            $table->json('responsive_images');
+            $table->unsignedInteger('order_column')->nullable()->index();
+
+            $table->nullableTimestamps();
+        });
+    }
+};

--- a/resources/views/event/display_includes/render_participant_list.blade.php
+++ b/resources/views/event/display_includes/render_participant_list.blade.php
@@ -1,10 +1,11 @@
+@php use App\Models\User; @endphp
 @foreach ($participants as $user)
-    <?php $pid =
-        $user::class == \App\Models\User::class && $event
+        <?php $pid =
+        $user::class == User::class && $event
             ? $user->pivot->id
             : $user->id; ?>
 
-    <?php $u = $user::class == \App\Models\User::class ? $user : $user->user; ?>
+        <?php $u = $user::class == User::class ? $user : $user->user; ?>
 
     <div class="btn-group btn-group-sm mb-1">
         <a

--- a/resources/views/event/display_includes/render_participant_list.blade.php
+++ b/resources/views/event/display_includes/render_participant_list.blade.php
@@ -14,7 +14,7 @@
             class="btn btn-outline-primary"
         >
             <img
-                src="{{ $u->smallPhoto()}}"
+                src="{{ $u->smallPhoto() }}"
                 class="rounded-circle me-1"
                 style="width: 21px; height: 21px; margin-top: -3px"
             />

--- a/resources/views/event/display_includes/render_participant_list.blade.php
+++ b/resources/views/event/display_includes/render_participant_list.blade.php
@@ -13,7 +13,7 @@
             class="btn btn-outline-primary"
         >
             <img
-                src="{{ $u->generatePhotoPath(25, 25) }}"
+                src="{{ $u->smallPhoto()}}"
                 class="rounded-circle me-1"
                 style="width: 21px; height: 21px; margin-top: -3px"
             />

--- a/resources/views/users/admin/admin_includes/hoofd.blade.php
+++ b/resources/views/users/admin/admin_includes/hoofd.blade.php
@@ -4,9 +4,6 @@
     </div>
 
     <div class="card-body p-5 text-center">
-        <img
-            src="{{ $user->smallPhoto() }}"
-            class="rounded-circle mw-100"
-        />
+        <img src="{{ $user->smallPhoto() }}" class="rounded-circle mw-100" />
     </div>
 </div>

--- a/resources/views/users/admin/admin_includes/hoofd.blade.php
+++ b/resources/views/users/admin/admin_includes/hoofd.blade.php
@@ -5,7 +5,7 @@
 
     <div class="card-body p-5 text-center">
         <img
-            src="{{ $user->generatePhotoPath(800, 800) }}"
+            src="{{ $user->smallPhoto() }}"
             class="rounded-circle mw-100"
         />
     </div>

--- a/resources/views/users/dashboard/includes/profilepic.blade.php
+++ b/resources/views/users/dashboard/includes/profilepic.blade.php
@@ -19,9 +19,9 @@
 
                 <div class="col-7 text-center">
                     <img
-                        src="{{ $user->generatePhotoPath(150, 150) }}"
-                        width="150px"
-                        height="150px"
+                        src="{{ $user->getFirstMediaUrl('profile_picture', 'thumb')}}"
+                        width="100px"
+                        height="100px"
                         class="rounded-circle"
                     />
                 </div>

--- a/resources/views/users/dashboard/includes/profilepic.blade.php
+++ b/resources/views/users/dashboard/includes/profilepic.blade.php
@@ -19,7 +19,7 @@
 
                 <div class="col-7 text-center">
                     <img
-                        src="{{ $user->getFirstMediaUrl('profile_picture', 'thumb')}}"
+                        src="{{ $user->smallPhoto()}}"
                         width="100px"
                         height="100px"
                         class="rounded-circle"

--- a/resources/views/users/includes/usercard.blade.php
+++ b/resources/views/users/includes/usercard.blade.php
@@ -6,7 +6,7 @@
                 height="50px"
                 class="rounded-circle float-end"
                 alt="{{ $user->name }}'s photo"
-                src="{!! $user->generatePhotoPath(50, 50) !!}"
+                src="{!! $user->smallPhoto() !!}"
             />
             <a
                 href="{{ route('user::profile', ['id' => $user->getPublicId()]) }}"

--- a/resources/views/users/profile/includes/about.blade.php
+++ b/resources/views/users/profile/includes/about.blade.php
@@ -9,7 +9,7 @@
 
             <div class="text-center">
                 <img
-                    src="{{ $user->generatePhotoPath(170, 170) }}"
+                    src="{{ $user->smallPhoto() }}"
                     class="rounded-circle bg-dark mt-2 border border-5 border-white"
                     width="170px"
                     height="170px"

--- a/resources/views/website/navbar.blade.php
+++ b/resources/views/website/navbar.blade.php
@@ -661,7 +661,7 @@
                                         id="profile-picture"
                                         class="rounded-circle ms-2"
                                         alt="your profile picture"
-                                        src="{{ Auth::user()->load('photo')->generatePhotoPath() }}"
+                                        src="{{ Auth::user()->load('photo')->smallPhoto() }}"
                                     />
                                 </a>
 


### PR DESCRIPTION
This puts the profile pictures on the public drive using laravel-media library.
This makes it also have a resized version of 100x100 so we do not need to do that with cache anymore.
For now only implemented for sysadmins to see if it works