### PR TITLE
Add support for a barcode scanner in the omnomcom

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -49,7 +49,7 @@ class ProductController extends Controller
     {
         return view('omnomcom.products.edit', [
             'product' => null,
-            'accounts' => Account::query()->orderBy('account_number', 'asc')->get(),
+            'accounts' => Account::query()->orderBy('account_number')->get(),
             'categories' => ProductCategory::all(),
         ]);
     }
@@ -61,11 +61,12 @@ class ProductController extends Controller
      */
     public function store(Request $request)
     {
-        $product = Product::query()->create($request->except('image', 'product_categories'));
+        $product = Product::query()->create($request->except('image', 'product_categories', 'barcode'));
         $product->price = floatval(str_replace(',', '.', $request->price));
         $product->is_visible = $request->has('is_visible');
         $product->is_alcoholic = $request->has('is_alcoholic');
         $product->is_visible_when_no_stock = $request->has('is_visible_when_no_stock');
+        $product->barcode = $request->input('barcode')!='' ? $request->input('barcode') : null;
 
         if ($request->file('image')) {
             $file = new StorageEntry;
@@ -105,7 +106,7 @@ class ProductController extends Controller
             'product' => $product,
             'accounts' => Account::query()->orderBy('account_number', 'asc')->get(),
             'categories' => ProductCategory::all(),
-            'orderlines' => $product->orderlines()->orderBy('created_at', 'DESC')->paginate(20),
+            'orderlines' => $product->orderlines()->with('user')->orderBy('created_at', 'DESC')->paginate(20),
         ]);
     }
 
@@ -156,6 +157,7 @@ class ProductController extends Controller
         $product->is_visible = $request->has('is_visible');
         $product->is_alcoholic = $request->has('is_alcoholic');
         $product->is_visible_when_no_stock = $request->has('is_visible_when_no_stock');
+        $product->barcode = $request->input('barcode')!='' ? $request->input('barcode') : null;
 
         if ($request->file('image')) {
             $file = new StorageEntry;

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Carbon;
  * @property string $name
  * @property float $price
  * @property int $calories
+ * @property int|null $barcode
  * @property string|null $supplier_id
  * @property int $stock
  * @property int $preferred_stock

--- a/database/migrations/2025_07_19_100444_add_barcode_to_products.php
+++ b/database/migrations/2025_07_19_100444_add_barcode_to_products.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->integer('barcode')->after('calories')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('barcode');
+        });
+    }
+};

--- a/resources/views/companies/adminlist.blade.php
+++ b/resources/views/companies/adminlist.blade.php
@@ -42,10 +42,10 @@
                                     </a>
                                 </td>
                                 <td class="on-carreer-page">
-                                    {{ $company->on_carreer_page ? 'Yes' : 'No' }}
+                                    {{ $company->on_carreer_page ? '✅' : '❌' }}
                                 </td>
                                 <td class="in-logo-bar">
-                                    {{ $company->in_logo_bar ? 'Yes' : 'No' }}
+                                    {{ $company->in_logo_bar ? '✅' : '❌' }}
                                 </td>
                                 <td>
                                     <a

--- a/resources/views/omnomcom/products/edit_includes/edit.blade.php
+++ b/resources/views/omnomcom/products/edit_includes/edit.blade.php
@@ -159,8 +159,8 @@
             </div>
 
             <div class="row mb-3">
-                <div class="col-md-4">
-                    <label for="price">Calories:</label>
+                <div class="col-md-6">
+                    <label for="calories">Calories:</label>
                     <div class="input-group">
                         <input
                             type="text"
@@ -169,6 +169,19 @@
                             name="calories"
                             placeholder="0"
                             value="{{ $product->calories ?? '' }}"
+                        />
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <label for="barcode">Barcode:</label>
+                    <div class="input-group">
+                        <input
+                            type="text"
+                            class="form-control"
+                            id="barcode"
+                            name="barcode"
+                            placeholder="42256700"
+                            value="{{ $product->barcode ?? '' }}"
                         />
                     </div>
                 </div>

--- a/resources/views/omnomcom/products/edit_includes/edit.blade.php
+++ b/resources/views/omnomcom/products/edit_includes/edit.blade.php
@@ -174,6 +174,11 @@
                 </div>
                 <div class="col-md-6">
                     <label for="barcode">Barcode:</label>
+                    <i
+                        class="fas fa-info-circle fa-fw mr-2"
+                        data-bs-toggle="tooltip"
+                        title="The number under the barcode of the product so it can be scanned"
+                    ></i>
                     <div class="input-group">
                         <input
                             type="text"

--- a/resources/views/omnomcom/products/index.blade.php
+++ b/resources/views/omnomcom/products/index.blade.php
@@ -123,6 +123,7 @@
                                     <td>Stock</td>
                                     <td>Visible</td>
                                     <td>Alcoholic</td>
+                                    <td>Barcode</td>
                                     <td></td>
                                 </tr>
                             </thead>
@@ -140,11 +141,12 @@
                                         <td>{{ $product->calories }}</td>
                                         <td>{{ $product->stock }}</td>
                                         <td>
-                                            {{ $product->is_visible ? 'Yes' : 'No' }}
+                                            {{ $product->is_visible ? '✅' : '❌' }}
                                         </td>
                                         <td>
