### PR TITLE
Move over the cover pictures of the events to the Laravel media library

### DIFF
--- a/app/Console/Commands/CopyEventPictures.php
+++ b/app/Console/Commands/CopyEventPictures.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Event;
+use Illuminate\Console\Command;
+
+class CopyEventPictures extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'proto:copy-event-pictures';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Copies the event pictures from our own storage entries to the laravel media library';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        Event::query()->whereHas('image')
+            ->with('image')->chunkById(100, function ($events) {
+                /** @var Event $event */
+                foreach ($events as $event) {
+                    $event->addMedia($event->image->generateLocalPath())
+                        ->usingName($event->image->original_filename)
+                        ->usingFileName('event_'.$event->id)
+                        ->preservingOriginal()
+                        ->toMediaCollection('header');
+                }
+            });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -7,6 +7,7 @@ use App\Console\Commands\AddSysadmin;
 use App\Console\Commands\BirthdayCron;
 use App\Console\Commands\CheckUtwenteAccounts;
 use App\Console\Commands\ClearSessionTable;
+use App\Console\Commands\CopyEventPictures;
 use App\Console\Commands\EmailCron;
 use App\Console\Commands\EndMemberships;
 use App\Console\Commands\FeeCron;
@@ -78,6 +79,7 @@ class Kernel extends ConsoleKernel
         TempAdminCleanup::class,
         SyncUTAccounts::class,
         GoogleSync::class,
+        CopyEventPictures::class,
     ];
 
     /**

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -286,6 +286,10 @@ class EventController extends Controller
 
         Session::flash('flash_message', "The event '".$event->title."' has been deleted.");
 
+        foreach ($event->getMedia('header') as $media) {
+            $media->delete();
+        }
+
         $event->delete();
 
         return Redirect::route('event::index');

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -11,7 +11,6 @@ use App\Models\EventCategory;
 use App\Models\HelpingCommittee;
 use App\Models\PhotoAlbum;
 use App\Models\Product;
-use App\Models\StorageEntry;
 use App\Models\User;
 use Exception;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -28,6 +27,8 @@ use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Session;
 use Illuminate\View\View;
 use Mollie\Api\Exceptions\ApiException;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileIsTooBig;
 
 class EventController extends Controller
 {
@@ -143,9 +144,14 @@ class EventController extends Controller
         ]);
 
         if ($request->file('image')) {
-            $file = new StorageEntry;
-            $file->createFromFile($request->file('image'));
-            $event->image()->associate($file);
+            try {
+                $event->addMediaFromRequest('image')
+                    ->usingFileName('event_'.$event->id)
+                    ->toMediaCollection('header');
+            } catch (FileDoesNotExist|FileIsTooBig $e) {
+                Session::flash('flash_message', $e->getMessage());
+                Redirect::back();
+            }
         }
 
         $committee = Committee::query()->find($request->input('committee'));
@@ -195,10 +201,14 @@ class EventController extends Controller
         }
 
         if ($request->file('image')) {
-            $file = new StorageEntry;
-            $file->createFromFile($request->file('image'));
-
-            $event->image()->associate($file);
+            try {
+                $event->addMediaFromRequest('image')
+                    ->usingFileName('event_'.$event->id)
+                    ->toMediaCollection('header');
+            } catch (FileDoesNotExist|FileIsTooBig $e) {
+                Session::flash('flash_message', $e->getMessage());
+                Redirect::back();
+            }
         }
 
         if ($request->has('committee')) {
@@ -420,7 +430,7 @@ class EventController extends Controller
             })
             ->whereNull('publication')
             ->orderBy('start')
-            ->with('activity.users.media', 'activity.backupUsers', 'image', 'committee.users', 'tickets')
+            ->with('activity.users.media', 'activity.backupUsers', 'media', 'committee.users', 'tickets')
             ->take($limit)
             ->get();
 
@@ -448,7 +458,7 @@ class EventController extends Controller
             $data[] = (object) [
                 'id' => $event->id,
                 'title' => $event->title,
-                'image' => ($event->image ? $event->image->generateImagePath(800, 300) : null),
+                'image' => ($event->getFirstMediaUrl('header', 'card')),
                 'description' => $event->description,
                 'start' => $event->start,
                 'organizing_committee' => ($event->committee ? [
@@ -645,6 +655,10 @@ CALSCALE:GREGORIAN
             ->header('Content-Disposition', 'attachment; filename="protocalendar.ics"');
     }
 
+    /**
+     * @throws FileIsTooBig
+     * @throws FileDoesNotExist
+     */
     public function copyEvent(Request $request): RedirectResponse
     {
         $event = Event::query()->findOrFail($request->input('id'));
@@ -669,6 +683,16 @@ CALSCALE:GREGORIAN
             'update_sequence' => 0,
         ]);
         $newEvent->save();
