### PR TITLE
Fix the Leaderboard and Weekly queries falling through the cache when null

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -50,8 +50,8 @@ class HomeController extends Controller
             ->where('published_at', '>', Date::now()->subWeek())
             ->where('is_weekly', true)
             ->orderBy('published_at', 'desc')
-            ->first()
-        );
+            ->get()
+        )->first();
 
         $newsitems = Cache::remember('home.newsitems', Date::tomorrow(), fn () => Newsitem::query()
             ->whereNotNull('published_at')

--- a/resources/views/website/home/cards/leaderboards.blade.php
+++ b/resources/views/website/home/cards/leaderboards.blade.php
@@ -1,14 +1,16 @@
 @php
     $leaderboard = Cache::rememberForever(
         'leaderboard.leaderboard',
-        fn () => App\Models\Leaderboard::where('featured', true)
+        fn () => App\Models\Leaderboard::query()
+            ->orderBy('created_at', 'desc')
+            ->where('featured', true)
             ->with([
                 'entries' => function ($q) {
                     $q->orderBy('points', 'DESC')->limit(5);
                 },
             ])
-            ->first(),
-    );
+            ->get(),
+    )->first();
 @endphp
 
 @if ($leaderboard)


### PR DESCRIPTION
When there is no weekly or featured leaderboard, the query returns null. This does not get cached. Now it returns an empty collection, which we get the first of after the cache. The empty collection does get cached.