### PR TITLE
Allow the orderlines of deleted users to be marked as loss

### DIFF
--- a/app/Http/Controllers/WithdrawalController.php
+++ b/app/Http/Controllers/WithdrawalController.php
@@ -284,18 +284,14 @@ class WithdrawalController extends Controller
         }
 
         /** @var User $user */
-        $user = User::query()->findOrFail($user_id);
+        $user = User::withTrashed()->findOrFail($user_id);
 
-        $orderlines = $withdrawal
-            ->orderlines()
+        $withdrawal->orderlines()
             ->where('user_id', $user->id)
-            ->get();
-
-        foreach ($orderlines as $orderline) {
-            $orderline->withdrawal()->dissociate();
-            $orderline->payed_with_loss = true;
-            $orderline->save();
-        }
+            ->update([
+                'payed_with_withdrawal' => null,
+                'payed_with_loss' => true,
+            ]);
 
         $withdrawal->recalculateTotals();
 


### PR DESCRIPTION
There are orderlines of deleted users which can not be processed anymore. This will allow them to be marked as loss for now.