### PR TITLE
Fix the sharing of the Proto Wrapped Top Protube slide

### DIFF
--- a/app/Csp/Presets/Wrapped.php
+++ b/app/Csp/Presets/Wrapped.php
@@ -17,5 +17,8 @@ class Wrapped implements Preset
         $policy->add(Directive::FRAME, [
             'https://www.youtube.com',
         ]);
+        $policy->add(Directive::CONNECT, [
+            'https://img.youtube.com',
+        ]);
     }
 }

--- a/resources/js/lib/stats.ts
+++ b/resources/js/lib/stats.ts
@@ -306,6 +306,11 @@ const preloadImages = async (stats: statsType) => {
     for (const product of stats.mostBought.items.slice(0, 5)) {
         product[0].image_url = await fetchImageAsBase64(product[0].image_url)
     }
+    for (const video of stats.protube.user.videos.slice(0, 5)) {
+        video.thumbnail_url = await fetchImageAsBase64(
+            `https://img.youtube.com/vi/${video.video_id}/mqdefault.jpg`
+        )
+    }
 }
 
 export const blobToBase64 = (blob: Blob): Promise<string> => {

--- a/resources/js/pages/Wrapped/Slides/ProtubeTop.vue
+++ b/resources/js/pages/Wrapped/Slides/ProtubeTop.vue
@@ -19,7 +19,7 @@ const stats = props.data.protube
             class="youtube"
         >
             <img
-                :src="`https://img.youtube.com/vi/${stats.user.videos[0].video_id}/mqdefault.jpg`"
+                :src="stats.user.videos[0].thumbnail_url"
                 style="
                     position: absolute;
                     top: 0;
@@ -71,9 +71,7 @@ const stats = props.data.protube
             :key="video.video_id"
             class="youtube-video"
         >
-            <img
-                :src="`https://img.youtube.com/vi/${video.video_id}/mqdefault.jpg`"
-            />
+            <img :src="video.thumbnail_url" />
             <span style="width: 19rem">
                 <span
                     style="

--- a/resources/js/pages/Wrapped/types.ts
+++ b/resources/js/pages/Wrapped/types.ts
@@ -1,5 +1,8 @@
 import ProductData = App.Data.ProductData
 
+interface VideoWithUrl extends App.Data.PlayedVideoData {
+    thumbnail_url?: string
+}
 export interface statsType {
     images: {
         cookieMonster: string
@@ -52,7 +55,7 @@ export interface statsType {
             duration_played: string
             percentile: number
             total_played: number
-            videos: Array<App.Data.PlayedVideoData>
+            videos: Array<VideoWithUrl>
         }
         total: {
             total_played: number


### PR DESCRIPTION
Add youtube to the connect-src so the images can be prefetched and the sharing of the protube top slide works