### PR TITLE
Remove duplicate logic by replacing transferOneBackupUser with processBackupQueue

### DIFF
--- a/app/Http/Controllers/ParticipationController.php
+++ b/app/Http/Controllers/ParticipationController.php
@@ -103,7 +103,7 @@ class ParticipationController extends Controller
 
         Session::flash('flash_message', $participation->user->name.' is not attending '.$participation->activity->event->title.' anymore.');
 
-        $this->processBackupQueue($participation->activity);
+        static::processBackupQueue($participation->activity);
 
         $participation->activity->event->updateUniqueUsersCount();
 

--- a/app/Http/Controllers/ParticipationController.php
+++ b/app/Http/Controllers/ParticipationController.php
@@ -103,9 +103,7 @@ class ParticipationController extends Controller
 
         Session::flash('flash_message', $participation->user->name.' is not attending '.$participation->activity->event->title.' anymore.');
 
-        if (! $participation->backup && $participation->activity->canUnsubscribe() && $participation->activity->users->count() < $participation->activity->participants) {
-            self::transferOneBackupUser($participation->activity);
-        }
+        $this->processBackupQueue($participation->activity);
 
         $participation->activity->event->updateUniqueUsersCount();
 


### PR DESCRIPTION
This if statement counted the event members differently and this is in general just a cleaner way to do it