-                                            {{ $product->is_alcoholic ? 'Yes' : 'No' }}
+                                            {{ $product->is_alcoholic ? '✅' : '❌' }}
                                         </td>
+                                        <td>{{ $product->barcode }}</td>
                                         <td style="min-width: 60px">
                                             <a
                                                 href="{{ route('omnomcom::products::edit', ['id' => $product->id]) }}"

--- a/resources/views/omnomcom/products/mutations.blade.php
+++ b/resources/views/omnomcom/products/mutations.blade.php
@@ -143,7 +143,7 @@
                                                 </a>
                                             </td>
                                             <td>
-                                                {{ $mutation->is_bulk ? 'Yes' : 'No' }}
+                                                {{ $mutation->is_bulk ? '✅' : '❌' }}
                                             </td>
                                             <td>{{ $mutation->date() }}</td>
                                         </tr>

--- a/resources/views/omnomcom/store/includes/product_overview.blade.php
+++ b/resources/views/omnomcom/store/includes/product_overview.blade.php
@@ -22,6 +22,7 @@
                         data-id="{{ $product->id }}"
                         data-stock="{{ $product->stock }}"
                         data-price="{{ $product->price }}"
+                        data-barcode="{{ $product->barcode }}"
                     >
                         <div class="product-inner">
                             <div class="product-image">

--- a/resources/views/omnomcom/store/show.blade.php
+++ b/resources/views/omnomcom/store/show.blade.php
@@ -122,7 +122,7 @@
             let stock = []
             let price = []
 
-            function addToCart(el){
+            function addToCart(el) {
                 const id = el.getAttribute('data-id')
                 const s = stock[id]
                 if (s <= 0) {
@@ -701,31 +701,29 @@
                 idleWarning = false
             })
 
-            function findItem(barcode){
-                const el = document.querySelector(
-                    `[data-barcode="${barcode}"]`
-                )
-                if(el){
+            function findItem(barcode) {
+                const el = document.querySelector(`[data-barcode="${barcode}"]`)
+                if (el) {
                     addToCart(el)
                 }
             }
 
-            let barcode = '';
-            let lastkeyPress = performance.now();
+            let barcode = ''
+            let lastkeyPress = performance.now()
 
             // Reset idle timer on keydown
             document.body.addEventListener('keydown', function (event) {
-                const key = event.key;
-                const now = performance.now();
-                if((now - lastkeyPress) > 30){
+                const key = event.key
+                const now = performance.now()
+                if (now - lastkeyPress > 30) {
                     barcode = ''
-                    barcode +=key
-                }else{
-                    if(event.key === 'Enter' && barcode !== ''){
-                     findItem(barcode)
+                    barcode += key
+                } else {
+                    if (event.key === 'Enter' && barcode !== '') {
+                        findItem(barcode)
                         barcode = ''
-                    }else{
-                        barcode +=key
+                    } else {
+                        barcode += key
                     }
                 }
 

--- a/resources/views/omnomcom/store/show.blade.php
+++ b/resources/views/omnomcom/store/show.blade.php
@@ -122,6 +122,18 @@
             let stock = []
             let price = []
 
+            function addToCart(el){
+                const id = el.getAttribute('data-id')
+                const s = stock[id]
+                if (s <= 0) {
+                    modals['outofstock-modal'].show()
+                } else {
+                    cart[id]++
+                    stock[id]--
+                    update('add')
+                }
+            }
+
             async function initializeOmNomCom() {
                 await get(config.routes.api_omnomcom_stock, {
                     store: '{{ $store_slug }}',
@@ -193,15 +205,7 @@
                                 modals['outofstock-modal'].show()
                             }
                         } else {
-                            const id = el.getAttribute('data-id')
-                            const s = stock[id]
-                            if (s <= 0) {
-                                modals['outofstock-modal'].show()
-                            } else {
-                                cart[id]++
-                                stock[id]--
-                                update('add')
-                            }
+                            addToCart(el)
                         }
                     })
                 })
@@ -697,8 +701,35 @@
                 idleWarning = false
             })
 
+            function findItem(barcode){
+                const el = document.querySelector(
+                    `[data-barcode="${barcode}"]`
+                )
+                if(el){
+                    addToCart(el)
+                }
+            }
+
+            let barcode = '';
+            let lastkeyPress = performance.now();
+
             // Reset idle timer on keydown
-            document.body.addEventListener('keydown', () => {
+            document.body.addEventListener('keydown', function (event) {
+                const key = event.key;
+                const now = performance.now();
+                if((now - lastkeyPress) > 30){
+                    barcode = ''
+                    barcode +=key
+                }else{
+                    if(event.key === 'Enter' && barcode !== ''){
+                     findItem(barcode)
+                        barcode = ''
+                    }else{
+                        barcode +=key
+                    }
+                }
+
+                lastkeyPress = now
                 idleTime = 0
                 idleWarning = false
             })


### PR DESCRIPTION
This PR adds support for a barcode scanner attached to the omnomcom.
We have barcode scanners that can read the EAN numbers, so if we add that code to the product the omnomcom page can detect the keypresses of the scanner (it simulates a keyboard) and try to find the right product. If it is found it will be added to the cart. 