### PR TITLE
Fix password update not saving

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -442,7 +442,8 @@ class User extends Authenticatable implements AuthenticatableContract, CanResetP
      */
     public function setPassword(string $password): void
     {
-        $this->update(['password' => Hash::make($password)]);
+        $this->password = Hash::make($password);
+        $this->save();
     }
 
     public function hasUnpaidOrderlines(): bool


### PR DESCRIPTION
->update calls ->fill under the hood; password is not a fillable field.

Broken by:
https://github.com/saproto/saproto/commit/4425dbd62887d3f467f3ee075c8c10f357bd15eb#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecb