### PR TITLE
Update dependabot to only make two PRs per week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,9 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
-      composer-prod:
-        dependency-type: "production"
-      composer-dev:
-        dependency-type: "development"
+      composer:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -21,10 +20,9 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
-      npm-prod:
-        dependency-type: "production"
-      npm-dev:
-        dependency-type: "development"
+      npm:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"


### PR DESCRIPTION
This reduces noise and makes it so that dependabot makes one npm, one composer and one GH actions PR instead of two per ecosystem