### PR TITLE
Prevent seeder crashes when event has bad dates.

### DIFF
--- a/database/factories/ActivityParticipationFactory.php
+++ b/database/factories/ActivityParticipationFactory.php
@@ -41,11 +41,12 @@ class ActivityParticipationFactory extends Factory
 
         try {
             $date = fake()->dateTimeBetween($start, $end);
-        } catch(Exception $e ) {
-            echo "\nWarning, error occured: ". $e->getMessage(). "\n";
-            echo "When creating participation for activity: '" . $activity->event->title . "' (" . $activity->event->id . ")\n" ;
+        } catch (Exception $e) {
+            echo "\nWarning, error occured: ".$e->getMessage()."\n";
+            echo "When creating participation for activity: '".$activity->event->title."' (".$activity->event->id.")\n";
             $date = $end;
         }
+
         return $date->format('Y-m-d H:i:s');
     }
 


### PR DESCRIPTION
This commit makes it so when the signup start is after the start of the activity, the seeder sends a warning and sets the signup date to the start date of the activity.

This behavior is not fully correct, and the activity should be corrected on the live site. That's why it sends a warning when the correction occurs.