+
+        $image = $event->getFirstMedia('header');
+        if($image) {
+            $newEvent->addMedia($image->getPath())
+                ->usingName($image->file_name)
+                ->usingFileName('event_'.$newEvent->id)
+                ->preservingOriginal()
+                ->toMediaCollection('header');
+        }
+
 
         if ($event->activity) {
             $newActivity = $event->activity->replicate([

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -143,14 +143,15 @@ class EventController extends Controller
             'publication' => $request->publication ? $request->date('publication')->timestamp : null,
         ]);
 
-        if ($request->file('image')) {
+        $file = $request->file('image');
+        if ($file) {
             try {
                 $event->addMediaFromRequest('image')
                     ->usingFileName('event_'.$event->id)
                     ->toMediaCollection('header');
             } catch (FileDoesNotExist|FileIsTooBig $e) {
                 Session::flash('flash_message', $e->getMessage());
-                Redirect::back();
+                return Redirect::back();
             }
         }
 
@@ -200,14 +201,15 @@ class EventController extends Controller
             return Redirect::back();
         }
 
-        if ($request->file('image')) {
+        $file = $request->file('image');
+        if ($file) {
             try {
                 $event->addMediaFromRequest('image')
                     ->usingFileName('event_'.$event->id)
                     ->toMediaCollection('header');
             } catch (FileDoesNotExist|FileIsTooBig $e) {
                 Session::flash('flash_message', $e->getMessage());
-                Redirect::back();
+                return Redirect::back();
             }
         }
 

--- a/app/Http/Controllers/ProfilePictureController.php
+++ b/app/Http/Controllers/ProfilePictureController.php
@@ -18,7 +18,7 @@ class ProfilePictureController extends Controller
     public function update(Request $request)
     {
         $request->validate([
-            'image' => 'required|image|max:5120', // max 5MB
+            'image' => 'required|image|max:5120|mimes:jpeg,png,jpg', // max 5MB
         ]);
 
         $user = Auth::user();

--- a/app/Http/Controllers/ProfilePictureController.php
+++ b/app/Http/Controllers/ProfilePictureController.php
@@ -26,7 +26,7 @@ class ProfilePictureController extends Controller
             $user->addMediaFromRequest('image')->toMediaCollection('profile_picture');
         } catch (FileDoesNotExist|FileIsTooBig $e) {
             Session::flash('flash_message', $e->getMessage());
-            Redirect::back();
+            return Redirect::back();
         }
 
         Session::flash('flash_message', 'Your profile picture has been updated!');

--- a/app/Http/Requests/StoreEventRequest.php
+++ b/app/Http/Requests/StoreEventRequest.php
@@ -24,13 +24,13 @@ class StoreEventRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'title' => ['required'],
+            'title' => ['required', 'max:255', 'string'],
             'start' => ['required', 'gte:end'],
-            'location' => ['required'],
+            'location' => ['required', 'max:255', 'string'],
             'secret' => ['required'],
             'description' => ['required'],
             'summary' => ['required'],
-            'image' => ['image'],
+            'image' => ['nullable', 'image', 'mimes:jpeg,png,jpg', 'max:2048'],
         ];
     }
 

--- a/resources/views/emails/newsletter.blade.php
+++ b/resources/views/emails/newsletter.blade.php
@@ -31,9 +31,9 @@
                 >
                     <tr style="margin: 0; padding: 0; border: none">
                         <td style="margin: 0; padding: 20px 40px; border: none">
-                            @if ($event->image)
+                            @if ($event->getFirstMediaUrl('header', 'card') != '')
                                 <img
-                                    src="{{ $event->image->generateImagePath(350, 100) }}"
+                                    src="{{ $event->getFirstMediaUrl('header', 'card') }}"
                                     style="width: 100%"
                                     alt="{{ $event->title }}'s cover image"
                                 />

--- a/resources/views/event/display.blade.php
+++ b/resources/views/event/display.blade.php
@@ -11,9 +11,9 @@
     {{ $event->description }}
 @endsection
 
-@if ($event->image)
+@if ($event->getFirstMediaUrl('header', 'card') !== '')
     @section('og-image')
-        {{ $event->image->generateImagePath(800, 300) }}
+        {{ $event->getFirstMediaUrl('header', 'card') }}
     @endsection
 @endif
 

--- a/resources/views/event/display_includes/event_block.blade.php
+++ b/resources/views/event/display_includes/event_block.blade.php
@@ -7,10 +7,14 @@
         class="card leftborder leftborder-info text-decoration-none mb-3"
         href="{{ route('event::show', ['event' => $event]) }}"
     >
+        @php
+            $url = $event->getFirstMediaUrl('header', 'card');
+        @endphp
+
         <div
-            class="card-body event {{ $event->image ? 'bg-img' : 'no-img' }} text-start"
-            style="{{ empty($lazyload) && $event->image ? 'background-size: cover; background: center no-repeat url(' . $event->image->generateImagePath(800, 300) . ')' : '' }}"
-            data-bgimage="{{ ! empty($lazyload) && $event->image ? $event->image->generateImagePath(800, 300) ?? '' : '' }}"
+            class="card-body event {{ $url !== '' ? 'bg-img' : 'no-img' }} text-start"
+            style="{{ empty($lazyload) && $url !== '' ? 'background-size: cover; background: center no-repeat url(' . $event->getFirstMediaUrl('header', 'card') . ')' : '' }}"
+            data-bgimage="{{ ! empty($lazyload) ? $url : '' }}"
         >
             {{-- Countdown --}}
             @if (! empty($countdown))

--- a/resources/views/event/display_includes/event_details.blade.php
+++ b/resources/views/event/display_includes/event_details.blade.php
@@ -42,10 +42,10 @@
 </div>
 
 <div class="card mb-3">
-    @if ($event->image)
+    @if ($event->getFirstMediaUrl('header', 'card') != '')
         <img
             class="card-img-top"
-            src="{{ $event->image->generateImagePath(800, 300) }}"
+            src="{{ $event->getFirstMediaUrl('header', 'card') }}"
             width="100%"
         />
     @endif

--- a/resources/views/event/edit_includes/event-details.blade.php
+++ b/resources/views/event/edit_includes/event-details.blade.php
@@ -247,7 +247,7 @@
 
                         <h5>Current image:</h5>
                         <img
-                            src="{!! $event->image->generateImagePath(800, 300) !!}"
+                            src="{!! $event->getFirstMediaUrl('header', 'card') !!}"
                             class="w-100 border"
                         />
                     @endif


### PR DESCRIPTION
This PR moves the cover pictures of the events to the laravel media library. 
The collection they are included in puts the pictures on the public drive, so they load faster. 
